### PR TITLE
feat(gui): add an SVG favicon matching the in-app logo mark

### DIFF
--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -6,6 +6,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
     <meta name="theme-color" content="#02110D"/>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <!-- Typography stack (single committed system):

--- a/gui/web/public/favicon.svg
+++ b/gui/web/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <!-- MowgliNext "m" mark: lime tech-garden gradient tile matching the in-app
+       side-rail logo (linear-gradient 135deg #7CFFB2 -> #45D688 -> #2BAA66). -->
+  <defs>
+    <linearGradient id="mn-fav" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7CFFB2"/>
+      <stop offset="50%" stop-color="#45D688"/>
+      <stop offset="100%" stop-color="#2BAA66"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="20" fill="url(#mn-fav)"/>
+  <text x="32" y="34" text-anchor="middle" dominant-baseline="central"
+        font-family="'Satoshi','Inter',system-ui,-apple-system,'Segoe UI',Roboto,Arial,sans-serif"
+        font-weight="900" font-size="42" fill="#02110D">m</text>
+</svg>


### PR DESCRIPTION
## Summary

The GUI had **no favicon** — `index.html` only linked a manifest, so browsers fell back to the default globe icon in the tab.

This adds an **SVG favicon** that matches the in-app side-rail logo (the lime "m" mark): the tech-garden gradient tile (`135deg #7CFFB2 → #45D688 → #2BAA66`) on dark ink, referenced via:

```html
<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
```

- Vector, so it stays crisp at any tab/bookmark size and on hi-DPI displays.
- Theme-consistent with the current UI (the `public/*.svg` robot-mower assets predate the lime theme and are a different design; left untouched).
- Two-file change: new `public/favicon.svg` + one `<link>` in `index.html`.

## Notes

- Supported by all current evergreen browsers (Chrome/Edge/Firefox, Safari 17+). Older Safari/iOS would need a PNG `apple-touch-icon`, and the PWA `manifest.json` could also be given an `icons` entry — happy to follow up with those if wanted (kept this PR minimal).
