### PR TITLE
fix(nav2): stop transit-pivot oscillation (pivot once, then pursue)

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
@@ -211,6 +211,14 @@ controller_server:
       rotate_to_heading_angular_vel: 0.75
       max_angular_accel: 2.5
       simulate_ahead_time: 1.0
+      # Pivot ONCE at the start of each transit, then hand to the primary
+      # controller — do NOT re-engage the in-place rotate mid-path. The transit
+      # plan is FROZEN (never replanned from the current pose) and RotationShim
+      # samples its target 0.5 m from poses.front() (the plan START). Once the
+      # robot drives off poses.front(), a re-engaged shim/RPP rotate aims at that
+      # STALE point and oscillates / runs to a wrong heading and never aligns
+      # (root cause hardware-confirmed 2026-06-20; see use_rotate_to_heading below).
+      rotate_to_heading_once: true
       # Terminal pivot. With this false, neither RotationShim (start-of-path
       # only) nor RPP (mid-path, rotate_to_heading_min_angle: 0.785 rad =
       # 45°) does anything when the navigation ends with a yaw error in the
@@ -225,7 +233,11 @@ controller_server:
       # goal heading. Cost: one ~1 s in-place rotation per nav action,
       # which the operator barely notices but the docking-server NEEDS.
       rotate_to_goal_heading: true
-      closed_loop: true                    # use wheel odom feedback for pivot completion
+      # was true ("wheel odom feedback for pivot completion"), but on this deadband
+      # chassis closed_loop:true reads ~0 below the ~0.5 rad/s firmware pivot
+      # deadband and stalls the pivot — the same hard lesson already documented for
+      # FollowCoveragePath below. Open-loop ramp is required here too.
+      closed_loop: false
 
       # --- RegulatedPurePursuitController (primary) params ---
       transform_tolerance: 0.3            # ARM TF jitter envelope
@@ -244,10 +256,13 @@ controller_server:
       regulated_linear_scaling_min_speed: 0.20
       use_cost_regulated_linear_velocity_scaling: false
       max_allowed_time_to_collision_up_to_carrot: 1.0
-      # In-place rotation toward heading at large yaw error — RPP's own
-      # rotate-to-heading hand-off complements RotationShim, kicking in
-      # after RotationShim disengages if the path bends mid-trajectory.
-      use_rotate_to_heading: true
+      # DISABLED: RPP's mid-path in-place re-rotate (together with RotationShim
+      # re-engaging on each setPlan) fires against the FROZEN transit plan and,
+      # once the robot has driven off poses.front(), rotates toward a STALE target
+      # → oscillation / wrong-heading runaway (hardware-confirmed 2026-06-20).
+      # With rotate_to_heading_once:true above, the shim does ONE start pivot then
+      # RPP PURSUES through any mid-path bends (smooth on the deadband chassis).
+      use_rotate_to_heading: false
       rotate_to_heading_min_angle: 0.785
       # Match the RotationShim values above (decisive pivot, clear of the
       # firmware deadband) so RPP's mid-path rotate-to-heading hand-off is


### PR DESCRIPTION
## Summary
On a transit (`FollowPath` = RotationShim + RegulatedPurePursuit), the in-place rotate-to-heading **re-engages mid-transit against the frozen transit plan** and oscillates / runs to a wrong heading, so the transit never completes. The same in-place-rotate path is shared with coverage swath pivots.

Hardware-confirmed on a Yardforce 500B (ROS 2 Kilted, prebuilt images): with this change the robot pivots once at the start, drives onto the path, and starts mowing - no oscillation. Without it, the robot just sits at the start of the path turning left and right.

## Root cause
`RotationShimController::getSampledPathPt()` samples its rotate target **0.5 m from `current_path_.poses.front()`** - the plan **START** - assuming the plan begins at the robot. That holds only for a fresh plan. The transit plan is **never replanned from the current pose** (observed `plan_age` climbing 0.7 s -> 27 s in one run), so once the robot drives off `poses.front()`, the re-engaged in-place rotate (RPP's `use_rotate_to_heading` + the shim re-triggering on each `setPlan`) aims at that stale point and runs away.

The **initial** pivot always worked (plan fresh, robot ~= `poses.front()`); only the re-engaged rotate on the stale plan failed. RPP **pursuit** prunes the plan to the robot and steers correctly - it was never the problem.

## Fix - pivot once, then pursue
| Param | Before | After | Why |
|---|---|---|---|
| `rotate_to_heading_once` | (absent -> false) | **true** | shim pivots only on the first command per plan |
| `use_rotate_to_heading` | true | **false** | RPP pursues mid-path bends instead of re-rotating in place |
| `closed_loop` | true | **false** | open-loop ramp, required on this deadband chassis - same lesson already documented for `FollowCoveragePath` |

`rotate_to_goal_heading` is **kept `true`**: the terminal goal pivot uses the fresh goal pose (not the stale plan), so it is not affected by this bug, and it is required for `opennav_docking` terminal heading alignment.

## Testing
Hardware-confirmed 2026-06-20 (Yardforce 500B, deadband chassis, single-hall encoders, MPU6050). Heading-error trace (computed from `/plan` + TF `map->base_link`, not the fused pose): shim pivots -115 deg -> -14 deg (deadband cleared), disengages, RPP drives the path (cmd_vx ~0.4 m/s), mowing starts. No oscillation across repeated runs.

## Notes for review
- The mid-path-bend hand-off that `use_rotate_to_heading: true` provided is given up; on a mower following smooth transit paths, RPP pursuit handles bends without an in-place rotate. If a deployment has very sharp mid-transit bends, this is the param to revisit.
- A robust upstream fix would have `getSampledPathPt()` prune to the robot's nearest point on the path (as RPP does) instead of `poses.front()`, so the start pivot is correct even on a stale plan; the param change here avoids the failure without touching nav2.
