### PR TITLE
fix(monitoring): gate LiDAR /scan health check on lidar_enabled

### DIFF
--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -45,6 +45,7 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -384,7 +385,12 @@ def generate_launch_description() -> LaunchDescription:
         output="screen",
         parameters=[
             monitoring_params,
-            {"use_sim_time": use_sim_time},
+            {
+                "use_sim_time": use_sim_time,
+                # Follow the same authoritative LiDAR flag as the Nav stack so the
+                # health check reports "disabled" instead of a false "no scan" error.
+                "lidar_enabled": ParameterValue(use_lidar, value_type=bool),
+            },
         ],
     )
 

--- a/ros2/src/mowgli_bringup/launch/sim_full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/sim_full_system.launch.py
@@ -54,6 +54,7 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -233,7 +234,10 @@ def generate_launch_description() -> LaunchDescription:
         output="screen",
         parameters=[
             monitoring_params,
-            {"use_sim_time": True},
+            {
+                "use_sim_time": True,
+                "lidar_enabled": ParameterValue(use_lidar, value_type=bool),
+            },
         ],
     )
 

--- a/ros2/src/mowgli_monitoring/include/mowgli_monitoring/diagnostics_node.hpp
+++ b/ros2/src/mowgli_monitoring/include/mowgli_monitoring/diagnostics_node.hpp
@@ -153,6 +153,8 @@ std::string level_name(uint8_t level);
  * battery_error_pct    double  10.0   %  — battery ERROR level
  * motor_temp_warn_c    double  60.0   °C — ESC/motor WARN temperature
  * motor_temp_error_c   double  80.0   °C — ESC/motor ERROR temperature
+ * lidar_enabled        bool    false     — gate the LiDAR /scan health check; when
+ *                                          false, report OK "LiDAR disabled"
  */
 class DiagnosticsNode : public rclcpp::Node
 {
@@ -232,6 +234,7 @@ private:
   double battery_error_pct_{10.0};
   double motor_temp_warn_c_{60.0};
   double motor_temp_error_c_{80.0};
+  bool lidar_enabled_{false};
 
   // ---- State snapshot -------------------------------------------------------
 

--- a/ros2/src/mowgli_monitoring/src/diagnostics_node.cpp
+++ b/ros2/src/mowgli_monitoring/src/diagnostics_node.cpp
@@ -133,6 +133,7 @@ void DiagnosticsNode::declare_parameters()
   battery_error_pct_ = declare_parameter<double>("battery_error_pct", 10.0);
   motor_temp_warn_c_ = declare_parameter<double>("motor_temp_warn_c", 60.0);
   motor_temp_error_c_ = declare_parameter<double>("motor_temp_error_c", 80.0);
+  lidar_enabled_ = declare_parameter<bool>("lidar_enabled", false);
 
   // Clamp publish_rate to [0.1, 100.0] Hz to prevent zero-division.
   if (publish_rate_ < 0.1 || publish_rate_ > 100.0)
@@ -452,6 +453,15 @@ diagnostic_msgs::msg::DiagnosticStatus DiagnosticsNode::check_lidar(const rclcpp
   diagnostic_msgs::msg::DiagnosticStatus status;
   status.name = "LiDAR";
   status.hardware_id = "mowgli/lidar";
+
+  // When the LiDAR is intentionally disabled (GPS-only operation) there is no
+  // /scan publisher, so don't raise a spurious "no scan" error.
+  if (!lidar_enabled_)
+  {
+    status.level = DiagLevel::OK;
+    status.message = "LiDAR disabled";
+    return status;
+  }
 
   if (!state_.scan_ever_received)
   {

--- a/ros2/src/mowgli_monitoring/test/test_diagnostics.cpp
+++ b/ros2/src/mowgli_monitoring/test/test_diagnostics.cpp
@@ -290,6 +290,33 @@ TEST_F(DiagnosticsTest, CategoryLevelsAreValidDiagnosticLevels)
 }
 
 // ===========================================================================
+// 4b. LiDAR enable gating
+// ===========================================================================
+
+TEST_F(DiagnosticsTest, LidarDisabledReportsOkNotError)
+{
+  // Default lidar_enabled=false (GPS-only operation): the health check must
+  // report OK rather than a spurious "No LiDAR scan received" error.
+  auto node = make_node("_lidar_off");
+  const auto status = node->check_lidar(node->now());
+  EXPECT_EQ(status.name, "LiDAR");
+  EXPECT_EQ(status.level, DiagLevel::OK);
+  EXPECT_EQ(status.message, "LiDAR disabled");
+}
+
+TEST_F(DiagnosticsTest, LidarEnabledWithoutScanReportsError)
+{
+  // With the LiDAR enabled but no /scan ever received, the error is preserved.
+  rclcpp::NodeOptions opts;
+  opts.arguments({"--ros-args", "--remap", "__node:=test_diag_lidar_on"});
+  opts.parameter_overrides({rclcpp::Parameter("lidar_enabled", true)});
+  auto node = std::make_shared<mowgli_monitoring::DiagnosticsNode>(opts);
+  const auto status = node->check_lidar(node->now());
+  EXPECT_EQ(status.level, DiagLevel::ERROR);
+  EXPECT_EQ(status.message, "No LiDAR scan received");
+}
+
+// ===========================================================================
 // 5. Edge cases
 // ===========================================================================
 


### PR DESCRIPTION
## Problem
On a GPS-only robot (no LiDAR), the GUI permanently shows **Alert: LiDAR — "No LiDAR scan received"**, even when the LiDAR is intentionally disabled (`mowgli_robot.yaml: lidar_enabled: false` / `LIDAR_ENABLED=false`).

## Root cause
`mowgli_monitoring`'s `diagnostics_node` always publishes a LiDAR `DiagnosticStatus`, and `check_lidar()` returns `ERROR "No LiDAR scan received"` whenever no `/scan` has ever been received. The node has no notion of whether the LiDAR is enabled, so with no `/scan` publisher it raises a permanent false alarm. (For comparison, GPS-absent is only `WARN`, but LiDAR-absent was `ERROR`.)

## Fix
- Add a `lidar_enabled` parameter (default `false`) to `diagnostics_node`.
- When it is false, `check_lidar()` reports `OK "LiDAR disabled"` instead of an error.
- Pass it from the existing `use_lidar` launch configuration — sourced authoritatively from `mowgli_robot.yaml: lidar_enabled` with the `LIDAR_ENABLED` env fallback — in `full_system.launch.py` and `sim_full_system.launch.py`, so the monitor follows the same flag as the Nav stack.
- When the LiDAR **is** enabled but no scan arrives, the `ERROR` is preserved (a real fault is still flagged).

## Tests
Adds unit tests for both gating paths:
- disabled -> `OK "LiDAR disabled"`
- enabled + no scan -> `ERROR "No LiDAR scan received"`

Existing `check_lidar` tests are unaffected.