### PR TITLE
fix(bt): low-pass filter v_battery before deriving battery_percent

### DIFF
--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -42,6 +42,7 @@ find_package(rcl_interfaces REQUIRED)
 
 add_executable(behavior_tree_node
   src/behavior_tree_node.cpp
+  src/battery_filter.cpp
   src/condition_nodes.cpp
   src/navigation_nodes.cpp
   src/docking_nodes.cpp
@@ -515,6 +516,24 @@ if(BUILD_TESTING)
     tf2
     tf2_ros
     tf2_geometry_msgs
+  )
+
+  # ---- test_battery_filter ----
+  # Regression for the premature LOW_BATTERY_DOCKING trip: battery_percent used
+  # to be interpolated off the RAW rail voltage, so a sub-second motor sag
+  # (PWM startup / stiction, 0.5-1 V) crossed battery_low_percent at a genuine
+  # 30-40 % SoC. Pins that a brief sag does not trip while a real discharge
+  # still does, that the smoothing is rate-independent (4 Hz robot vs 10 Hz
+  # sim), and that an invalid reading never becomes a 0 % gauge.
+  # Pure logic — no ROS, so no ament_target_dependencies needed.
+  ament_add_gtest(test_battery_filter
+    test/test_battery_filter.cpp
+    src/battery_filter.cpp
+  )
+
+  target_include_directories(test_battery_filter PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
   )
 
 endif()

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/battery_filter.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/battery_filter.hpp
@@ -1,0 +1,108 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+
+#ifndef MOWGLI_BEHAVIOR__BATTERY_FILTER_HPP_
+#define MOWGLI_BEHAVIOR__BATTERY_FILTER_HPP_
+
+#include <optional>
+
+namespace mowgli_behavior
+{
+
+// ── Why this exists ────────────────────────────────────────────────────────
+// battery_percent is a linear interpolation of v_battery between the empty and
+// full endpoints, and every percent-gated BT condition (NeedsDocking at
+// battery_low_percent, IsBatteryLow at battery_critical_percent, PreFlightCheck)
+// reads it. Feeding the raw rail voltage in means motor transients decide when
+// the robot docks: PWM startup and stiction-overcome pull the pack down
+// 0.5–1 V for well under a second. A run reported from the field ended in
+// LOW_BATTERY_DOCKING while the GUI still showed ~35 %, because the sag briefly
+// crossed the 20 % voltage — and the moment the BT reacted (SetMowerEnabled
+// false / StopMoving) the load collapsed, the rail recovered to ~25.6 V, and
+// the percent snapped back. The trip was numerically correct and operationally
+// wrong: it acted on the under-load voltage, not on the state of charge.
+//
+// So low-pass the voltage before deriving the percent.
+//
+// ── Why the time constant, not a fixed alpha ───────────────────────────────
+// A fixed EWMA weight silently encodes the sample rate, and this topic's rate
+// is not ours to assume. /hardware_bridge/power is published once per firmware
+// status packet (hardware_bridge_node::handle_status), and the firmware emits
+// those every STATUS_NBT_TIME_MS = 250 ms — 4 Hz, not the 10 Hz the sim's
+// fake_hardware_bridge_node runs at. One alpha would therefore mean two
+// different filters on the robot and in sim, and would drift again the day
+// anyone retunes STATUS_NBT_TIME_MS. Deriving alpha per sample from the
+// elapsed time (alpha = dt / (tau + dt)) fixes the behaviour to TAU_S
+// regardless of the rate, and makes the tuning knob the quantity you can
+// actually reason about against a transient's duration.
+constexpr double kBatteryFilterTauS = 2.0;
+
+/// Samples at or below this are treated as no reading at all — a disconnected
+/// pack or a glitched ADC, not a flat battery. A 24 V pack that has genuinely
+/// collapsed this far is long past any threshold the BT reacts to.
+constexpr float kBatteryMinValidVoltage = 10.0f;
+
+/// First-order low-pass over v_battery with a rate-independent time constant.
+///
+/// Pure logic, no ROS, so it is unit-testable standalone (see
+/// test_battery_filter.cpp) — same shape as localization_health.hpp.
+class BatteryVoltageFilter
+{
+public:
+  BatteryVoltageFilter() = default;
+
+  /// @param tau_s      time constant in seconds; <= 0 disables smoothing
+  ///                   (every valid sample passes through unchanged).
+  /// @param min_valid_v samples below this are ignored as invalid.
+  BatteryVoltageFilter(double tau_s, float min_valid_v);
+
+  /// Fold one sample in.
+  ///
+  /// @param v_raw   the reported rail voltage.
+  /// @param now_sec a monotonically increasing clock, in seconds. The node
+  ///                passes its ROS clock (so sim time works) rather than the
+  ///                message stamp, which keeps the filter correct even for a
+  ///                publisher that does not stamp its messages.
+  /// @return the filtered voltage, or nullopt while no valid sample has ever
+  ///         arrived. Callers must not derive a percent from nullopt: writing
+  ///         a 0 % derived from a glitch reading is exactly the false reading
+  ///         this filter exists to prevent.
+  std::optional<float> update(float v_raw, double now_sec);
+
+  /// Last filtered value, or nullopt before the first valid sample.
+  std::optional<float> value() const
+  {
+    return value_;
+  }
+
+  /// Drop the state — the next valid sample bootstraps the filter again.
+  void reset();
+
+private:
+  double tau_s_{kBatteryFilterTauS};
+  float min_valid_v_{kBatteryMinValidVoltage};
+  std::optional<float> value_;
+  double last_sec_{0.0};
+};
+
+/// Linear voltage → percent interpolation against the configured endpoints,
+/// clamped to [0, 100]. Returns 0 for a degenerate (non-positive) range.
+float batteryPercentFromVoltage(float voltage, float v_empty, float v_full);
+
+}  // namespace mowgli_behavior
+
+#endif  // MOWGLI_BEHAVIOR__BATTERY_FILTER_HPP_

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -202,6 +202,13 @@ struct BTContext
   // -----------------------------------------------------------------------
 
   float battery_percent{100.0f};
+
+  /// Low-pass-filtered v_battery, in volts, from which battery_percent above is
+  /// derived. 0 means no valid reading has arrived yet — check that before
+  /// comparing against a voltage threshold. Raw latest_power.v_battery swings
+  /// 0.5-1 V on motor transients; see battery_filter.hpp.
+  float battery_voltage_filtered{0.0f};
+
   float gps_quality{0.0f};
 
   /// Latest GPS position in map frame (from /gps/absolute_pose)

--- a/ros2/src/mowgli_behavior/src/battery_filter.cpp
+++ b/ros2/src/mowgli_behavior/src/battery_filter.cpp
@@ -1,0 +1,85 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+
+#include "mowgli_behavior/battery_filter.hpp"
+
+#include <algorithm>
+
+namespace mowgli_behavior
+{
+
+BatteryVoltageFilter::BatteryVoltageFilter(double tau_s, float min_valid_v)
+    : tau_s_(tau_s), min_valid_v_(min_valid_v)
+{
+}
+
+void BatteryVoltageFilter::reset()
+{
+  value_.reset();
+  last_sec_ = 0.0;
+}
+
+std::optional<float> BatteryVoltageFilter::update(float v_raw, double now_sec)
+{
+  // An invalid sample carries no information, so hold the last filtered value
+  // and — deliberately — do NOT advance last_sec_. The gap therefore counts
+  // towards the next valid sample's dt, so recovering from a dropout snaps to
+  // the fresh reading instead of dragging the pre-dropout value back in.
+  if (v_raw < min_valid_v_)
+  {
+    return value_;
+  }
+
+  if (!value_)
+  {
+    // Bootstrap on the first sane sample. Seeding from a zero-initialised
+    // state would otherwise ramp the percent up from 0 % over one time
+    // constant every startup.
+    value_ = v_raw;
+    last_sec_ = now_sec;
+    return value_;
+  }
+
+  const double dt = now_sec - last_sec_;
+  if (dt <= 0.0)
+  {
+    // Duplicate or non-monotonic clock reading (a stalled /clock before sim
+    // time starts ticking, say). Nothing sensible to integrate over.
+    return value_;
+  }
+
+  // alpha = dt / (tau + dt) — the discrete-time equivalent of a first-order
+  // lag with time constant tau_s_, evaluated at whatever rate this sample
+  // happened to arrive at. tau <= 0 degenerates to alpha = 1 (pass-through).
+  const double alpha = (tau_s_ > 0.0) ? std::clamp(dt / (tau_s_ + dt), 0.0, 1.0) : 1.0;
+  value_ = static_cast<float>(alpha * v_raw + (1.0 - alpha) * static_cast<double>(*value_));
+  last_sec_ = now_sec;
+  return value_;
+}
+
+float batteryPercentFromVoltage(float voltage, float v_empty, float v_full)
+{
+  const float range = v_full - v_empty;
+  if (range <= 0.01f)
+  {
+    return 0.0f;
+  }
+  const float clamped = std::clamp(voltage, v_empty, v_full);
+  return 100.0f * (clamped - v_empty) / range;
+}
+
+}  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -119,11 +119,41 @@ private:
                                      std::lock_guard<std::mutex> lock(context_->context_mutex);
                                      context_->latest_power = *msg;
 
+                                     // Low-pass filter on v_battery before deriving the
+                                     // percent. Motors pull the rail down 0.5–1 V during
+                                     // PWM startup / stiction-overcome transients; without
+                                     // smoothing those dips drove LOW_BATTERY_DOCKING trips
+                                     // while the true SoC was still 30–40 %. ALPHA=0.05 at
+                                     // the topic's ~10 Hz rate gives a ≈2 s time constant —
+                                     // brief spikes are absorbed, real discharge still
+                                     // tracks closely. Bootstrap on the first sane sample
+                                     // (≥10 V floor) so a zero-initialised filter doesn't
+                                     // produce an artificial startup dip; ignore obviously
+                                     // invalid samples (sensor glitch / disconnected pack).
+                                     constexpr float ALPHA = 0.05f;
+                                     constexpr float MIN_VALID_V = 10.0f;
+                                     const float v_raw = msg->v_battery;
+                                     if (v_raw >= MIN_VALID_V)
+                                     {
+                                       if (v_battery_filtered_ < MIN_VALID_V)
+                                       {
+                                         v_battery_filtered_ = v_raw;  // bootstrap
+                                       }
+                                       else
+                                       {
+                                         v_battery_filtered_ =
+                                             ALPHA * v_raw + (1.0f - ALPHA) * v_battery_filtered_;
+                                       }
+                                     }
+                                     const float v_for_pct = (v_battery_filtered_ >= MIN_VALID_V)
+                                                                 ? v_battery_filtered_
+                                                                 : v_raw;
+
                                      // Derive battery_percent from voltage using
                                      // configurable thresholds from ROS parameters.
                                      const float v_max = battery_full_voltage_;
                                      const float v_min = battery_empty_voltage_;
-                                     const float clamped = std::clamp(msg->v_battery, v_min, v_max);
+                                     const float clamped = std::clamp(v_for_pct, v_min, v_max);
                                      const float range = v_max - v_min;
                                      context_->battery_percent =
                                          (range > 0.01f) ? 100.0f * (clamped - v_min) / range
@@ -529,6 +559,9 @@ private:
   // Battery voltage curve parameters
   float battery_full_voltage_{28.5f};
   float battery_empty_voltage_{24.0f};
+  // Running low-pass filter state for v_battery. Below MIN_VALID_V the
+  // filter is treated as un-bootstrapped (first sane sample seeds it).
+  float v_battery_filtered_{0.0f};
 };
 
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -165,11 +165,41 @@ private:
                                      std::lock_guard<std::mutex> lock(context_->context_mutex);
                                      context_->latest_power = *msg;
 
+                                     // Low-pass filter on v_battery before deriving the
+                                     // percent. Motors pull the rail down 0.5–1 V during
+                                     // PWM startup / stiction-overcome transients; without
+                                     // smoothing those dips drove LOW_BATTERY_DOCKING trips
+                                     // while the true SoC was still 30–40 %. ALPHA=0.05 at
+                                     // the topic's ~10 Hz rate gives a ≈2 s time constant —
+                                     // brief spikes are absorbed, real discharge still
+                                     // tracks closely. Bootstrap on the first sane sample
+                                     // (≥10 V floor) so a zero-initialised filter doesn't
+                                     // produce an artificial startup dip; ignore obviously
+                                     // invalid samples (sensor glitch / disconnected pack).
+                                     constexpr float ALPHA = 0.05f;
+                                     constexpr float MIN_VALID_V = 10.0f;
+                                     const float v_raw = msg->v_battery;
+                                     if (v_raw >= MIN_VALID_V)
+                                     {
+                                       if (v_battery_filtered_ < MIN_VALID_V)
+                                       {
+                                         v_battery_filtered_ = v_raw;  // bootstrap
+                                       }
+                                       else
+                                       {
+                                         v_battery_filtered_ =
+                                             ALPHA * v_raw + (1.0f - ALPHA) * v_battery_filtered_;
+                                       }
+                                     }
+                                     const float v_for_pct = (v_battery_filtered_ >= MIN_VALID_V)
+                                                                 ? v_battery_filtered_
+                                                                 : v_raw;
+
                                      // Derive battery_percent from voltage using
                                      // configurable thresholds from ROS parameters.
                                      const float v_max = battery_full_voltage_;
                                      const float v_min = battery_empty_voltage_;
-                                     const float clamped = std::clamp(msg->v_battery, v_min, v_max);
+                                     const float clamped = std::clamp(v_for_pct, v_min, v_max);
                                      const float range = v_max - v_min;
                                      context_->battery_percent =
                                          (range > 0.01f) ? 100.0f * (clamped - v_min) / range
@@ -983,6 +1013,9 @@ private:
   // Battery voltage curve parameters
   float battery_full_voltage_{28.0f};
   float battery_empty_voltage_{24.0f};
+  // Running low-pass filter state for v_battery. Below MIN_VALID_V the
+  // filter is treated as un-bootstrapped (first sane sample seeds it).
+  float v_battery_filtered_{0.0f};
 };
 
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -27,6 +27,7 @@
 #include "behaviortree_cpp/behavior_tree.h"
 #include "behaviortree_cpp/loggers/bt_cout_logger.h"
 #include "mowgli_behavior/action_nodes.hpp"
+#include "mowgli_behavior/battery_filter.hpp"
 #include "mowgli_behavior/bt_context.hpp"
 #include "mowgli_behavior/condition_nodes.hpp"
 #include "mowgli_behavior/coverage_nodes.hpp"
@@ -157,54 +158,32 @@ private:
                                              std::chrono::steady_clock::now();
                                        });
 
-    power_sub_ =
-        create_subscription<Power>("/hardware_bridge/power",
-                                   10,
-                                   [this](Power::ConstSharedPtr msg)
-                                   {
-                                     std::lock_guard<std::mutex> lock(context_->context_mutex);
-                                     context_->latest_power = *msg;
+    power_sub_ = create_subscription<Power>(
+        "/hardware_bridge/power",
+        10,
+        [this](Power::ConstSharedPtr msg)
+        {
+          std::lock_guard<std::mutex> lock(context_->context_mutex);
+          context_->latest_power = *msg;
 
-                                     // Low-pass filter on v_battery before deriving the
-                                     // percent. Motors pull the rail down 0.5–1 V during
-                                     // PWM startup / stiction-overcome transients; without
-                                     // smoothing those dips drove LOW_BATTERY_DOCKING trips
-                                     // while the true SoC was still 30–40 %. ALPHA=0.05 at
-                                     // the topic's ~10 Hz rate gives a ≈2 s time constant —
-                                     // brief spikes are absorbed, real discharge still
-                                     // tracks closely. Bootstrap on the first sane sample
-                                     // (≥10 V floor) so a zero-initialised filter doesn't
-                                     // produce an artificial startup dip; ignore obviously
-                                     // invalid samples (sensor glitch / disconnected pack).
-                                     constexpr float ALPHA = 0.05f;
-                                     constexpr float MIN_VALID_V = 10.0f;
-                                     const float v_raw = msg->v_battery;
-                                     if (v_raw >= MIN_VALID_V)
-                                     {
-                                       if (v_battery_filtered_ < MIN_VALID_V)
-                                       {
-                                         v_battery_filtered_ = v_raw;  // bootstrap
-                                       }
-                                       else
-                                       {
-                                         v_battery_filtered_ =
-                                             ALPHA * v_raw + (1.0f - ALPHA) * v_battery_filtered_;
-                                       }
-                                     }
-                                     const float v_for_pct = (v_battery_filtered_ >= MIN_VALID_V)
-                                                                 ? v_battery_filtered_
-                                                                 : v_raw;
+          // Smooth the rail voltage before deriving the percent — motor transients
+          // sag it 0.5-1 V and used to trip the docking thresholds at a genuine
+          // 30-40 % SoC. See battery_filter.hpp for the incident, and for why the
+          // time constant rather than a fixed EWMA weight is the tuning knob.
+          const auto v_filtered = battery_filter_.update(msg->v_battery, now().seconds());
+          if (!v_filtered)
+          {
+            // No valid reading yet. Leave battery_percent at its last good value
+            // rather than publishing a 0 % derived from a disconnected pack.
+            return;
+          }
 
-                                     // Derive battery_percent from voltage using
-                                     // configurable thresholds from ROS parameters.
-                                     const float v_max = battery_full_voltage_;
-                                     const float v_min = battery_empty_voltage_;
-                                     const float clamped = std::clamp(v_for_pct, v_min, v_max);
-                                     const float range = v_max - v_min;
-                                     context_->battery_percent =
-                                         (range > 0.01f) ? 100.0f * (clamped - v_min) / range
-                                                         : 0.0f;
-                                   });
+          // Derive battery_percent from voltage using
+          // configurable thresholds from ROS parameters.
+          context_->battery_voltage_filtered = *v_filtered;
+          context_->battery_percent =
+              batteryPercentFromVoltage(*v_filtered, battery_empty_voltage_, battery_full_voltage_);
+        });
 
     // Replan / boundary signals from map_server_node
     replan_needed_sub_ =
@@ -1013,9 +992,11 @@ private:
   // Battery voltage curve parameters
   float battery_full_voltage_{28.0f};
   float battery_empty_voltage_{24.0f};
-  // Running low-pass filter state for v_battery. Below MIN_VALID_V the
-  // filter is treated as un-bootstrapped (first sane sample seeds it).
-  float v_battery_filtered_{0.0f};
+
+  // Low-pass state for v_battery. Rate-independent (time-constant based), so
+  // the robot's 4 Hz status packets and the sim bridge's 10 Hz both behave the
+  // same. See battery_filter.hpp.
+  BatteryVoltageFilter battery_filter_;
 };
 
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -98,8 +98,15 @@ BT::NodeStatus IsBatteryLow::tick()
   // Voltage gate as a redundant trip: a sagging pack can read fine on
   // percent (which is interpolated from full/empty endpoints) and still
   // be below the safe operating voltage. Disabled when threshold is 0.
-  if (voltage_threshold > 0.0f && ctx->latest_power.v_battery > 0.0f &&
-      ctx->latest_power.v_battery < voltage_threshold)
+  //
+  // Reads the FILTERED voltage, not latest_power.v_battery. Both trips in this
+  // node have to see the same signal — gating this one on the raw rail would
+  // re-open, for any operator who sets battery_critical_voltage, exactly the
+  // motor-transient false trip that filtering battery_percent closes. A pack
+  // that is genuinely below the threshold stays below it, so the gate still
+  // fires, just one time constant (~2 s) later. 0 means no reading yet.
+  if (voltage_threshold > 0.0f && ctx->battery_voltage_filtered > 0.0f &&
+      ctx->battery_voltage_filtered < voltage_threshold)
   {
     return BT::NodeStatus::SUCCESS;
   }

--- a/ros2/src/mowgli_behavior/test/test_battery_filter.cpp
+++ b/ros2/src/mowgli_behavior/test/test_battery_filter.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_battery_filter.cpp
+ * @brief Regression tests for the premature LOW_BATTERY_DOCKING trip.
+ *
+ * A mowing run ended in LOW_BATTERY_DOCKING while the GUI still showed ~35 %.
+ * The BT fired correctly — battery_percent really had crossed 20 % — because
+ * battery_percent was interpolated straight off the raw rail voltage, and the
+ * motors had pulled the pack down ~1 V for well under a second (PWM startup /
+ * stiction). The instant the BT reacted, the load collapsed and the rail
+ * recovered to ~25.6 V.
+ *
+ * These tests pin the two properties that fix requires: a sub-second sag must
+ * not move the percent far enough to trip, and a genuine discharge must still
+ * be tracked. They also pin the two failure modes the filter itself could
+ * introduce — a bogus reading turning into a 0 % gauge, and the smoothing
+ * silently changing strength with the publish rate.
+ */
+
+#include "mowgli_behavior/battery_filter.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::batteryPercentFromVoltage;
+using mowgli_behavior::BatteryVoltageFilter;
+using mowgli_behavior::kBatteryFilterTauS;
+
+namespace
+{
+
+// The YardForce 500 SLA endpoints behavior_tree_node declares by default.
+constexpr float kEmptyV = 24.0f;
+constexpr float kFullV = 28.0f;
+
+/// The robot's real cadence: /hardware_bridge/power is published once per
+/// firmware status packet, and STATUS_NBT_TIME_MS is 250.
+constexpr double kRobotPeriodS = 0.25;
+/// What fake_hardware_bridge_node publishes at in sim.
+constexpr double kSimPeriodS = 0.10;
+
+/// Feed a constant voltage for @p duration_s at @p period_s, starting at
+/// @p t0, and return the clock after the last sample.
+double feed(
+    BatteryVoltageFilter& filter, float voltage, double t0, double duration_s, double period_s)
+{
+  double t = t0;
+  const double end = t0 + duration_s;
+  while (t < end)
+  {
+    t += period_s;
+    filter.update(voltage, t);
+  }
+  return t;
+}
+
+float percentOf(const BatteryVoltageFilter& filter)
+{
+  return batteryPercentFromVoltage(filter.value().value(), kEmptyV, kFullV);
+}
+
+}  // namespace
+
+// ── The incident ───────────────────────────────────────────────────────────
+
+TEST(BatteryFilter, SubSecondMotorSagDoesNotCrossTheDockingThreshold)
+{
+  // Settled at 25.6 V — the voltage the pack recovered to, ~40 % of the scale
+  // and comfortably above the 20 % battery_low_percent trip.
+  BatteryVoltageFilter filter;
+  double t = feed(filter, 25.6f, 0.0, 20.0, kRobotPeriodS);
+  ASSERT_GT(percentOf(filter), 20.0f);
+
+  // Blade engagement drags the rail to 24.8 V — 20.0 % raw, i.e. exactly on
+  // the trip — for 600 ms.
+  ASSERT_NEAR(batteryPercentFromVoltage(24.8f, kEmptyV, kFullV), 20.0f, 0.01f);
+  t = feed(filter, 24.8f, t, 0.6, kRobotPeriodS);
+
+  EXPECT_GT(percentOf(filter), 20.0f) << "a 600 ms sag still trips LOW_BATTERY_DOCKING";
+
+  // Load collapses, rail recovers: the percent must come back, not stay dented.
+  feed(filter, 25.6f, t, 5.0, kRobotPeriodS);
+  EXPECT_NEAR(percentOf(filter), 40.0f, 1.0f);
+}
+
+TEST(BatteryFilter, GenuineDischargeStillReachesTheThreshold)
+{
+  // The filter must lag, not block. Hold a real, unloaded 24.6 V (15 % of the
+  // scale) and the trip has to arrive — a few seconds late is fine, never is
+  // not.
+  BatteryVoltageFilter filter;
+  double t = feed(filter, 25.6f, 0.0, 20.0, kRobotPeriodS);
+  ASSERT_GT(percentOf(filter), 20.0f);
+
+  feed(filter, 24.6f, t, 4.0 * kBatteryFilterTauS, kRobotPeriodS);
+  EXPECT_LT(percentOf(filter), 20.0f);
+}
+
+// ── Rate independence ──────────────────────────────────────────────────────
+
+TEST(BatteryFilter, SmoothingIsTheSameOnTheRobotAndInSim)
+{
+  // A fixed EWMA weight would make the sim's 10 Hz smooth 2.5x harder than the
+  // robot's 4 Hz. Deriving alpha from dt has to make the two agree after the
+  // same amount of WALL-CLOCK time.
+  BatteryVoltageFilter robot;
+  BatteryVoltageFilter sim;
+  robot.update(26.0f, 0.0);
+  sim.update(26.0f, 0.0);
+
+  feed(robot, 25.0f, 0.0, 3.0, kRobotPeriodS);
+  feed(sim, 25.0f, 0.0, 3.0, kSimPeriodS);
+
+  EXPECT_NEAR(*robot.value(), *sim.value(), 0.02f);
+}
+
+TEST(BatteryFilter, ReachesMostOfAStepAfterOneTimeConstant)
+{
+  // A first-order lag covers ~63 % of a step in one tau. This is what makes
+  // kBatteryFilterTauS a knob you can size against a transient's duration.
+  BatteryVoltageFilter filter;
+  filter.update(26.0f, 0.0);
+  feed(filter, 25.0f, 0.0, kBatteryFilterTauS, kRobotPeriodS);
+
+  EXPECT_NEAR(*filter.value(), 26.0f - 0.63f, 0.03f);
+}
+
+// ── Invalid samples ────────────────────────────────────────────────────────
+
+TEST(BatteryFilter, NoValueUntilAValidSampleArrives)
+{
+  // The caller keys "do not touch battery_percent" off nullopt. A glitched or
+  // disconnected-pack reading must not become a 0 % gauge and a docking trip.
+  BatteryVoltageFilter filter;
+  EXPECT_FALSE(filter.value().has_value());
+  EXPECT_FALSE(filter.update(0.0f, 0.0).has_value());
+  EXPECT_FALSE(filter.update(-1.0f, 0.25).has_value());
+  EXPECT_FALSE(filter.value().has_value());
+
+  EXPECT_TRUE(filter.update(25.6f, 0.5).has_value());
+}
+
+TEST(BatteryFilter, BootstrapsOnTheFirstValidSampleWithoutRampingUp)
+{
+  // Seeding from a zero-initialised state would ramp the percent up from 0 %
+  // over a full time constant on every startup.
+  BatteryVoltageFilter filter;
+  EXPECT_FLOAT_EQ(filter.update(25.6f, 10.0).value(), 25.6f);
+}
+
+TEST(BatteryFilter, HoldsTheLastGoodValueThroughADropout)
+{
+  BatteryVoltageFilter filter;
+  double t = feed(filter, 25.6f, 0.0, 10.0, kRobotPeriodS);
+  const float settled = *filter.value();
+
+  for (int i = 0; i < 20; ++i)
+  {
+    t += kRobotPeriodS;
+    EXPECT_FLOAT_EQ(filter.update(0.0f, t).value(), settled);
+  }
+}
+
+TEST(BatteryFilter, SnapsToTheFreshReadingAfterALongDropout)
+{
+  // Ten seconds of nothing, then the pack reappears a volt lower (the bridge
+  // reconnected, or the robot was moved meanwhile). Because an invalid sample
+  // does not advance the filter's clock, the gap counts towards the next
+  // valid sample's dt, so that sample carries most of the weight instead of
+  // dragging a stale charge back in.
+  BatteryVoltageFilter filter;
+  double t = feed(filter, 26.0f, 0.0, 10.0, kRobotPeriodS);
+  t = feed(filter, 0.0f, t, 10.0, kRobotPeriodS);
+
+  filter.update(25.0f, t + kRobotPeriodS);
+  EXPECT_NEAR(*filter.value(), 25.0f, 0.25f);
+
+  // Contrast: with no gap, one sample moves only a small fraction of the step.
+  BatteryVoltageFilter steady;
+  steady.update(26.0f, 0.0);
+  steady.update(25.0f, kRobotPeriodS);
+  EXPECT_GT(*steady.value(), 25.8f);
+}
+
+// ── Clock and configuration edge cases ─────────────────────────────────────
+
+TEST(BatteryFilter, StalledClockLeavesTheValueUnchanged)
+{
+  // use_sim_time before /clock starts ticking hands out the same stamp
+  // forever. dt = 0 must not divide by zero or freeze into a wrong value.
+  BatteryVoltageFilter filter;
+  filter.update(26.0f, 7.0);
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_FLOAT_EQ(filter.update(24.0f, 7.0).value(), 26.0f);
+  }
+}
+
+TEST(BatteryFilter, NonPositiveTauDisablesSmoothing)
+{
+  BatteryVoltageFilter filter(0.0, mowgli_behavior::kBatteryMinValidVoltage);
+  filter.update(26.0f, 0.0);
+  EXPECT_FLOAT_EQ(filter.update(25.0f, 0.25).value(), 25.0f);
+}
+
+TEST(BatteryFilter, ResetRequiresANewBootstrap)
+{
+  BatteryVoltageFilter filter;
+  filter.update(26.0f, 0.0);
+  filter.reset();
+  EXPECT_FALSE(filter.value().has_value());
+  EXPECT_FLOAT_EQ(filter.update(25.0f, 0.25).value(), 25.0f);
+}
+
+// ── The percent interpolation ──────────────────────────────────────────────
+
+TEST(BatteryPercent, InterpolatesAndClampsToTheEndpoints)
+{
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(kEmptyV, kEmptyV, kFullV), 0.0f);
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(kFullV, kEmptyV, kFullV), 100.0f);
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(26.0f, kEmptyV, kFullV), 50.0f);
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(20.0f, kEmptyV, kFullV), 0.0f);
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(30.0f, kEmptyV, kFullV), 100.0f);
+}
+
+TEST(BatteryPercent, DegenerateRangeReportsZeroRatherThanDividingByZero)
+{
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(26.0f, 26.0f, 26.0f), 0.0f);
+  EXPECT_FLOAT_EQ(batteryPercentFromVoltage(26.0f, 28.0f, 24.0f), 0.0f);
+}


### PR DESCRIPTION
## Symptom

A normal mowing run terminated in `LOW_BATTERY_DOCKING` while the GUI was still rendering ~35 % battery remaining. The BT fired correctly: `battery_percent` really had crossed 20 % — because the motors were heavily loaded and the rail had sagged 0.5–1 V from PWM-startup / stiction transients. As soon as the BT reacted (`SetMowerEnabled false` / `StopMoving`) the current draw collapsed, `v_battery` recovered to ~25.6 V, and the GUI snapped back to ~35 %.

The trigger was numerically correct but operationally premature — it acted on the under-load voltage, not on the true SoC.

## Cause

`power_sub_` in `behavior_tree_node.cpp` fed `msg->v_battery` straight into the linear voltage→percent interpolation, with no smoothing. Every sub-second sag showed up as a percent dip, and every percent-gated BT condition (`NeedsDocking` at `battery_low_percent`, `IsBatteryLow` at `battery_critical_percent`, `PreFlightCheck`) saw it.

## Fix

Low-pass the rail voltage before deriving the percent, with a **time constant** (`kBatteryFilterTauS = 2.0 s`), not a fixed EWMA weight.

The distinction matters: `/hardware_bridge/power` is published once per firmware status packet (`hardware_bridge_node::handle_status`), and the firmware emits those every `STATUS_NBT_TIME_MS = 250 ms` — **4 Hz**, while the sim's `fake_hardware_bridge_node` runs at 10 Hz. A fixed alpha silently encodes one of those rates and behaves differently on the other (and drifts again the day anyone retunes the packet period). Deriving `alpha = dt / (tau + dt)` per sample pins the behaviour to `TAU_S` regardless of rate, and makes the knob something you can size against a transient's duration.

Also in this PR:

- **An invalid reading can no longer become a 0 % gauge.** `update()` returns `nullopt` until a valid sample (≥ 10 V) has arrived, and the caller leaves `battery_percent` alone rather than clamping a glitch reading to `v_empty`.
- **`IsBatteryLow`'s redundant voltage gate now reads the filtered voltage** (`BTContext::battery_voltage_filtered`) instead of the raw rail. It is inert at the default (`battery_critical_voltage = 0.0` disables it), but any operator who set it would otherwise have re-opened the exact false trip this PR closes, from the other half of the same node. ⚠️ **Safety-relevant:** a pack that is genuinely below the threshold still trips, one time constant (~2 s) later.
- **The logic is extracted and unit-tested.** `battery_filter.{hpp,cpp}` is pure — no ROS — following the same shape as `localization_health.hpp` / `status_snapshot.hpp`.

The 20 % docking threshold and every other percent-based BT condition are unchanged; this only adjusts what voltage they see. No new ROS parameters.

## Tests

`test_battery_filter.cpp`, 13 cases:

| Property | Test |
|---|---|
| A 600 ms sag at 25.6 V does not cross the 20 % trip, and recovers | `SubSecondMotorSagDoesNotCrossTheDockingThreshold` |
| A genuine discharge still trips (lags, does not block) | `GenuineDischargeStillReachesTheThreshold` |
| 4 Hz robot and 10 Hz sim smooth identically per wall-clock second | `SmoothingIsTheSameOnTheRobotAndInSim` |
| ~63 % of a step in one tau | `ReachesMostOfAStepAfterOneTimeConstant` |
| No value — and so no percent write — until a valid sample | `NoValueUntilAValidSampleArrives` |
| Bootstrap does not ramp up from 0 V | `BootstrapsOnTheFirstValidSampleWithoutRampingUp` |
| Dropouts hold the last good value, then snap to the fresh reading | `HoldsTheLastGoodValueThroughADropout`, `SnapsToTheFreshReadingAfterALongDropout` |
| Stalled `/clock` (dt = 0) does not divide by zero or freeze wrong | `StalledClockLeavesTheValueUnchanged` |
| `tau <= 0` disables smoothing; `reset()` re-bootstraps | `NonPositiveTauDisablesSmoothing`, `ResetRequiresANewBootstrap` |
| Percent interpolation clamps, and survives a degenerate range | `InterpolatesAndClampsToTheEndpoints`, `DegenerateRangeReportsZeroRatherThanDividingByZero` |

Verified locally on `ros:kilted` (`colcon build` + `colcon test`): **291 tests, 0 failures, 44 skipped**, lint clean.

## Field test plan (still owed)

- [ ] Mowing run with intermittent heavy load (blade engagement, stiction recovery): compare raw `/hardware_bridge/power.v_battery` against the derived `battery_percent` — percent should stay monotone within the noise of the actual discharge.
- [ ] `LOW_BATTERY_DOCKING` fires only when the *unloaded* rail is genuinely near 24.8 V, not during a transient dip.
- [ ] Cold start with no `/hardware_bridge/power` messages yet → no spurious 0 % battery until the first valid sample arrives.

## Notes

Rebased onto `dev` (was targeting `main`) and revised after review; @danyial's original commit is preserved as the first commit.
