### PR TITLE
fix(gui): review findings — service-call timeout, error bodies, origin check, msgpack test

### DIFF
--- a/gui/pkg/api/containers.go
+++ b/gui/pkg/api/containers.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 )
 
 func ContainersRoutes(r *gin.RouterGroup, provider types2.IDockerProvider) {
@@ -105,7 +106,21 @@ func ContainerLogsRoutes(group *gin.RouterGroup, provider types2.IDockerProvider
 	var upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
+		// Same exact-host Origin check as the main API upgrader
+		// (mowglinext.go): the API has no auth layer, so accepting any
+		// origin let a malicious page on the same network open this
+		// stream cross-site. Empty Origin (non-browser clients) allowed.
+		CheckOrigin: func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			u, err := url.Parse(origin)
+			if err != nil {
+				return false
+			}
+			return u.Host == r.Host
+		},
 	}
 
 	group.GET("/:containerId/logs", func(c *gin.Context) {

--- a/gui/pkg/api/mowglinext.go
+++ b/gui/pkg/api/mowglinext.go
@@ -311,7 +311,7 @@ func SubscriberRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 		case "recordingTrajectory":
 			def, err = subscribe(provider, c, conn, "recordingTrajectory", -1)
 		case "obstacles":
-			def, err = subscribe(provider, c, conn, "obstacles", -1)
+			def, err = subscribe(provider, c, conn, "obstacles", 200) // match topicSubscribeInterval (multiplex path)
 		case "cogHeading":
 			def, err = subscribe(provider, c, conn, "cogHeading", 200)
 		case "magYaw":
@@ -573,43 +573,64 @@ func subscribe(provider types.IRosProvider, c *gin.Context, conn *websocket.Conn
 func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 	group.POST("/call/:command", func(c *gin.Context) {
 		command := c.Param("command")
+		// Bound every ROS service call: foxglove's CallService waits on
+		// ctx.Done(), and ctx only cancels when the browser
+		// drops the HTTP connection — a hung ROS node (behavior_tree /
+		// hardware_bridge / fusion_graph down) would otherwise pin this
+		// handler goroutine and a pendingSvc slot indefinitely. Every other
+		// route in this file already wraps with WithTimeout; this one was the
+		// exception.
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
 		var err error
 		switch command {
 		case "high_level_control":
 			var CallReq mowgli.HighLevelControlReq
 			err = c.BindJSON(&CallReq)
 			if err != nil {
+				// Explicit JSON body: gin's BindJSON aborts with a bare 400, and
+				// the frontend's useMowerAction reads res.error from JSON.
+				c.JSON(400, ErrorResponse{Error: err.Error()})
 				return
 			}
-			err = provider.CallService(c.Request.Context(), "/behavior_tree_node/high_level_control", &CallReq, &mowgli.HighLevelControlRes{}, "mowgli_interfaces/srv/HighLevelControl")
+			err = provider.CallService(ctx, "/behavior_tree_node/high_level_control", &CallReq, &mowgli.HighLevelControlRes{}, "mowgli_interfaces/srv/HighLevelControl")
 		case "emergency":
 			var CallReq mowgli.EmergencyStopReq
 			err = c.BindJSON(&CallReq)
 			if err != nil {
+				// Explicit JSON body: gin's BindJSON aborts with a bare 400, and
+				// the frontend's useMowerAction reads res.error from JSON.
+				c.JSON(400, ErrorResponse{Error: err.Error()})
 				return
 			}
-			err = provider.CallService(c.Request.Context(), "/hardware_bridge/emergency_stop", &CallReq, &mowgli.EmergencyStopRes{}, "mowgli_interfaces/srv/EmergencyStop")
+			err = provider.CallService(ctx, "/hardware_bridge/emergency_stop", &CallReq, &mowgli.EmergencyStopRes{}, "mowgli_interfaces/srv/EmergencyStop")
 		case "mow_enabled":
 			var CallReq mowgli.MowerControlReq
 			err = c.BindJSON(&CallReq)
 			if err != nil {
+				// Explicit JSON body: gin's BindJSON aborts with a bare 400, and
+				// the frontend's useMowerAction reads res.error from JSON.
+				c.JSON(400, ErrorResponse{Error: err.Error()})
 				return
 			}
-			err = provider.CallService(c.Request.Context(), "/hardware_bridge/mower_control", &CallReq, &mowgli.MowerControlRes{}, "mowgli_interfaces/srv/MowerControl")
+			err = provider.CallService(ctx, "/hardware_bridge/mower_control", &CallReq, &mowgli.MowerControlRes{}, "mowgli_interfaces/srv/MowerControl")
 		case "start_in_area":
 			var CallReq mowgli.StartInAreaReq
 			err = c.BindJSON(&CallReq)
 			if err != nil {
+				// Explicit JSON body: gin's BindJSON aborts with a bare 400, and
+				// the frontend's useMowerAction reads res.error from JSON.
+				c.JSON(400, ErrorResponse{Error: err.Error()})
 				return
 			}
-			err = provider.CallService(c.Request.Context(), "/behavior_tree_node/start_in_area", &CallReq, &mowgli.StartInAreaRes{}, "mowgli_interfaces/srv/StartInArea")
+			err = provider.CallService(ctx, "/behavior_tree_node/start_in_area", &CallReq, &mowgli.StartInAreaRes{}, "mowgli_interfaces/srv/StartInArea")
 		case "set_datum":
 			type TriggerRes struct {
 				Success bool   `json:"success"`
 				Message string `json:"message"`
 			}
 			var res TriggerRes
-			err = provider.CallService(c.Request.Context(), "/navsat_to_absolute_pose/set_datum", &struct{}{}, &res, "std_srvs/srv/Trigger")
+			err = provider.CallService(ctx, "/navsat_to_absolute_pose/set_datum", &struct{}{}, &res, "std_srvs/srv/Trigger")
 			if err == nil && !res.Success {
 				err = errors.New(res.Message)
 			}
@@ -626,10 +647,13 @@ func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 			var CallReq mowgli.PromoteObstacleReq
 			err = c.BindJSON(&CallReq)
 			if err != nil {
+				// Explicit JSON body: gin's BindJSON aborts with a bare 400, and
+				// the frontend's useMowerAction reads res.error from JSON.
+				c.JSON(400, ErrorResponse{Error: err.Error()})
 				return
 			}
 			var promoteRes mowgli.PromoteObstacleRes
-			err = provider.CallService(c.Request.Context(),
+			err = provider.CallService(ctx,
 				"/map_server_node/promote_obstacle",
 				&CallReq,
 				&promoteRes,
@@ -652,7 +676,7 @@ func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 				service = "/fusion_graph_node/clear_graph"
 			}
 			var res TriggerRes
-			err = provider.CallService(c.Request.Context(), service, &struct{}{}, &res, "std_srvs/srv/Trigger")
+			err = provider.CallService(ctx, service, &struct{}{}, &res, "std_srvs/srv/Trigger")
 			if err == nil && !res.Success {
 				err = errors.New(res.Message)
 			}
@@ -670,7 +694,7 @@ func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 				Message string `json:"message"`
 			}
 			var res TriggerRes
-			err = provider.CallService(c.Request.Context(), "/behavior_tree_node/clear_coverage_resume", &struct{}{}, &res, "std_srvs/srv/Trigger")
+			err = provider.CallService(ctx, "/behavior_tree_node/clear_coverage_resume", &struct{}{}, &res, "std_srvs/srv/Trigger")
 			if err == nil && !res.Success {
 				err = errors.New(res.Message)
 			}
@@ -686,7 +710,7 @@ func ServiceRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 				Message string `json:"message"`
 			}
 			var res TriggerRes
-			err = provider.CallService(c.Request.Context(), "/hardware_bridge/reboot_board", &struct{}{}, &res, "std_srvs/srv/Trigger")
+			err = provider.CallService(ctx, "/hardware_bridge/reboot_board", &struct{}{}, &res, "std_srvs/srv/Trigger")
 			if err == nil && !res.Success {
 				err = errors.New(res.Message)
 			}

--- a/gui/pkg/api/mowglinext_test.go
+++ b/gui/pkg/api/mowglinext_test.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
+
+	"github.com/vmihailenco/msgpack/v5"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -191,14 +192,18 @@ func readMultiplexFrame(t *testing.T, conn *websocket.Conn) (string, []byte) {
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	_, raw, err := conn.ReadMessage()
 	require.NoError(t, err)
+	// Since the #337 binary transport, frames are msgpack-encoded
+	// {topic, data:<decoded object>} sent as BINARY websocket messages
+	// (was JSON {topic, data:<base64>}). Re-encode the decoded object as
+	// JSON so the assertions can keep comparing JSON payloads.
 	var frame struct {
-		Topic string `json:"topic"`
-		Data  string `json:"data"`
+		Topic string      `msgpack:"topic"`
+		Data  interface{} `msgpack:"data"`
 	}
-	require.NoError(t, json.Unmarshal(raw, &frame))
-	decoded, err := base64.StdEncoding.DecodeString(frame.Data)
+	require.NoError(t, msgpack.Unmarshal(raw, &frame))
+	payload, err := json.Marshal(frame.Data)
 	require.NoError(t, err)
-	return frame.Topic, decoded
+	return frame.Topic, payload
 }
 
 func TestMultiplexRoute_FansOutOnSubscribe(t *testing.T) {


### PR DESCRIPTION
Verified findings from a deep GUI code review (Go backend + transport):

| Sev | Fix |
|-----|-----|
| High | **ServiceRoute had no timeout**: `CallService` waits on `ctx.Done()` and the raw request context only cancels on browser disconnect — a hung ROS node pinned the handler goroutine + a `pendingSvc` slot indefinitely (the `callServiceTimeout` constant existed but was never used). All calls now run under a 10 s context, like every other route. |
| Medium | `BindJSON` failures returned a bare 400 with no body; the frontend reads `res.error` from JSON, so malformed requests surfaced as an opaque parse crash. Explicit `ErrorResponse` bodies added (×5). |
| Medium | `SubscriberRoute` `obstacles` was unthrottled (`-1`) while the multiplex path throttles at 200 ms — aligned. |
| Low (security) | `containers.go` log-stream upgrader accepted **any** Origin (`return true`) — cross-site WebSocket hijacking surface on an unauthenticated API. Now uses the same exact-host check as the main upgrader. |
| Test debt | `TestMultiplexRoute_FansOutOnSubscribe` was broken since #337 (still parsed the old JSON+base64 envelope instead of the msgpack binary frame). Fixed — `go test ./...` is fully green again. |

Also review-verified with **no change needed**: the foxglove client needs no `SetReadLimit` (gorilla v1.5.3 default is unlimited — enforcement is `if readLimit > 0`), so large `/coverage/full_plan` CDR frames are not dropped at that layer.

`go build ./...`, `go vet ./...`, `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)