### PR TITLE
fix(devcontainer): stabilize ROS2 workspace and Fields2Cover integration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,6 +86,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kilted-nav2-core \
     ros-kilted-nav2-util \
     ros-kilted-nav2-msgs \
+    ros-kilted-fields2cover \
     # ── DDS (Cyclone is required — FastRTPS has stale shm issues on ARM) ──
     ros-kilted-rmw-cyclonedds-cpp \
     # ── Docking ──
@@ -164,6 +165,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       > /etc/apt/sources.list.d/github-cli.list \
  && apt-get update && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
+
+# Fields2Cover as system CMake dependency for mowgli_coverage.
+RUN git clone --depth 1 --branch v2.0.0 https://github.com/Fields2Cover/Fields2Cover.git /tmp/Fields2Cover && \
+    cmake -S /tmp/Fields2Cover -B /tmp/Fields2Cover/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DBUILD_TESTING=OFF && \
+    cmake --build /tmp/Fields2Cover/build -j$(nproc) && \
+    cmake --install /tmp/Fields2Cover/build && \
+    rm -rf /tmp/Fields2Cover && \
+    ldconfig
 
 # ---------------------------------------------------------------------------
 # 2. Python linters + pre-commit (system-wide, PEP 668 override OK inside

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,6 +14,15 @@ source /opt/ros/kilted/setup.bash
 
 cd /ros2_ws
 
+echo "Cleaning stale workspace artifacts..."
+
+# Never let generated colcon artifacts inside src/ be discovered as packages.
+rm -rf src/install src/build src/log
+
+# Fields2Cover is installed as a system CMake dependency in the devcontainer.
+# Do not build a workspace copy if one is present from older tests.
+rm -f src/fields2cover src/Fields2Cover
+
 # ---------------------------------------------------------------------------
 # Symlink ROS2 packages from monorepo into workspace src/
 #
@@ -21,14 +30,25 @@ cd /ros2_ws
 # /ros2_ws/src/mowglinext. We symlink each mowgli_* package into src/
 # so colcon discovers them at the workspace root, plus fusion_graph.
 # ---------------------------------------------------------------------------
+
 echo "Linking ROS2 packages into workspace..."
 
 mkdir -p src
 
 for pkg_dir in src/mowglinext/ros2/src/mowgli_*/; do
+    [ -d "$pkg_dir" ] || continue
     pkg_name=$(basename "$pkg_dir")
     ln -sfn "/ros2_ws/$pkg_dir" "src/$pkg_name"
     echo "  Linked: $pkg_name"
+done
+
+# OpenNav coverage packages.
+for pkg_dir in src/mowglinext/ros2/src/opennav_coverage/*/; do
+    if [ -f "${pkg_dir}/package.xml" ]; then
+        pkg_name=$(basename "$pkg_dir")
+        ln -sfn "/ros2_ws/$pkg_dir" "src/$pkg_name"
+        echo "  Linked: $pkg_name"
+    fi
 done
 
 if [ -d "src/mowglinext/ros2/src/fusion_graph" ]; then
@@ -64,11 +84,11 @@ rosdep install \
 # Build the workspace.
 # ---------------------------------------------------------------------------
 echo "Building workspace (this may take a few minutes on first run)..."
-# unicore_gnss is a stub package.xml under sensors/unicore/ (no
-# CMakeLists in tree — it lives in the GPS Docker image build context).
-# colcon discovers it via the workspace mount and would fail; ignore it.
+
+# unicore_gnss is a stub package.xml under sensors/unicore/ with no CMakeLists.
+# fields2cover is provided as a system dependency, not built as a ROS package.
 colcon build \
-    --packages-ignore unicore_gnss \
+    --packages-ignore unicore_gnss fields2cover \
     --cmake-args \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_TESTING=OFF \


### PR DESCRIPTION
## Summary

This PR also standardizes the handling of Fields2Cover as a system dependency instead of a workspace ROS package.

# Changes
 clean stale colcon artifacts from src/ before workspace setup
 prevent install/, build/, and log/ directories from being discovered as ROS packages
 ignore workspace fields2cover package in favor of system-installed Fields2Cover
 improve monorepo package symlink handling inside the devcontainer workspace
 make workspace rebuilds deterministic and reproducible
 avoid duplicate package discovery conflicts in bind-mounted ROS2 workspaces
 improve overall devcontainer reliability for first boot and rebuild scenarios


## Component

<!-- Check all that apply -->

- [x] ROS2 Stack (`ros2/`)
- [ ] GUI (`gui/`)
- [x] Docker (`docker/`)
- [ ] Sensors (`sensors/`)
- [ ] Firmware (`firmware/`)
- [ ] Documentation (`docs/`)
- [ ] CI/CD (`.github/`)

## Testing

<!-- How was this tested? -->

- [x] Built successfully
- [ ] Tested on hardware
- [ ] Tested in simulation
- [ ] Unit tests pass
- [x] Manual testing

## Checklist

- [x] Follows conventional commit format
- [ ] Documentation updated (if user-facing)
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes
