### PR TITLE
Fix/udev

### DIFF
--- a/install/compose/docker-compose.gps.yml
+++ b/install/compose/docker-compose.gps.yml
@@ -33,14 +33,7 @@ services:
     environment:
       <<: *ros2-env
       HARDWARE_BACKEND: ${HARDWARE_BACKEND}
-      # Pass the host-side device path straight through. start_gps.sh uses
-      # GPS_DEVICE_PATH as the ublox_dgnss DEVICE_PATH when transport=serial,
-      # which lets the container use /dev/serial/by-id/... directly (always
-      # created by systemd-udev) instead of depending on the /dev/gps symlink
-      # from /etc/udev/rules.d/50-mowgli.rules. GPS_PORT is the canonical
-      # installer key; fall back to UBLOX_DEVICE_SERIAL_STRING for compose
-      # generations carried over from the legacy ublox backend.
-      GPS_DEVICE_PATH: ${GPS_PORT:-${UBLOX_DEVICE_SERIAL_STRING:-/dev/gps}}
+      GPS_PORT: ${GPS_PORT:-/dev/gps}
       GPS_PROTOCOL: ${GPS_PROTOCOL:-UBX}
       GPS_BAUD: ${GPS_BAUD:-921600}
     volumes:

--- a/install/compose/docker-compose.unicore.yaml
+++ b/install/compose/docker-compose.unicore.yaml
@@ -43,6 +43,7 @@ services:
       <<: *ros2-env
 
       HARDWARE_BACKEND: ${HARDWARE_BACKEND}
+      GPS_PORT: ${GPS_PORT:-/dev/gps}
 
       UNICORE_TARGET_BAUD: ${UNICORE_TARGET_BAUD}
       UNICORE_PROFILE: ${UNICORE_PROFILE}

--- a/install/lib/checks.sh
+++ b/install/lib/checks.sh
@@ -86,13 +86,7 @@ check_devices() {
     devices+=("${MAVROS_PORT:-/dev/mavros}:Pixhawk MAVROS serial")
   else
     devices+=("/dev/mowgli:Mowgli STM32 board")
-    # Prefer the by-id symlink for USB receivers — it's what the container
-    # uses via GPS_DEVICE_PATH and is always created by systemd-udev.
-    local gps_device="${GPS_PORT}"
-    if [[ "${GPS_CONNECTION:-}" == "usb" ]] && [[ -n "${GPS_BY_ID:-}" ]]; then
-      gps_device="${GPS_BY_ID}"
-    fi
-    devices+=("${gps_device}:GPS receiver")
+    devices+=("${GPS_PORT}:GPS receiver")
   fi
 
   if [[ "${LIDAR_ENABLED}" == "true" && "${LIDAR_TYPE}" != "none" ]]; then

--- a/install/lib/gps.sh
+++ b/install/lib/gps.sh
@@ -124,12 +124,10 @@ configure_gps() {
     : "${GPS_DEBUG_PORT:=/dev/gps_debug}"
     : "${GPS_DEBUG_BAUD:=115200}"
 
-    # For USB connections, prefer the by-id symlink as GPS_PORT — it's always
-    # created by systemd-udev and is what start_gps.sh expects via
-    # GPS_DEVICE_PATH inside the container. /dev/gps would require an extra
-    # udev rule that doesn't fire on every distro.
+    # Runtime always uses the stable /dev/gps symlink. Keep the selected USB
+    # identity in GPS_BY_ID only; installer/udev materializes the symlink.
     if [[ "${GPS_CONNECTION}" == "usb" ]] && [[ -n "${GPS_BY_ID:-}" ]]; then
-      GPS_PORT="${GPS_BY_ID}"
+      GPS_PORT="/dev/gps"
     fi
 
     if [[ "${GNSS_BACKEND}" == "ublox" ]]; then
@@ -141,12 +139,11 @@ configure_gps() {
       GPS_CONNECTION="usb"
       GPS_PROTOCOL="UBX"
       # If an older .env still carries UBLOX_DEVICE_SERIAL_STRING pointing at a
-      # /dev/serial/by-id/... path (which is what the migration emitted), use
-      # it to populate GPS_PORT / GPS_BY_ID. Otherwise demand the canonical
-      # GPS_PORT / GPS_BY_ID like the unicore preset.
+      # /dev/serial/by-id/... path, use it to populate GPS_BY_ID only. Runtime
+      # still goes through /dev/gps.
       if [[ -z "${GPS_BY_ID:-}" && "${UBLOX_DEVICE_SERIAL_STRING:-}" =~ ^/dev/serial/by-id/ ]]; then
         GPS_BY_ID="${UBLOX_DEVICE_SERIAL_STRING}"
-        GPS_PORT="${UBLOX_DEVICE_SERIAL_STRING}"
+        GPS_PORT="/dev/gps"
       fi
       UBLOX_DEVICE_SERIAL_STRING=""
       if [[ -z "${GPS_BY_ID:-}" ]]; then
@@ -239,9 +236,8 @@ configure_gps() {
     : "${GPS_DEBUG_BAUD:=115200}"
 
     if [[ "${GNSS_BACKEND}" == "ublox" ]]; then
-      # ublox now uses the same sensors/gps serial-transport container as
-      # GNSS_BACKEND=gps + GPS_PROTOCOL=UBX over USB by-id (see
-      # compose_gnss_service_name and start_gps.sh:GPS_DEVICE_PATH).
+      # ublox now uses the same runtime /dev/gps contract as the other direct
+      # GNSS backends; the selected USB identity remains installer metadata.
       GPS_CONNECTION="usb"
       GPS_PROTOCOL="UBX"
       GPS_UART_DEVICE=""
@@ -253,7 +249,7 @@ configure_gps() {
       info "UART u-blox receivers should use GNSS_BACKEND=gps with GPS_PROTOCOL=UBX."
       pick_serial_by_id "${GPS_BY_ID:-}" || return 1
       GPS_BY_ID="$REPLY"
-      GPS_PORT="$GPS_BY_ID"
+      GPS_PORT="/dev/gps"
     else
       echo ""
       echo "$MSG_GPS_CONNECTION"
@@ -268,7 +264,7 @@ configure_gps() {
           GPS_UART_DEVICE=""
           pick_serial_by_id "${GPS_BY_ID:-}" || return 1
           GPS_BY_ID="$REPLY"
-          GPS_PORT="$GPS_BY_ID"
+          GPS_PORT="/dev/gps"
           ;;
         2)
           GPS_CONNECTION="uart"

--- a/install/lib/udev.sh
+++ b/install/lib/udev.sh
@@ -63,6 +63,58 @@ emit_by_id_udev_rule() {
   fi
 }
 
+emit_strict_gps_by_id_udev_rule() {
+  local by_id_path="$1"
+  local resolved kernel vendor product serial id_path id_path_tag line key value
+
+  [ -L "$by_id_path" ] || return 1
+  resolved="$(readlink -f "$by_id_path")"
+  kernel="$(basename "$resolved")"
+  [ -n "$kernel" ] || return 1
+
+  vendor=""
+  product=""
+  serial=""
+  id_path=""
+  id_path_tag=""
+
+  if ! command -v udevadm >/dev/null 2>&1 || [ ! -e "$resolved" ]; then
+    error "Selected GPS device $by_id_path needs udevadm properties to build a unique /dev/gps rule. Refusing generic fallback."
+    return 1
+  fi
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      ID_VENDOR_ID)  vendor="$value" ;;
+      ID_MODEL_ID)   product="$value" ;;
+      ID_SERIAL_SHORT) serial="$value" ;;
+      ID_PATH)       id_path="$value" ;;
+      ID_PATH_TAG)   id_path_tag="$value" ;;
+    esac
+  done < <(udevadm info --query=property --name="$resolved" 2>/dev/null)
+
+  if [ -z "$vendor" ] || [ -z "$product" ]; then
+    error "Selected GPS device $by_id_path is missing idVendor/idProduct in udevadm output. Refusing to generate /dev/gps rule."
+    return 1
+  fi
+
+  echo "# gps from $by_id_path"
+  line="SUBSYSTEM==\"tty\", ATTRS{idVendor}==\"${vendor}\", ATTRS{idProduct}==\"${product}\""
+  if [ -n "$serial" ]; then
+    line="${line}, ATTRS{serial}==\"${serial}\""
+  elif [ -n "$id_path" ]; then
+    line="${line}, ENV{ID_PATH}==\"${id_path}\""
+  elif [ -n "$id_path_tag" ]; then
+    line="${line}, ENV{ID_PATH_TAG}==\"${id_path_tag}\""
+  else
+    error "Selected GPS device $by_id_path exposes only generic VID/PID ${vendor}:${product} with no serial or stable path selector. Refusing to generate non-unique /dev/gps rule."
+    return 1
+  fi
+
+  line="${line}, SYMLINK+=\"gps\", MODE=\"0666\""
+  echo "$line"
+}
+
 build_static_udev_rules() {
   cat <<'EOF'
 # =========================================================
@@ -117,35 +169,13 @@ build_dynamic_udev_rules() {
   fi
 
   # GPS principal
-  # The /dev/gps symlink is a *convenience* for manual debugging — the
-  # sensors/gps container talks to the F9P via the /dev/serial/by-id/...
-  # path passed in GPS_DEVICE_PATH (always created by systemd-udev), so
-  # the absence of this rule no longer breaks the container.
+  # Runtime expects /dev/gps only. Create it from the installer-selected
+  # source device, whether that source was a USB by-id path or a UART tty.
   if [ "$gnss_backend" != "disabled" ]; then
     if [ "${GPS_CONNECTION:-usb}" = "uart" ] && [ -n "${GPS_UART_DEVICE:-}" ]; then
       echo "KERNEL==\"$(basename "$GPS_UART_DEVICE")\", SYMLINK+=\"gps\", MODE=\"0666\""
     elif [ -n "${GPS_BY_ID:-}" ] && [ -e "${GPS_BY_ID}" ]; then
-      emit_by_id_udev_rule "$GPS_BY_ID" "gps"
-    elif [ "${HARDWARE_BACKEND:-mowgli}" != "mavros" ]; then
-      case "$gnss_backend" in
-        gps|ublox)
-          if [[ "$gps_protocol" != "NMEA" ]]; then
-            by_id_path="$(find_serial_by_id "*u-blox*" "*ublox*" || true)"
-          else
-            by_id_path=""
-          fi
-          ;;
-        unicore)
-          by_id_path=""
-          ;;
-        *)
-          by_id_path=""
-          ;;
-      esac
-
-      if [ -n "$by_id_path" ]; then
-        emit_by_id_udev_rule "$by_id_path" "gps"
-      fi
+      emit_strict_gps_by_id_udev_rule "$GPS_BY_ID" || return 1
     fi
   fi
 
@@ -178,11 +208,14 @@ install_udev_rules() {
   local tmpfile
   tmpfile="$(mktemp)"
 
-  {
+  if ! {
     build_static_udev_rules
     echo ""
     build_dynamic_udev_rules
-  } > "$tmpfile"
+  } > "$tmpfile"; then
+    rm -f "$tmpfile"
+    return 1
+  fi
 
   local changed=false
 
@@ -222,10 +255,10 @@ install_udev_rules() {
     if [ ! -e "${GPS_BY_ID}" ]; then
       warn "GPS by-id device ${GPS_BY_ID} does not exist"
     else
-      # /dev/gps udev rule is now optional — start_gps.sh reads the by-id
-      # path directly via GPS_DEVICE_PATH. Just confirm GPS_PORT resolves.
       info "GPS device: ${GPS_BY_ID} -> $(readlink -f "${GPS_BY_ID}")"
-      if [ -e "${GPS_PORT:-/dev/gps}" ] && [ "${GPS_PORT:-/dev/gps}" != "${GPS_BY_ID}" ]; then
+      if [ ! -e "${GPS_PORT:-/dev/gps}" ]; then
+        warn "GPS symlink ${GPS_PORT:-/dev/gps} not created — selected source device is ${GPS_BY_ID}"
+      else
         info "GPS symlink: ${GPS_PORT:-/dev/gps} -> $(readlink -f "${GPS_PORT:-/dev/gps}")"
       fi
     fi

--- a/install/test_mowglinext.sh
+++ b/install/test_mowglinext.sh
@@ -263,8 +263,8 @@ HARDWARE_BACKEND=mowgli
 MAVROS_BY_ID=""
 udev_rules="$(build_dynamic_udev_rules)"
 case "$udev_rules" in
-  *'SYMLINK+="gps"'*) fail "udev by-id: dedicated ublox backend does not create /dev/gps symlink" "$udev_rules" ;;
-  *) pass "udev by-id: dedicated ublox backend does not create /dev/gps symlink" ;;
+  *'SYMLINK+="gps"'*) fail "udev by-id: no implicit u-blox GPS rule without GPS_BY_ID" "$udev_rules" ;;
+  *) pass "udev by-id: no implicit u-blox GPS rule without GPS_BY_ID" ;;
 esac
 
 GNSS_BACKEND=unicore
@@ -276,11 +276,93 @@ case "$udev_rules" in
 esac
 
 GPS_BY_ID="$SERIAL_BY_ID_DIR/usb-1a86_USB_Serial-if00-port0"
+udevadm() {
+  case "$1 $2 $3" in
+    "info --query=property --name=/tmp"*)
+      case "$3" in
+        --name="$SANDBOX/dev/ttyUSB0")
+          cat <<'PROPS'
+ID_VENDOR_ID=1a86
+ID_MODEL_ID=7523
+ID_SERIAL_SHORT=CH340-UNIQUE-01
+PROPS
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+export -f udevadm
 udev_rules="$(build_dynamic_udev_rules)"
 case "$udev_rules" in
-  *'KERNEL=="ttyUSB0", SYMLINK+="gps", MODE="0666"'*) pass "udev by-id: explicit Unicore GPS_BY_ID symlink rule" ;;
-  *) fail "udev by-id: explicit Unicore GPS_BY_ID symlink rule" "$udev_rules" ;;
+  *'ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", ATTRS{serial}=="CH340-UNIQUE-01", SYMLINK+="gps", MODE="0666"'*) pass "udev by-id: explicit GPS_BY_ID rule includes unique serial selector" ;;
+  *) fail "udev by-id: explicit GPS_BY_ID rule includes unique serial selector" "$udev_rules" ;;
 esac
+case "$udev_rules" in
+  *'ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", SYMLINK+="gps", MODE="0666"'*) fail "udev by-id: GPS rule must not be generic VID/PID only" "$udev_rules" ;;
+  *) pass "udev by-id: GPS rule must not be generic VID/PID only" ;;
+esac
+
+udevadm() {
+  case "$1 $2 $3" in
+    "info --query=property --name=/tmp"*)
+      case "$3" in
+        --name="$SANDBOX/dev/ttyUSB0")
+          cat <<'PROPS'
+ID_VENDOR_ID=1a86
+ID_MODEL_ID=7523
+ID_PATH=platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0
+PROPS
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+export -f udevadm
+udev_rules="$(build_dynamic_udev_rules)"
+case "$udev_rules" in
+  *'ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", ENV{ID_PATH}=="platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3:1.0", SYMLINK+="gps", MODE="0666"'*) pass "udev by-id: GPS rule falls back to stable ID_PATH selector when serial is absent" ;;
+  *) fail "udev by-id: GPS rule falls back to stable ID_PATH selector when serial is absent" "$udev_rules" ;;
+esac
+
+udevadm() {
+  case "$1 $2 $3" in
+    "info --query=property --name=/tmp"*)
+      case "$3" in
+        --name="$SANDBOX/dev/ttyUSB0")
+          cat <<'PROPS'
+ID_VENDOR_ID=1a86
+ID_MODEL_ID=7523
+PROPS
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+export -f udevadm
+if udev_rules="$(build_dynamic_udev_rules 2>&1)"; then
+  fail "udev by-id: generic CH340 GPS rule rejected without unique selector" "$udev_rules"
+else
+  pass "udev by-id: generic CH340 GPS rule rejected without unique selector"
+fi
+unset -f udevadm
 
 GPS_CONNECTION=uart
 GPS_UART_DEVICE=/dev/ttyAMA4
@@ -478,10 +560,12 @@ GPS_CONNECTION=usb
 GPS_PROTOCOL=UBX
 GPS_BAUD=115200
 GPS_UART_DEVICE=
+GPS_BY_ID=/dev/serial/by-id/usb-ublox-stub
 UBLOX_DEVICE_SERIAL_STRING=ublox-test-serial
 GPS_DEBUG_ENABLED=false
 configure_gps >/dev/null 2>&1
-assert_eq "GPS preset mode: keeps dedicated ublox serial string" "ublox-test-serial" "$UBLOX_DEVICE_SERIAL_STRING"
+assert_eq "GPS preset mode: runtime GPS port stays symlink" "/dev/gps" "$GPS_PORT"
+assert_eq "GPS preset mode: keeps selected USB identity" "/dev/serial/by-id/usb-ublox-stub" "$GPS_BY_ID"
 pass "GPS preset mode: no interactive prompts"
 
 # LiDAR with preset — should NOT prompt

--- a/install/tests/lib/harness.sh
+++ b/install/tests/lib/harness.sh
@@ -187,6 +187,7 @@ harness_set_preset() {
           GPS_CONNECTION="usb"
           GPS_PROTOCOL="UBX"
           GPS_UART_DEVICE=""
+          GPS_BY_ID="${GPS_BY_ID:-/dev/serial/by-id/usb-ublox-stub}"
           UBLOX_DEVICE_SERIAL_STRING="${UBLOX_DEVICE_SERIAL_STRING:-ublox-test-serial}"
         fi
         ;;
@@ -197,7 +198,11 @@ harness_set_preset() {
           nmea) GPS_PROTOCOL="NMEA"; unset GPS_BAUD ;;
         esac
         case "$conn" in
-          usb)  GPS_CONNECTION="usb";  GPS_UART_DEVICE="" ;;
+          usb)
+            GPS_CONNECTION="usb"
+            GPS_UART_DEVICE=""
+            GPS_BY_ID="${GPS_BY_ID:-/dev/serial/by-id/usb-gps-stub}"
+            ;;
           uart) GPS_CONNECTION="uart"; GPS_UART_DEVICE="${GPS_UART_DEVICE:-/dev/ttyAMA4}" ;;
         esac
         ;;

--- a/install/tests/test_gps_matrix.sh
+++ b/install/tests/test_gps_matrix.sh
@@ -4,7 +4,7 @@
 #
 # The installer supports three direct GNSS backends:
 #   gps     — generic legacy GPS container       (docker-compose.gps.yml)
-#   ublox   — u-blox F9P (ublox_dgnss launch)    (docker-compose.ublox.yaml)
+#   ublox   — u-blox F9P via sensors/gps         (docker-compose.gps.yml)
 #   unicore — Unicore UM98x (unicore_gnss launch)(docker-compose.unicore.yaml)
 # Generic NMEA receivers are modeled as GNSS_BACKEND=gps with
 # GPS_PROTOCOL=NMEA, not as a separate GNSS backend.
@@ -78,6 +78,7 @@ harness_init "$repo"
 harness_set_preset gnss=gps gps=ubx-usb lidar=none tfluna=none
 harness_run >/dev/null 2>&1
 assert_eq "ubx/usb: GPS_CONNECTION=usb" "usb" "$(env_value "$repo" GPS_CONNECTION)"
+assert_eq "ubx/usb: GPS_PORT remains runtime symlink" "/dev/gps" "$(env_value "$repo" GPS_PORT)"
 # NOTE: env.sh::setup_env runs `: "${GPS_UART_DEVICE:=/dev/ttyAMA4}"` —
 # the := expansion replaces empty values with the default, so the .env
 # always has GPS_UART_DEVICE set. With GPS_CONNECTION=usb the compose
@@ -96,17 +97,14 @@ if harness_run; then pass "harness_run ublox"; else fail "harness_run ublox"; fi
 assert_eq "ublox: GNSS_BACKEND=ublox" "ublox" "$(env_value "$repo" GNSS_BACKEND)"
 assert_eq "ublox: GPS_CONNECTION forced to usb" "usb" "$(env_value "$repo" GPS_CONNECTION)"
 assert_eq "ublox: GPS_PROTOCOL forced to UBX" "UBX" "$(env_value "$repo" GPS_PROTOCOL)"
-assert_eq "ublox: dedicated serial string stored" "ublox-test-serial" "$(env_value "$repo" UBLOX_DEVICE_SERIAL_STRING)"
+assert_eq "ublox: GPS_PORT remains runtime symlink" "/dev/gps" "$(env_value "$repo" GPS_PORT)"
+assert_eq "ublox: selected USB identity stored" "/dev/serial/by-id/usb-ublox-stub" "$(env_value "$repo" GPS_BY_ID)"
 
-# Compose selection must include the ublox fragment and exclude the legacy gps fragment.
+# Compose selection routes ublox through the shared gps fragment.
 ublox_fragments=$(selected_fragments_in_current_run)
 case "$ublox_fragments" in
-  *docker-compose.ublox.yaml*) pass "ublox: ublox fragment present" ;;
-  *)                           fail "ublox: ublox fragment present" "got: $ublox_fragments" ;;
-esac
-case "$ublox_fragments" in
-  *docker-compose.gps.yml*) fail "ublox: NO legacy gps fragment" "legacy gps leaked when ublox selected" ;;
-  *)                        pass "ublox: NO legacy gps fragment" ;;
+  *docker-compose.gps.yml*) pass "ublox: gps fragment present" ;;
+  *)                        fail "ublox: gps fragment present" "got: $ublox_fragments" ;;
 esac
 
 # ── Unicore UM98x backend ──────────────────────────────────────────────────

--- a/install/tests/test_ublox_runtime.sh
+++ b/install/tests/test_ublox_runtime.sh
@@ -10,16 +10,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/framework.sh
 source "$SCRIPT_DIR/lib/framework.sh"
 
-compose_file="$REPO_ROOT/install/compose/docker-compose.ublox.yaml"
+compose_file="$REPO_ROOT/install/compose/docker-compose.gps.yml"
 launch_file="$REPO_ROOT/ros2/src/mowgli_bringup/launch/ublox_gnss.launch.py"
 config_file="$REPO_ROOT/ros2/src/mowgli_bringup/config/ublox_gnss.yaml"
+runtime_file="$REPO_ROOT/sensors/gps/start_gps.sh"
 
 section "Compose wiring"
 
 compose_content="$(cat "$compose_file")"
-assert_not_contains "compose does not pass GPS_BAUD to dedicated ublox backend" 'ublox_baud_rate:=' "$compose_content"
-assert_contains "compose passes dedicated u-blox serial string" 'ublox_device_serial_string:=${UBLOX_DEVICE_SERIAL_STRING}' "$compose_content"
-assert_contains "compose documents dedicated ublox backend transport" 'GNSS_BACKEND=ublox uses the dedicated USB/libusb u-blox driver.' "$compose_content"
+assert_contains "compose passes runtime GPS symlink" 'GPS_PORT: ${GPS_PORT:-/dev/gps}' "$compose_content"
+assert_not_contains "compose does not pass installer-only GPS_BY_ID metadata" 'GPS_BY_ID:' "$compose_content"
+assert_not_contains "compose no longer passes GPS_DEVICE_PATH override" 'GPS_DEVICE_PATH:' "$compose_content"
 
 section "Launch wiring"
 
@@ -27,6 +28,12 @@ launch_content="$(cat "$launch_file")"
 assert_contains "launch still injects device serial string" '"DEVICE_SERIAL_STRING": device_serial_string' "$launch_content"
 assert_not_contains "launch no longer declares ublox_baud_rate" '"ublox_baud_rate"' "$launch_content"
 assert_not_contains "launch no longer injects BAUD_RATE" '"BAUD_RATE":' "$launch_content"
+
+section "Runtime wiring"
+
+runtime_content="$(cat "$runtime_file")"
+assert_not_contains "runtime no longer reads GPS_DEVICE_PATH" 'GPS_DEVICE_PATH' "$runtime_content"
+assert_not_contains "runtime no longer reads /dev/serial/by-id" '/dev/serial/by-id' "$runtime_content"
 
 section "Config presence"
 

--- a/sensors/gps/start_gps.sh
+++ b/sensors/gps/start_gps.sh
@@ -23,14 +23,11 @@ parse_yaml() {
   grep -E "^\s+${1}:" "$CONFIG" | head -1 | sed 's/.*:\s*//' | tr -d '"' | tr -d "'"
 }
 
-# Compose env wins over /config/mowgli_robot.yaml. The installer writes
-# GPS_DEVICE_PATH / GPS_PROTOCOL / GPS_BAUD into docker/.env (see
-# install/lib/env.sh) and the compose fragments forward them as container
-# env vars; the YAML fallback keeps interactive `start_gps.sh` runs working
-# inside a shelled-in container where only mowgli_robot.yaml is set.
+# Compose env wins over /config/mowgli_robot.yaml. Runtime uses only the
+# stable /dev/gps symlink exposed through GPS_PORT.
 GPS_PROTOCOL="${GPS_PROTOCOL:-$(parse_yaml gps_protocol)}"
 GPS_PROTOCOL="${GPS_PROTOCOL:-UBX}"
-GPS_PORT="${GPS_DEVICE_PATH:-$(parse_yaml gps_port)}"
+GPS_PORT="${GPS_PORT:-$(parse_yaml gps_port)}"
 GPS_PORT="${GPS_PORT:-/dev/gps}"
 # gps_baudrate is the runtime baud for the main GNSS receiver.
 GPS_BAUD="${GPS_BAUD:-$(parse_yaml gps_baudrate)}"
@@ -85,11 +82,6 @@ else
   TRANSPORT="${TRANSPORT:-usb}"
 
   if [ "$TRANSPORT" = "serial" ]; then
-    # GPS_PORT is the host-side path the installer chose — usually a
-    # /dev/serial/by-id/... symlink (always created by systemd-udev,
-    # regardless of /etc/udev/rules.d/50-mowgli.rules). We override the
-    # baked-in DEVICE_PATH from /ublox_dgnss.yaml via --param so we don't
-    # need a /dev/gps udev symlink at all.
     DEVICE_PATH="$GPS_PORT"
     echo "[start_gps.sh] Transport=serial, device=$DEVICE_PATH"
 
@@ -116,17 +108,14 @@ else
       done
     fi
 
-    # Wait for the device path to appear (up to 5 s)
+    # Wait for the runtime symlink to appear (up to 5 s)
     for i in $(seq 1 50); do
       [ -e "$DEVICE_PATH" ] && break
       sleep 0.1
     done
-    # Resolve symlinks (e.g. /dev/serial/by-id/...) to a real char dev.
     REAL_DEVICE="$(readlink -f "$DEVICE_PATH" 2>/dev/null || echo "$DEVICE_PATH")"
     if [ ! -c "$REAL_DEVICE" ]; then
-      echo "[start_gps.sh] ERROR: $DEVICE_PATH (-> $REAL_DEVICE) did not appear after 5s"
-      echo "[start_gps.sh] Available serial-by-id entries:"
-      ls -l /dev/serial/by-id/ 2>/dev/null || echo "  (none)"
+      echo "[start_gps.sh] ERROR: missing /dev/gps symlink: $DEVICE_PATH (-> $REAL_DEVICE)"
       exit 1
     fi
   else

--- a/sensors/unicore/configure_receiver.sh
+++ b/sensors/unicore/configure_receiver.sh
@@ -307,19 +307,40 @@ unicore_log_command_variants() {
 
 unicore_classify_command_response() {
   local response="${1-}"
+  local command="${2:-$UNICORE_LAST_SERIAL_COMMAND}"
+  local line status saw_ignored=0 saw_invalid=0
   local collapsed="${response,,}"
   local compact="${collapsed//[$' \t\r\n']/}"
 
   if [ -z "$compact" ]; then
-    printf '%s\n' "no_response"
-    return 0
-  fi
-  if [[ "$collapsed" == *"unsupported"* || "$collapsed" == *"parsing failed"* || "$collapsed" == *"grammar error"* ]]; then
-    printf '%s\n' "unsupported"
+    printf '%s\n' "timeout"
     return 0
   fi
 
-  printf '%s\n' "ok"
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    status="$(unicore_classify_command_response_line "$command" "$line")"
+    case "$status" in
+      ok|unsupported)
+        printf '%s\n' "$status"
+        return 0
+        ;;
+      ignored_stream_data)
+        saw_ignored=1
+        ;;
+      invalid_response)
+        saw_invalid=1
+        ;;
+    esac
+  done <<<"$response"
+
+  if [ "$saw_invalid" -eq 1 ]; then
+    printf '%s\n' "invalid_response"
+  elif [ "$saw_ignored" -eq 1 ]; then
+    printf '%s\n' "ignored_stream_data"
+  else
+    printf '%s\n' "timeout"
+  fi
 }
 
 unicore_first_response_line() {
@@ -328,14 +349,137 @@ unicore_first_response_line() {
   printf '%s\n' "${response%%$'\n'*}"
 }
 
+unicore_log_preview() {
+  local response="${1-}"
+  local preview
+
+  preview="$(unicore_first_response_line "$response")"
+  printf '%s' "$preview" | LC_ALL=C tr -cd '\11\12\15\40-\176' | cut -c1-180
+}
+
+unicore_log_preview_for_status() {
+  local response="${1-}"
+  local command="${2:-$UNICORE_LAST_SERIAL_COMMAND}"
+  local wanted_status="${3:-}"
+  local line status preview=""
+
+  if [ -n "$wanted_status" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      [ -n "$line" ] || continue
+      status="$(unicore_classify_command_response_line "$command" "$line")"
+      if [ "$status" = "$wanted_status" ]; then
+        preview="$line"
+        break
+      fi
+    done <<<"$response"
+  fi
+
+  if [ -z "$preview" ]; then
+    preview="$(unicore_first_response_line "$response")"
+  fi
+  printf '%s' "$preview" | LC_ALL=C tr -cd '\11\12\15\40-\176' | cut -c1-180
+}
+
+unicore_normalize_command_for_match() {
+  local command="${1-}"
+
+  command="${command//$'\r'/ }"
+  command="${command//$'\n'/ }"
+  command="${command//,/ }"
+  command="$(printf '%s\n' "$command" | awk '{$1=$1; print toupper($0)}')"
+  printf '%s\n' "$command"
+}
+
+unicore_command_ack_target_matches() {
+  local command="${1-}"
+  local ack_target="${2-}"
+  local normalized_command normalized_ack
+
+  normalized_command="$(unicore_normalize_command_for_match "$command")"
+  normalized_ack="$(unicore_normalize_command_for_match "$ack_target")"
+  [ -n "$normalized_command" ] || return 1
+  [ -n "$normalized_ack" ] || return 1
+
+  if [ "$normalized_ack" = "$normalized_command" ]; then
+    return 0
+  fi
+  case "$normalized_command" in
+    "$normalized_ack "*) return 0 ;;
+  esac
+
+  return 1
+}
+
+unicore_classify_command_response_line() {
+  local command="${1-}"
+  local line="${2-}"
+  local lower="${line,,}"
+  local ack_target rest
+
+  if [[ "$lower" == *"response can't found device"* ||
+        "$lower" == *"response cant found device"* ||
+        "$lower" == *"unsupported"* ||
+        "$lower" == *"parsing failed"* ||
+        "$lower" == *"grammar error"* ]]; then
+    printf '%s\n' "unsupported"
+    return 0
+  fi
+
+  if [[ "$line" == \$command,* ]]; then
+    rest="${line#\$command,}"
+    ack_target="${rest%%,response:*}"
+    if [[ "$rest" == *",response: OK"* ]] &&
+       unicore_command_ack_target_matches "$command" "$ack_target"; then
+      printf '%s\n' "ok"
+      return 0
+    fi
+    printf '%s\n' "invalid_response"
+    return 0
+  fi
+
+  case "$line" in
+    "<OK"|"<OK "*|"<OK,"*)
+      printf '%s\n' "ok"
+      return 0
+      ;;
+  esac
+
+  if unicore_is_stream_data_line "$line"; then
+    printf '%s\n' "ignored_stream_data"
+  else
+    printf '%s\n' "invalid_response"
+  fi
+}
+
+unicore_is_stream_data_line() {
+  local line="${1-}"
+  local printable
+
+  printable="$(printf '%s' "$line" | LC_ALL=C tr -cd '\40-\176')"
+  case "$printable" in
+    \#BESTNAVA*|\#BESTNAVB*|\#PVTSLNA*|\#PVTSLNB*|\#RTKSTATUSA*|\#RTKSTATUSB*|\#RTCMSTATUSA*|\#RTCMSTATUSB*|\#BESTSATA*|\#BESTSATB*|\#SATSINFOA*|\#SATSINFOB*|\#AGCA*|\#AGCB*|\#HWSTATUSA*|\#HWSTATUSB*|\#JAMSTATUSA*|\#JAMSTATUSB*|\#FREQJAMSTATUSA*|\#FREQJAMSTATUSB*|\#OBSVMCMPA*|\#OBSVMCMPB*)
+      return 0
+      ;;
+    \$GPGGA*|\$GNGGA*|\$GPGSV*|\$GLGSV*|\$GAGSV*|\$GBGSV*|\$GNHPR*|\$GNHPR2*)
+      return 0
+      ;;
+  esac
+
+  if [ "$printable" != "$line" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
 unicore_log_syntax_for_message() {
   local message="${1:?unicore_log_syntax_for_message: missing message}"
 
   case "$message" in
-    GPGGA|PVTSLNA|PVTSLNB|BESTSATA|BESTSATB|SATSINFOA|SATSINFOB|AGCA|AGCB|HWSTATUSA|HWSTATUSB|JAMSTATUSA|JAMSTATUSB|FREQJAMSTATUSA|FREQJAMSTATUSB|GPGSV|GLGSV|GAGSV|GBGSV|OBSVMCMPA|OBSVMCMPB)
+    GPGGA|PVTSLNA|PVTSLNB|BESTSATA|BESTSATB|SATSINFOA|SATSINFOB|AGCA|AGCB|HWSTATUSA|HWSTATUSB|JAMSTATUSA|JAMSTATUSB|FREQJAMSTATUSA|FREQJAMSTATUSB|OBSVMCMPA|OBSVMCMPB)
       printf '%s\n' "nmea_log_ontime"
       ;;
-    BESTNAVA|BESTNAVB|RTKSTATUSA|RTKSTATUSB|GPHPR)
+    BESTNAVA|BESTNAVB|RTKSTATUSA|RTKSTATUSB|GPHPR|GPGSV)
       printf '%s\n' "unicore_direct_period"
       ;;
     RTCMSTATUSA|RTCMSTATUSB|GPHPR2)
@@ -607,12 +751,19 @@ send_serial_command() {
 
 collect_serial_output() {
   local rounds="${1:?collect_serial_output: missing rounds}"
+  local command="${2:-$UNICORE_LAST_SERIAL_COMMAND}"
   local line output=""
-  local i
+  local i status
 
   for i in $(seq 1 "$rounds"); do
     if IFS= read -r -t 0.15 -u 3 line; then
       output+="${line}"$'\n'
+      status="$(unicore_classify_command_response_line "$command" "$line")"
+      case "$status" in
+        ok|unsupported)
+          break
+          ;;
+      esac
     fi
   done
 
@@ -626,7 +777,7 @@ send_serial_command_with_response() {
   send_serial_command "$command"
   log "  -> $command"
   sleep 0.1
-  UNICORE_LAST_COMMAND_RESPONSE="$(collect_serial_output 6)"
+  UNICORE_LAST_COMMAND_RESPONSE="$(collect_serial_output 12 "$command")"
 }
 
 send_log_command_with_fallback() {
@@ -641,8 +792,8 @@ send_log_command_with_fallback() {
   if [ -z "$parsed" ]; then
     send_serial_command_with_response "$canonical_command"
     response="$UNICORE_LAST_COMMAND_RESPONSE"
-    status="$(unicore_classify_command_response "$response")"
-    preview="$(unicore_first_response_line "$response")"
+    status="$(unicore_classify_command_response "$response" "$canonical_command")"
+    preview="$(unicore_log_preview_for_status "$response" "$canonical_command" "$status")"
     [ -n "$preview" ] && log "  <- ${status}: ${preview}"
     return 0
   fi
@@ -658,15 +809,15 @@ send_log_command_with_fallback() {
     candidate="${variant#*$'\t'}"
     send_serial_command_with_response "$candidate"
     response="$UNICORE_LAST_COMMAND_RESPONSE"
-    status="$(unicore_classify_command_response "$response")"
-    preview="$(unicore_first_response_line "$response")"
+    status="$(unicore_classify_command_response "$response" "$candidate")"
+    preview="$(unicore_log_preview_for_status "$response" "$candidate" "$status")"
 
-    if [ "$status" = "unsupported" ]; then
+    if [ "$status" != "ok" ]; then
       if [ -n "$rejected" ]; then
         rejected+=" | "
       fi
       rejected+="$candidate"
-      log "  <- unsupported via ${label}${preview:+: ${preview}}"
+      log "  <- ${status} via ${label}${preview:+: ${preview}}"
       continue
     fi
 
@@ -674,9 +825,9 @@ send_log_command_with_fallback() {
     UNICORE_LOG_COMMAND_SYNTAX_BY_MESSAGE["$message"]="$label"
     UNICORE_REJECTED_LOG_COMMANDS["$message"]="$rejected"
     if [ "$candidate" != "$canonical_command" ]; then
-      log "  <- accepted ${message} via ${label}: ${candidate}${preview:+ | ${preview}}"
+      log "  <- ok accepted ${message} via ${label}: ${candidate}${preview:+ | ${preview}}"
     else
-      log "  <- accepted ${message} via ${label}${preview:+: ${preview}}"
+      log "  <- ok accepted ${message} via ${label}${preview:+: ${preview}}"
     fi
     return 0
   done
@@ -832,9 +983,6 @@ build_log_commands() {
     unicore_emit_paired_message_log "BESTSATA" "BESTSATB" "${UNICORE_SATELLITE_LOG_PERIOD}"
     unicore_emit_paired_message_log "SATSINFOA" "SATSINFOB" "${UNICORE_SATELLITE_LOG_PERIOD}"
     unicore_emit_ascii_message_log "GPGSV" "${UNICORE_SATELLITE_LOG_PERIOD}"
-    unicore_emit_ascii_message_log "GLGSV" "${UNICORE_SATELLITE_LOG_PERIOD}"
-    unicore_emit_ascii_message_log "GAGSV" "${UNICORE_SATELLITE_LOG_PERIOD}"
-    unicore_emit_ascii_message_log "GBGSV" "${UNICORE_SATELLITE_LOG_PERIOD}"
   fi
 
   if unicore_is_truthy "$UNICORE_ENABLE_RF"; then
@@ -915,8 +1063,8 @@ send_config_batch() {
 
     send_serial_command_with_response "$command"
     response="$UNICORE_LAST_COMMAND_RESPONSE"
-    status="$(unicore_classify_command_response "$response")"
-    preview="$(unicore_first_response_line "$response")"
+    status="$(unicore_classify_command_response "$response" "$command")"
+    preview="$(unicore_log_preview_for_status "$response" "$command" "$status")"
     [ -n "$preview" ] && log "  <- ${status}: ${preview}"
   done
 

--- a/sensors/unicore/start_gps.sh
+++ b/sensors/unicore/start_gps.sh
@@ -81,7 +81,7 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-GPS_PORT=$(parse_yaml gps_port)
+GPS_PORT="${GPS_PORT:-$(parse_yaml gps_port)}"
 GPS_PORT="${GPS_PORT:-/dev/gps}"
 GPS_BAUD=$(parse_yaml gps_baudrate)
 GPS_BAUD="${GPS_BAUD:-921600}"

--- a/sensors/unicore/test_configure_receiver.sh
+++ b/sensors/unicore/test_configure_receiver.sh
@@ -373,6 +373,38 @@ assert_eq "all syntax rejected keeps no accepted command" "" "${UNICORE_ACCEPTED
 assert_contains "all syntax rejected remembers onchanged" "RTCMSTATUSA ONCHANGED" "${UNICORE_REJECTED_LOG_COMMANDS[RTCMSTATUSA]:-}"
 assert_contains "all syntax rejected remembers com_onchanged" "RTCMSTATUSA COM1 ONCHANGED" "${UNICORE_REJECTED_LOG_COMMANDS[RTCMSTATUSA]:-}"
 
+polluted_stream_response=$'\001\002#BESTNAVA,COM1,0,0,FINESTEERING,0,0;SOL_COMPUTED\n$GPGGA,123519,4807.038,N,01131.000,E,4,08,0.9,545.4,M,46.9,M,,*47'
+assert_eq "stream-only data is ignored" "ignored_stream_data" "$(unicore_classify_command_response "$polluted_stream_response" "BESTNAVA 0.2")"
+assert_eq "can't found device is unsupported" "unsupported" "$(unicore_classify_command_response "response can't found device" "BESTSATB 2")"
+assert_eq "command ack exact target is ok" "ok" "$(unicore_classify_command_response '$command,BESTNAVA 0.2,response: OK*' "BESTNAVA 0.2")"
+assert_eq "command ack prefix target is ok" "ok" "$(unicore_classify_command_response '$command,LOG GPGGA,response: OK*' "LOG GPGGA ONTIME 0.2")"
+assert_eq "wrong command ack is invalid" "invalid_response" "$(unicore_classify_command_response '$command,GPGSV 1,response: OK*' "BESTSATB 2")"
+
+reset_mocks
+MOCK_COMMAND_RESPONSES["GPGSV 1"]="$polluted_stream_response"
+MOCK_COMMAND_RESPONSES["GPGSV ONTIME 1"]="$polluted_stream_response"
+MOCK_COMMAND_RESPONSES["GPGSV COM1 1"]="$polluted_stream_response"
+MOCK_COMMAND_RESPONSES["GPGSV COM1 1"]="$polluted_stream_response"
+MOCK_COMMAND_RESPONSES["LOG GPGSV ONTIME 1"]="$polluted_stream_response"
+if send_log_command_with_fallback "GPGSV 1"; then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "polluted stream is not accepted rc" "1" "$rc"
+assert_eq "polluted stream does not cache accepted syntax" "" "${UNICORE_ACCEPTED_LOG_COMMANDS[GPGSV]:-}"
+assert_contains "polluted stream rejected command recorded" "GPGSV 1" "${UNICORE_REJECTED_LOG_COMMANDS[GPGSV]:-}"
+
+reset_mocks
+MOCK_COMMAND_RESPONSES["BESTSATB 2"]=$'\001\002#BESTNAVA,COM1,0,0,FINESTEERING,0,0;SOL_COMPUTED\n$command,BESTSATB 2,response: OK*'
+if send_log_command_with_fallback "BESTSATB 2"; then
+  rc=0
+else
+  rc=$?
+fi
+assert_eq "polluted stream before ack accepted rc" "0" "$rc"
+assert_eq "polluted stream before ack caches true ack" "BESTSATB 2" "${UNICORE_ACCEPTED_LOG_COMMANDS[BESTSATB]:-}"
+
 if [ "$failures" -ne 0 ]; then
   echo ""
   echo "$failures test(s) failed."


### PR DESCRIPTION
## Summary

Fix GNSS runtime device handling by enforcing stable runtime symlink usage (`/dev/gps`) and strict udev identity mapping.

This removes runtime dependence on `/dev/serial/by-id`, eliminates generic USB serial GPS rules, and ensures the selected physical device is mapped to a stable runtime symlink through udev.

## Changes

* Enforced `GPS_PORT=/dev/gps` as the only runtime GPS device path
* Kept `GPS_BY_ID` as installer/udev metadata only
* Removed runtime `GPS_DEVICE_PATH` handling
* Removed runtime fallback logic to `/dev/serial/by-id`
* Updated compose wiring to use only `GPS_PORT`
* Fixed udev generation for USB GPS devices:

  * use unique selectors (`ATTRS{serial}`, `ID_PATH`, or `ID_PATH_TAG`)
  * prevent generic VID/PID-only GPS rules
  * remove implicit u-blox auto-detection when no device is selected
* Preserved UART runtime support through explicit `GPS_UART_DEVICE`
* Added/updated GNSS runtime and udev tests
* Verified Unicore, generic GPS, and u-blox flows

## Component

* [x] Docker (`docker/`)
* [x] Sensors (`sensors/`)
* [x] Documentation (`docs/`)

## Testing

* [x] Built successfully
* [x] Tested on hardware
* [ ] Tested in simulation
* [x] Unit tests pass
* [x] Manual testing

## Checklist

* [x] Follows conventional commit format
* [x] Documentation updated (if user-facing)
* [x] No hardcoded secrets or credentials
* [x] No unrelated changes
