### PR TITLE
Complete a stuck-at-end coverage mow instead of circling forever

### DIFF
--- a/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/path_progress_goal_checker.hpp
+++ b/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/path_progress_goal_checker.hpp
@@ -114,6 +114,18 @@ private:
   // arrival.
   std::optional<rclcpp::Time> empty_path_first_call_;
   double fallback_timeout_s_{5.0};
+
+  // Stuck-at-end fallback. If the robot has covered at least
+  // stuck_completion_progress_ of the path but max_reached_index_ has not
+  // advanced for fallback_timeout_s_ — e.g. it is circling a sub-tolerance
+  // F2C end loop (min_turning_radius ~0.1 m) whose goal point sits inside
+  // the loop, so xy_goal_tolerance can NEVER be met — declare the goal
+  // reached rather than spin forever. Healthy following never reaches this
+  // branch: the monotonic index keeps advancing and clears the timer.
+  // progress_stalled_since_ is the time max_reached_index_ last failed to
+  // advance; reset on every real advance, on reset(), and on a new path.
+  double stuck_completion_progress_{0.90};
+  std::optional<rclcpp::Time> progress_stalled_since_;
 };
 
 }  // namespace mowgli_nav2_plugins

--- a/ros2/src/mowgli_nav2_plugins/src/path_progress_goal_checker.cpp
+++ b/ros2/src/mowgli_nav2_plugins/src/path_progress_goal_checker.cpp
@@ -41,6 +41,10 @@ void PathProgressGoalChecker::initialize(
   xy_goal_tolerance_ = declare("xy_goal_tolerance", 0.20).as_double();
   yaw_goal_tolerance_ = declare("yaw_goal_tolerance", 0.30).as_double();
   fallback_timeout_s_ = declare("fallback_timeout_s", 5.0).as_double();
+  // See header: complete a stuck-at-end mow (index pinned for
+  // fallback_timeout_s_ at >= this progress) instead of circling forever.
+  stuck_completion_progress_ =
+      declare("stuck_completion_progress", 0.90).as_double();
   // Max idx advance per isGoalReached call. Bounds the "find closest
   // pose forward of max_reached_index_" search so a boustrophedon-
   // style path that loops back over earlier ground doesn't let the
@@ -86,6 +90,7 @@ void PathProgressGoalChecker::reset()
   std::lock_guard<std::mutex> lock(mutex_);
   max_reached_index_ = 0;
   empty_path_first_call_.reset();
+  progress_stalled_since_.reset();
 }
 
 void PathProgressGoalChecker::onPath(nav_msgs::msg::Path::SharedPtr msg)
@@ -127,6 +132,7 @@ void PathProgressGoalChecker::onPath(nav_msgs::msg::Path::SharedPtr msg)
     last_path_first_x_ = fx;
     last_path_first_y_ = fy;
     max_reached_index_ = 0;
+    progress_stalled_since_.reset();
     RCLCPP_INFO(logger_,
                 "PathProgressGoalChecker: new path with %zu poses, "
                 "start=(%.2f,%.2f), end=(%.2f,%.2f) — reset progress",
@@ -249,44 +255,77 @@ bool PathProgressGoalChecker::isGoalReached(
       best_idx = i;
     }
   }
+  // Track whether the monotonic index advanced this call. A real advance
+  // clears the stall timer; a call with no advance starts/continues it.
+  // This distinguishes healthy following (index climbs every few calls)
+  // from a stuck end loop (index pinned for seconds). Note: at typical
+  // chassis speeds the robot crosses < 1 pose per call, so most healthy
+  // calls don't advance — but the timer resets well within a second each
+  // time a pose IS crossed, so it never approaches fallback_timeout_s_.
   if (best_idx > max_reached_index_)
   {
     max_reached_index_ = best_idx;
+    progress_stalled_since_.reset();
+  }
+  else if (!progress_stalled_since_.has_value())
+  {
+    progress_stalled_since_ = clock_->now();
   }
 
   const double progress = static_cast<double>(max_reached_index_) /
                           static_cast<double>(n - 1);
-  if (progress < progress_threshold_)
-  {
-    return false;
-  }
 
-  // Path progress condition met — also require XY proximity to the
-  // goal pose and yaw within tolerance, matching SimpleGoalChecker's
-  // final-pose check (so FTC can still do POST_ROTATE precision work).
+  // Distance + yaw error to the goal pose — needed by both the normal
+  // completion check and the stuck-fallback diagnostic.
   const double dx = query_pose.position.x - goal_pose.position.x;
   const double dy = query_pose.position.y - goal_pose.position.y;
   const double xy_err = std::hypot(dx, dy);
-  if (xy_err > xy_goal_tolerance_)
-  {
-    return false;
-  }
-
   const double yaw_q = tf2::getYaw(query_pose.orientation);
   const double yaw_g = tf2::getYaw(goal_pose.orientation);
-  double yaw_err = std::atan2(std::sin(yaw_q - yaw_g),
-                              std::cos(yaw_q - yaw_g));
-  if (std::abs(yaw_err) > yaw_goal_tolerance_)
+  const double yaw_err = std::atan2(std::sin(yaw_q - yaw_g),
+                                    std::cos(yaw_q - yaw_g));
+
+  // Normal completion: enough of the path covered AND within final-pose
+  // xy + yaw tolerance (matches SimpleGoalChecker's final-pose check so
+  // FTC can still do POST_ROTATE precision work).
+  if (progress >= progress_threshold_ &&
+      xy_err <= xy_goal_tolerance_ &&
+      std::abs(yaw_err) <= yaw_goal_tolerance_)
   {
-    return false;
+    RCLCPP_INFO(logger_,
+                "PathProgressGoalChecker: goal reached — progress=%.1f%% "
+                "(idx %zu/%zu), xy_err=%.3fm, yaw_err=%.3frad",
+                progress * 100.0, max_reached_index_, n - 1,
+                xy_err, yaw_err);
+    return true;
   }
 
-  RCLCPP_INFO(logger_,
-              "PathProgressGoalChecker: goal reached — progress=%.1f%% "
-              "(idx %zu/%zu), xy_err=%.3fm, yaw_err=%.3frad",
-              progress * 100.0, max_reached_index_, n - 1,
-              xy_err, yaw_err);
-  return true;
+  // Stuck-at-end fallback: most of the path is covered but the index has
+  // not advanced for fallback_timeout_s_. The degenerate case is an F2C
+  // end loop tighter than xy_goal_tolerance_ whose goal point sits inside
+  // the loop — the chassis circles it forever and the xy gate never
+  // closes. Complete instead of spinning. Healthy following never reaches
+  // here (the index keeps advancing, clearing the timer).
+  if (progress >= stuck_completion_progress_ &&
+      progress_stalled_since_.has_value())
+  {
+    const double stalled =
+        (clock_->now() - *progress_stalled_since_).seconds();
+    if (stalled >= fallback_timeout_s_)
+    {
+      RCLCPP_WARN(logger_,
+                  "PathProgressGoalChecker: progress=%.1f%% (idx %zu/%zu) but "
+                  "index stalled %.1fs — completing despite xy_err=%.3fm "
+                  "yaw_err=%.3frad (degenerate path end / unreachable goal "
+                  "pose). Tune coverage min_turning_radius or "
+                  "stuck_completion_progress if unexpected.",
+                  progress * 100.0, max_reached_index_, n - 1, stalled,
+                  xy_err, yaw_err);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 bool PathProgressGoalChecker::getTolerances(


### PR DESCRIPTION
## Problem

`PathProgressGoalChecker` only has an **empty-path** fallback (for the DDS race before FTC's `global_plan` first arrives). Once a plan is present, the only completion path requires `progress >= progress_threshold` **AND** `xy <= xy_goal_tolerance` **AND** `yaw <= yaw_goal_tolerance`.

F2C can emit a **degenerate end loop tighter than `xy_goal_tolerance`** — a small area with a tight `min_turning_radius` produces a ~0.1 m turn loop at the path end whose goal point sits *inside* the loop. The chassis tracks that loop faithfully (cross-track error stays small) but can never get within `xy_goal_tolerance` of the goal point, so the action never completes and the robot **circles until the controller `goal_timeout`**.

Observed in the field on a 3.4 m test area (`min_turning_radius: 0.05`, `coverage_xy_tolerance: 0.1`): the robot circled a ~0.12 m-radius loop indefinitely, always >0.12 m from the goal, `cmd_wz` pinned near max, net displacement ~0 over 20 s.

## Fix

Add a **stuck-at-end fallback**: track when `max_reached_index_` last advanced and, if the robot has covered `>= stuck_completion_progress` (default **0.90**) of the path but the index has been pinned for `fallback_timeout_s`, declare the goal reached (with a WARN).

Healthy following never reaches this branch — the monotonic index keeps advancing and clears the timer. It only fires when the robot is genuinely stuck near the end.

- New param: `stuck_completion_progress` (default 0.90).
- Reuses the existing `fallback_timeout_s` (5.0) for the stall window.
- `progress_stalled_since_` reset on every real advance, on `reset()`, and on a new path.

## Notes

The underlying planner degeneracy (a `min_turning_radius` low enough to emit sub-tolerance end loops) is best avoided at the source, but the goal-checker should never spin forever on a path it was handed — this makes completion robust regardless of the planned end geometry.