### PR TITLE
fix(nav2): controllers had no velocity feedback (odom_topic defaulted to unpublished /odom)

### DIFF
--- a/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
@@ -63,6 +63,16 @@ controller_server:
   ros__parameters:
     use_sim_time: false
     enable_stamped_cmd_vel: true
+    # Velocity-feedback source for the controllers — MPPI reads current speed
+    # from here to seed its trajectory rollouts, RPP for its velocity-scaled
+    # lookahead. MUST be set: the nav2 default is "odom", but nothing publishes
+    # /odom on this robot (the wheel odometry is /wheel_odom), so leaving the
+    # default gave both controllers ZERO velocity feedback — MPPI planned every
+    # cycle as if stationary (circling on tight coverage) and RPP's lookahead
+    # collapsed to its minimum (transit weaving). Use /wheel_odom (raw, carries
+    # angular velocity); the fused /odometry/filtered currently reports
+    # twist.angular.z = 0 (separate fusion gap, so it is NOT usable here yet).
+    odom_topic: /wheel_odom
     # 10 Hz: 0.3 m/s × 100 ms = 3 cm of motion between decisions, matches
     # the 5-10 Hz upstream costmap / GPS refresh. Dropped from 20 Hz
     # because the ARM host was chronically missing the 20 Hz loop rate


### PR DESCRIPTION
## Summary
`controller_server` never sets `odom_topic`, so it falls back to the nav2 default `"odom"` — but **nothing publishes `/odom`** on this robot (the wheel odometry is on `/wheel_odom`). The MPPI and RPP controllers therefore run with **zero velocity feedback**.

Confirmed on a Yardforce 500B: `/odom` has **0 publishers**, and `controller_server` was subscribed to it.

## Impact
- **MPPI (FollowCoveragePath):** seeds its trajectory rollouts from the current speed. Reading zero while actually moving/rotating, it mis-predicts its own motion over the ~3.6 s horizon → erratic turning, **circling** (worst on tight coverage paths).
- **RPP (FollowPath):** `use_velocity_scaled_lookahead_dist: true` scales the lookahead by speed; with zero speed it pins to `min_lookahead_dist` permanently → short lookahead → **transit weaving**.
- Also contributed to the documented RotationShim `closed_loop=true "reads ~0"` lesson — that `~0` was this dead-odom feedback (it broke the closed-loop ramp even mid-pivot). Note: this does **not** re-enable `closed_loop: true` — the deadband chassis independently needs the open-loop ramp to break stiction at a pivot start (a closed-loop ramp pins at one accel-step below the ~0.5 rad/s deadband and never starts), so `closed_loop: false` stays regardless.

## Fix
```yaml
controller_server:
  ros__parameters:
    odom_topic: /wheel_odom
```
`/wheel_odom` (hardware_bridge, ~16 Hz) carries linear + angular velocity. Hardware-confirmed: once subscribed, the wheel angular velocity tracks the IMU within ~0.1 rad/s and the controllers receive real feedback.

## Why not `/odometry/filtered`
The fused odom would be the smoother choice, but it currently publishes `twist.angular.z = 0` (a separate gap in the fusion node) — so it is not usable for the controllers' angular feedback yet. `/wheel_odom` is the correct source until the fusion is fixed.

## Testing
Yardforce 500B, ROS 2 Kilted.
- **Before:** `controller_server` subscribed to `/odom` (0 publishers); logged controller-side wheel angular = `nan`.
- **After:** `controller_server` subscribes `/wheel_odom`; logged wheel angular velocity tracks the IMU (mean |Δ| ≈ 0.10 rad/s), feedback flowing.

Note: a separate tight-coverage / deadband-chassis limitation can still cause circling on *very small* areas (the coverage planner emitting sub-minimum-radius turns the chassis can't drive at its non-stall speed) — that is independent of this fix and tracked separately.
