### PR TITLE
fix(gui): tolerate both ublox and unicore key spellings for GPS diag tile

### DIFF
--- a/gui/web/src/pages/DiagnosticsPage.tsx
+++ b/gui/web/src/pages/DiagnosticsPage.tsx
@@ -438,10 +438,21 @@ export const DiagnosticsPage = () => {
                                     </Col>
                                 );
                             }
-                            const cnoMean = sat?.mean_cno_db_hz ? parseFloat(sat.mean_cno_db_hz) : null;
+                            // CN0 key differs by GPS backend:
+                            //   ublox aggregator (sensors/gps/gps_health_aggregator.py): mean_cno_db_hz  (since 2026-05-01)
+                            //   unicore_node     (sensors/unicore/...unicore_node.cpp): cn0_mean_db_hz (since 2026-05-13)
+                            // ublox is the established canonical spelling (~12 d older). Try it first;
+                            // fall back to the unicore form so unicore-backed stacks still render
+                            // until unicore_node is renamed to match.
+                            const cnoMeanRaw = sat?.mean_cno_db_hz ?? sat?.cn0_mean_db_hz;
+                            const cnoMean = cnoMeanRaw ? parseFloat(cnoMeanRaw) : null;
                             const cnoOk = cnoMean !== null && cnoMean >= 40;
                             const cnoWarn = cnoMean !== null && cnoMean >= 35 && cnoMean < 40;
-                            const ageS = rtcm?.age_of_last_corr_s ? parseFloat(rtcm.age_of_last_corr_s) : null;
+                            // RTCM-age key also differs by backend:
+                            //   ublox aggregator: age_of_last_corr_s              (canonical, older)
+                            //   unicore_node:     age_of_last_injected_corr_s    (newer, also publishes age_of_last_rtcmstatus_s)
+                            const ageRaw = rtcm?.age_of_last_corr_s ?? rtcm?.age_of_last_injected_corr_s;
+                            const ageS = ageRaw ? parseFloat(ageRaw) : null;
                             const sigmaMm = fix?.sigma_xy_mm && fix.sigma_xy_mm !== "n/a"
                                 ? parseFloat(fix.sigma_xy_mm) : null;
                             return (


### PR DESCRIPTION
## Symptom

DiagnosticsPage's GPS card renders **"—"** (placeholder) for **Mean CN0 (dB-Hz)** and **Last correction (s)** on stacks running the unicore GPS backend, even when the underlying receiver data is perfectly healthy.

## Cause

The two GPS aggregators emit **different key names** for the same conceptual field:

| Backend | CN0 key | RTCM age key | First seen |
|---|---|---|---|
| `sensors/gps/gps_health_aggregator.py` (ublox) | `mean_cno_db_hz` | `age_of_last_corr_s` | 2026-05-01 (`9fd026e0`) |
| `sensors/unicore/.../unicore_node.cpp` | `cn0_mean_db_hz` | `age_of_last_injected_corr_s` | 2026-05-13 (`f8f106a` in cedbossneo/unicore-ros2) |

The ublox spelling is **canonical by precedence** (12 days older). The previous GUI code was correct for ublox; unicore is the divergent name.

## Evidence

Live `/diagnostics` from a unicore-backed stack:
```
- key: cn0_mean_db_hz
  value: '29.780'
- key: age_of_last_injected_corr_s
  value: '0.397'
```
GUI tile at the same moment: "Mean CN0 — Last correction —".

## Fix

Read with a `??` fallback chain. **ublox form is preferred** (canonical), unicore as fallback:

```ts
const cnoMeanRaw = sat?.mean_cno_db_hz ?? sat?.cn0_mean_db_hz;
const ageRaw    = rtcm?.age_of_last_corr_s ?? rtcm?.age_of_last_injected_corr_s;
```

This unblocks unicore-backed installs today without picking a winner that contradicts precedence.

## Test plan

- [x] Live verified on a Pi-5 unicore stack — both fields now render real numbers via the fallback branch
- [ ] ublox regression — fields should render same values as today (the primary branch is unchanged)
- [ ] No change to color thresholds (40 / 35-40 / <35 dB-Hz; 5 s correction age)

## Long-term

A follow-up PR against `cedbossneo/unicore-ros2` will rename the unicore keys (`cn0_mean_db_hz` → `mean_cno_db_hz`, `age_of_last_injected_corr_s` → `age_of_last_corr_s`) so the GUI fallback chain eventually becomes a no-op and there's one canonical spelling across the project. The `age_of_last_rtcmstatus_s` key on unicore stays — it's a distinct concept (RTCMSTATUS message receipt time vs RTCM injection time).