### PR TITLE
fix(gui): i18n follow-ups — resolve mower-model tag key + fallback chain

### DIFF
--- a/gui/web/src/components/settings/HardwareSection.tsx
+++ b/gui/web/src/components/settings/HardwareSection.tsx
@@ -63,7 +63,7 @@ export const HardwareSection: React.FC<Props> = ({ values, onChange, onBulkChang
                                         <Space direction="vertical" size={2} style={{ width: "100%" }}>
                                             <Space size={4}>
                                                 <Text strong style={{ fontSize: 12 }}>{t(model.label)}</Text>
-                                                {model.tag && <Tag color="green" style={{ fontSize: 10 }}>{model.tag}</Tag>}
+                                                {model.tag && <Tag color="green" style={{ fontSize: 10 }}>{t(model.tag)}</Tag>}
                                             </Space>
                                             <Text type="secondary" style={{ fontSize: 11 }}>
                                                 {t(model.description)}

--- a/gui/web/src/i18n/index.ts
+++ b/gui/web/src/i18n/index.ts
@@ -24,7 +24,10 @@ i18n
       fr: {translation: fr},
       en: {translation: en},
     },
-    fallbackLng: "fr",
+    // Fallback chain (covers both directions if a key is ever missing):
+    // a missing English key falls back to French (the source language), and a
+    // missing French key falls back to English instead of showing a raw key.
+    fallbackLng: ["fr", "en"],
     supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
     // Map regional codes (e.g. "en-US", "fr-CA") onto the base language.
     nonExplicitSupportedLngs: true,


### PR DESCRIPTION
## Summary

Two small follow-up fixes to the i18n work (#298).

### 1. Mower-model `tag` rendered a raw i18n key (visible bug)
`HardwareSection` rendered the model `tag` field directly. Since the mower-model catalog now stores i18n keys, the **YardForce 500 card on /settings showed the literal `mowerModels.YardForce500.tag`** — and the long unbreakable string collapsed the card title to one character per line. Now resolved with `t()` (OnboardingPage already did this for the same field). The tag renders as “Popular” / “Populaire”.

### 2. i18n fallback chain so missing keys never render raw
`fallbackLng` was `"fr"`, so a key missing from the **French** bundle had nothing left to fall back to and would render the raw key. Switched to a chain `["fr", "en"]`:
- Missing **English** key → falls back to **French** (source language), as before.
- Missing **French** key → falls back to **English** instead of a raw key.

Only changes behaviour when a key is genuinely absent; the bundles currently have full FR/EN parity, so there's no visible change today beyond fix #1 — it's resilience for future strings.

## Impact
- Two files touched (`HardwareSection.tsx`, `i18n/index.ts`); no locale or component-structure changes.
