### PR TITLE
fix(gui): scale map-save timeout with area count (#341)

### DIFF
--- a/gui/pkg/api/mowglinext.go
+++ b/gui/pkg/api/mowglinext.go
@@ -144,6 +144,23 @@ func ClearMapRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 	})
 }
 
+// mapWriteBudget returns the context timeout for a clear_map → add_area×N →
+// save_areas sequence. clear_map + save_areas are fixed-cost, but each add_area
+// RASTERISES its polygon into the map_server grid, which on a large area takes
+// seconds — and on a slow SBC (RPi4) a multi-area map easily blows a fixed
+// budget, leaving the map half-written (issue #341: "can't save a big map,
+// ~30 s timeout"). Scale it: a 60 s base plus per-area headroom, capped at
+// 6 min. Map writes are rare and operator-driven, so a generous ceiling beats a
+// false timeout. Shared by ReplaceMapRoute (map editor "Save Map") and the
+// OpenMower importer so the two never drift.
+func mapWriteBudget(nAreas int) time.Duration {
+	budget := 60*time.Second + time.Duration(nAreas)*5*time.Second
+	if budget > 6*time.Minute {
+		budget = 6 * time.Minute
+	}
+	return budget
+}
+
 // replaceMapInternal is the ROS-side flow shared by the public PUT
 // handler and the OpenMower importer. It does clear_map → add_area×N →
 // save_areas; the wrapping (HTTP body decode / response codes) is the
@@ -192,14 +209,17 @@ func replaceMapInternal(ctx context.Context, provider types.IRosProvider, req *m
 // @Router /mowglinext/map [put]
 func ReplaceMapRoute(group *gin.RouterGroup, provider types.IRosProvider) {
 	group.PUT("/map", func(c *gin.Context) {
-		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
-		defer cancel()
-
+		// Decode BEFORE choosing the timeout so the budget can scale with the
+		// area count (each add_area rasterises — a fixed 30 s timed out saving a
+		// big edited map on RPi4, issue #341).
 		var CallReq mowgli.ReplaceMapReq
 		if err := unmarshalROSMessage[*mowgli.ReplaceMapReq](c.Request.Body, &CallReq); err != nil {
 			c.JSON(500, ErrorResponse{Error: err.Error()})
 			return
 		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), mapWriteBudget(len(CallReq.Areas)))
+		defer cancel()
+
 		if err := replaceMapInternal(ctx, provider, &CallReq); err != nil {
 			c.JSON(500, ErrorResponse{Error: err.Error()})
 			return

--- a/gui/pkg/api/mowglinext_test.go
+++ b/gui/pkg/api/mowglinext_test.go
@@ -273,3 +273,15 @@ func TestMultiplexRoute_DropsSubscriptionsOnDisconnect(t *testing.T) {
 	// Dispatch after the client is gone should be a no-op (no panic).
 	mock.Dispatch("imu", []byte(`{"a":1}`))
 }
+
+func TestMapWriteBudget(t *testing.T) {
+	// Base budget for a small/empty map (regression: a fixed 30 s used to time
+	// out saving a big edited map on RPi4 — issue #341).
+	assert.Equal(t, 60*time.Second, mapWriteBudget(0))
+	// Scales +5 s per area.
+	assert.Equal(t, 60*time.Second+10*5*time.Second, mapWriteBudget(10))
+	// Capped at 6 min so a pathological area count can't set an absurd budget.
+	assert.Equal(t, 6*time.Minute, mapWriteBudget(1000))
+	// The old fixed 30 s is always exceeded now, even for zero areas.
+	assert.Greater(t, mapWriteBudget(0), 30*time.Second)
+}

--- a/gui/pkg/api/openmower_import.go
+++ b/gui/pkg/api/openmower_import.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/cedbossneo/mowglinext/pkg/msgs/geometry"
 	"github.com/cedbossneo/mowglinext/pkg/msgs/mowgli"
@@ -814,17 +813,10 @@ func applyImport(c *gin.Context, rosProvider types.IRosProvider, replaceReq *mow
 		return errors.New("apply: nil replace request")
 	}
 	// Reuse the gin request context for cancellation propagation, but give the
-	// whole sequence its own budget. clear_map + save_areas are fixed-cost, but
-	// each add_area rasterises its polygon into the map_server grid, which on a
-	// large area can take seconds. A fixed 30 s timed out on huge multi-area
-	// maps, so scale the budget: a 60 s base plus per-area headroom, capped at
-	// 6 min (imports are rare and one-shot — a generous ceiling beats a false
-	// timeout that leaves the map half-written).
-	budget := 60*time.Second + time.Duration(len(replaceReq.Areas))*5*time.Second
-	if budget > 6*time.Minute {
-		budget = 6 * time.Minute
-	}
-	ctx, cancel := context.WithTimeout(c.Request.Context(), budget)
+	// whole clear_map → add_area×N → save_areas sequence a size-scaled budget
+	// (each add_area rasterises — a fixed timeout leaves a huge map half-written).
+	// Shared with ReplaceMapRoute so the import and the map editor stay in sync.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), mapWriteBudget(len(replaceReq.Areas)))
 	defer cancel()
 
 	logImportf("import/openmower applying: %d areas, dock=%v", len(replaceReq.Areas), dockReq != nil)


### PR DESCRIPTION
Fixes #341 — "Timeout in editing map mode" (can't save a big edited map on RPi4, ~30 s timeout).

The map editor's **Save Map** (`PUT /map` → `replaceMapInternal`) ran the `clear_map → add_area×N → save_areas` sequence under a **fixed 30 s** context. Each `add_area` rasterises its polygon into the `map_server` grid (seconds per large area on an RPi4), so a big / multi-area map blew the budget and left the map half-written.

This is the **same bug class already fixed for the OpenMower import in #331**. This PR:
- extracts the size-scaled budget into a shared `mapWriteBudget(nAreas)` helper (**60 s base + 5 s/area, capped at 6 min**),
- uses it in **both** `ReplaceMapRoute` (the map editor) and the OpenMower importer, so they can't drift again,
- reorders `ReplaceMapRoute` to decode the body before picking the timeout (needs the area count).

Note: the frontend has no client-side request timeout (its `AbortController` is only wired to explicit cancel tokens), so the backend budget is the effective bound.

`go build`/`vet`/`test ./...` green; `+TestMapWriteBudget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)