### PR TITLE
fix(fusion_graph): review findings — odom twist.angular.z, preint persistence guards, async save service

### DIFF
--- a/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
@@ -102,6 +102,13 @@ void FusionGraphNode::PublishLocalOdom()
   odom.pose.pose.orientation = q_msg;
   odom.twist.twist.linear.x = wheel_vx_;
   odom.twist.twist.linear.y = 0.0;
+  // Bias-corrected gyro yaw rate — the SAME rate dead-reckoning integrates into
+  // dr_yaw_. Leaving this 0 made /odometry/filtered unusable as Nav2's
+  // controller_server.odom_topic (MPPI seeds rollouts / RPP scales lookahead
+  // from twist.angular.z — the documented "controllers had zero velocity
+  // feedback" gap that forced odom_topic onto raw /wheel_odom). Same executor
+  // thread as the dr_* writers, so no lock needed here.
+  odom.twist.twist.angular.z = dr_last_gz_;
   // Dead reckoning has unbounded drift — leave pose covariance loose
   // and let Nav2 trust the graph's /odometry/filtered_map for absolute
   // positioning. Tight roll/pitch/z so 2D consumers don't see NaN.
@@ -113,6 +120,10 @@ void FusionGraphNode::PublishLocalOdom()
   odom.pose.covariance[21] = 1e-9;  // roll
   odom.pose.covariance[28] = 1e-9;  // pitch
   odom.pose.covariance[35] = 0.02;  // yaw — gyro short-term σ ≈ 0.14 rad
+  for (auto& v : odom.twist.covariance)
+    v = 0.0;
+  odom.twist.covariance[0] = 0.02;  // vx — wheel-odom velocity noise
+  odom.twist.covariance[35] = 4e-4;  // wz — gyro rate noise (σ ≈ 0.02 rad/s)
   pub_local_odom_->publish(odom);
 }
 

--- a/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
@@ -207,13 +207,15 @@ void FusionGraphNode::SetupCommunications(double node_period_s)
       [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>,
              std::shared_ptr<std_srvs::srv::Trigger::Response> resp)
       {
-        const bool ok = graph_->Save(graph_save_prefix_);
-        resp->success = ok;
-        resp->message = ok ? "saved to " + graph_save_prefix_ + ".*" : "save failed";
-        if (ok)
-          RCLCPP_INFO(get_logger(), "fusion_graph: %s", resp->message.c_str());
-        else
-          RCLCPP_WARN(get_logger(), "fusion_graph: %s", resp->message.c_str());
+        // Dispatch on the async save worker, never inline: a direct Save()
+        // blocks this executor for the full file write (~500 ms on the robot's
+        // eMMC — the exact stall DispatchAsyncSave was built to avoid,
+        // 2026-05-14 incident), starving the timers that feed the TF fallback
+        // path and risking Nav2 ExtrapolationExceptions on every manual save.
+        DispatchAsyncSave("manual-service");
+        resp->success = true;
+        resp->message = "save dispatched to " + graph_save_prefix_ + ".* (async)";
+        RCLCPP_INFO(get_logger(), "fusion_graph: %s", resp->message.c_str());
       });
 
   // ── Clear-graph service ─────────────────────────────────────────

--- a/ros2/src/fusion_graph/src/graph_manager_persistence.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager_persistence.cpp
@@ -349,7 +349,15 @@ bool GraphManager::Load(const std::string& prefix)
   gtsam::Values kept_values;
   for (const auto& key_value : loaded_values)
   {
-    if (cutoff > 0 && gtsam::Symbol(key_value.key).index() < cutoff)
+    const gtsam::Symbol sym(key_value.key);
+    // Only pose keys ('x') are restored. A graph saved with use_imu_preint=true
+    // also serializes per-node gyro-bias variables (Symbol 'b', type double):
+    // casting those to Pose2 throws at boot, and re-inserting them with no
+    // factor referencing them leaves the update underconstrained. Bias is
+    // cheap to re-estimate live, so drop them on load.
+    if (sym.chr() != 'x')
+      continue;
+    if (cutoff > 0 && sym.index() < cutoff)
       continue;  // older than the window — drop (its info was already in priors)
     fg.add(gtsam::PriorFactor<gtsam::Pose2>(key_value.key,
                                             key_value.value.cast<gtsam::Pose2>(),

--- a/ros2/src/fusion_graph/src/graph_manager_rebase.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager_rebase.cpp
@@ -288,6 +288,13 @@ void GraphManager::RigidTransformAll(const gtsam::Pose2& correction,
   auto tight_noise = MakeDiagonal({std::max(latest_node_sigma_xy, 1.0e-4),
                                    std::max(latest_node_sigma_xy, 1.0e-4),
                                    std::max(latest_node_sigma_theta, 1.0e-4)});
+  // Rebuild from POSE keys only. `transformed` may also carry per-node
+  // gyro-bias variables ('b', double) when use_imu_preint is on; the loop below
+  // adds no factor for them, and handing iSAM2 new variables that no new factor
+  // references makes the update underconstrained (IndeterminantLinearSystem →
+  // ResetLocked wipes the graph). Bias is re-estimated live, so drop it here —
+  // mirroring what Load() does.
+  gtsam::Values pose_values;
   for (const auto& kv : transformed)
   {
     gtsam::Symbol s(kv.key);
@@ -295,8 +302,9 @@ void GraphManager::RigidTransformAll(const gtsam::Pose2& correction,
       continue;
     const auto noise = (kv.key == latest_key) ? tight_noise : loose_noise;
     fg.add(gtsam::PriorFactor<gtsam::Pose2>(kv.key, kv.value.cast<gtsam::Pose2>(), noise));
+    pose_values.insert(kv.key, kv.value);
   }
-  fresh.update(fg, transformed);
+  fresh.update(fg, pose_values);
   isam_ = std::move(fresh);
   estimate_dirty_ = true;
   // Loop-closure edges collapsed into priors during the rebuild.


### PR DESCRIPTION
Four verified fixes from a deep code review of \`fusion_graph\` (the sole map+odom localizer):

| Sev | Fix |
|-----|-----|
| High | **\`/odometry/filtered\` now carries \`twist.angular.z\`** (bias-corrected gyro rate) + twist covariance — the documented "controllers had zero velocity feedback" gap that forced \`controller_server.odom_topic\` onto raw \`/wheel_odom\`. The fused local odom is now a valid odom_topic candidate. |
| Critical (latent) | \`Load()\` cast **every** restored key to \`Pose2\` — a graph saved with \`use_imu_preint=true\` also serializes per-node gyro-bias doubles ('b' keys) → throw at boot. Now restores pose keys only (mirrors the existing rebase guard). |
| Critical (latent) | \`RigidTransformAll()\` passed bias variables with **no referencing factor** into the fresh iSAM2 → underconstrained update → \`IndeterminantLinearSystem\` → graph wipe. Now rebuilds from pose values only. |
| Medium | \`~/save_graph\` service did a **blocking inline \`Save()\`** (~500 ms on eMMC) on the executor — the exact stall class \`DispatchAsyncSave\` was built to avoid (2026-05-14 incident). Now dispatches async. |

Also reviewed and **verified as false positives** (no change): the meta-file timestamp \`setprecision(6)\` (safe — \`std::fixed\` sticky), the wrong-fix gate's \`last_gps_map_xy_\` update-on-rejection (deliberate anti-lockout), and the \`GnssLeverArmFactor\` analytic Jacobian (correct per GTSAM retract convention + pinned by test).

Built + tested: all fusion_graph functional tests pass (the only local failure is \`Perf.ScanMatcherSingle\`, a wall-clock benchmark that fails on an unoptimized local build and is untouched by these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)