### PR TITLE
fix(coverage): smooth headland ring closures/junctions — no more per-ring FTC stall

### DIFF
--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
@@ -132,7 +132,8 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
                                     double chassis_safety_inset,
                                     double mow_angle_rad,
                                     double min_swath_length,
-                                    int ring_direction = 0);
+                                    int ring_direction = 0,
+                                    double min_turn_radius = 0.15);
 
 // Flatten a BoustrophedonPlan into ONE continuous, cusp-free, in-bounds
 // polyline so an MPPI-class sampling controller can track it without the

--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -623,6 +623,64 @@ std::vector<std::pair<double, double>> roundSharpCorners(
   return out;
 }
 
+// Collapse the collinear runs of a densified polyline back to its sparse
+// vertices (endpoints always kept). On a headland ring — straight polygon edges
+// densified at kDensifyStep — this recovers the original polygon, giving
+// roundSharpCorners the TRUE edge lengths. Feeding it the densified polyline
+// instead silently disabled every ring fillet: the trim budget (0.49 × in_len)
+// with in_len = one 0.10 m densify step caps the fillet radius at ~0.03 m,
+// below the min_turning_radius floor, so every corner was "left sharp".
+std::vector<std::pair<double, double>> sparsifyCollinear(
+    const std::vector<std::pair<double, double>>& pts, double angle_eps_rad)
+{
+  if (pts.size() < 3)
+  {
+    return pts;
+  }
+  std::vector<std::pair<double, double>> out;
+  out.reserve(64);
+  out.push_back(pts.front());
+  for (std::size_t i = 1; i + 1 < pts.size(); ++i)
+  {
+    const double ax = pts[i].first - out.back().first;
+    const double ay = pts[i].second - out.back().second;
+    const double bx = pts[i + 1].first - pts[i].first;
+    const double by = pts[i + 1].second - pts[i].second;
+    const double na = std::hypot(ax, ay), nb = std::hypot(bx, by);
+    if (na < 1e-9 || nb < 1e-9)
+    {
+      continue;
+    }
+    double c = (ax * bx + ay * by) / (na * nb);
+    c = std::max(-1.0, std::min(1.0, c));
+    if (std::acos(c) > angle_eps_rad)
+    {
+      out.push_back(pts[i]);  // a real vertex — the heading changes here
+    }
+  }
+  out.push_back(pts.back());
+  return out;
+}
+
+// Densify the straight gaps of `pts` so consecutive points sit at most `step`
+// apart (fillet arc samples are already dense and pass through unchanged).
+std::vector<std::pair<double, double>> densifyPolyline(
+    const std::vector<std::pair<double, double>>& pts, double step)
+{
+  std::vector<std::pair<double, double>> out;
+  if (pts.empty())
+  {
+    return out;
+  }
+  out.reserve(pts.size() * 4);
+  for (std::size_t i = 0; i + 1 < pts.size(); ++i)
+  {
+    densifySegmentStep(pts[i].first, pts[i].second, pts[i + 1].first, pts[i + 1].second, step, out);
+  }
+  out.push_back(pts.back());
+  return out;
+}
+
 }  // namespace
 
 BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
@@ -632,12 +690,27 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
                                     double chassis_safety_inset,
                                     double mow_angle_rad,
                                     double min_swath_length,
-                                    int ring_direction)
+                                    int ring_direction,
+                                    double min_turn_radius)
 {
   BoustrophedonPlan plan;
   // Polygon area the planned-coverage fraction is taken over (the operator's
   // authorised area, before any inset). Instrumentation only.
   plan.diagnostics.field_area = field_cell.area();
+
+  // Raw operator boundary as (x, y) pairs — the ring-corner fillet's in-bounds
+  // fallback when no chassis-safety inset was applied (plan.safe_boundary empty).
+  std::vector<std::pair<double, double>> field_outer_pts;
+  if (field_cell.size() > 0)
+  {
+    const auto outer_ring = field_cell.getGeometry(0);
+    field_outer_pts.reserve(outer_ring.size());
+    for (std::size_t i = 0; i < outer_ring.size(); ++i)
+    {
+      const auto p = outer_ring.getGeometry(i);
+      field_outer_pts.emplace_back(p.getX(), p.getY());
+    }
+  }
 
   f2c::hg::ConstHL hl;
   f2c::types::Cells cells;
@@ -753,6 +826,76 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
           std::reverse(loop.begin(), loop.end());
         }
       }
+
+      // Ring corner smoothing (field report 2026-07: "the robot stalls after
+      // every headland ring, oscillating, before moving on"). Two fixes here:
+      //
+      // 1. START THE LOOP MID-LONGEST-EDGE. F2C closes every concentric ring at
+      //    the same polygon corner, so the loop closure sat ON a corner: the
+      //    closure vertex is the one corner roundSharpCorners can never fillet
+      //    (it only processes interior vertices), and the ring→ring junction
+      //    then demanded the full corner turn across a ~op_width gap (measured
+      //    112° on the field replica) — a near-cusp FTC fights the drivetrain
+      //    deadband through. Rotating the closure onto the middle of the
+      //    longest straight edge makes the closure a straight-line point and
+      //    stacks the junctions of consecutive rings on parallel edges (a
+      //    tangent ~op_width sideways shift).
+      //
+      // 2. FILLET AT SPARSE (true-edge-length) LEVEL. roundSharpCorners' trim
+      //    budget is 0.49 × the incoming edge length; fed the DENSIFIED loop,
+      //    in_len is one 0.10 m densify step, capping the fillet radius at
+      //    ~0.03 m — below the min_turn_radius floor — so every ring-corner
+      //    fillet silently failed and all polygon corners stayed sharp.
+      //    Collapse the collinear runs first, fillet on real edges, then
+      //    re-densify.
+      {
+        auto sparse = sparsifyCollinear(loop, 0.01 /* rad — straight-run merge */);
+        if (sparse.size() >= 5)
+        {
+          sparse.pop_back();  // open the closed loop for rotation
+          std::size_t le = 0;
+          double le_len = -1.0;
+          for (std::size_t j = 0; j < sparse.size(); ++j)
+          {
+            const auto& a = sparse[j];
+            const auto& b = sparse[(j + 1) % sparse.size()];
+            const double len = std::hypot(b.first - a.first, b.second - a.second);
+            if (len > le_len)
+            {
+              le_len = len;
+              le = j;
+            }
+          }
+          // New start = the longest edge's midpoint. Rotate so the loop begins
+          // at the vertex AFTER the edge (v_{le+1}) and stitch the midpoint on
+          // both ends: mid → v_{le+1} → … → v_le → mid. (Rotating to v_le
+          // instead would make the path step BACKWARD from mid to v_le — a
+          // 180° reversal baked into the ring.)
+          const std::pair<double, double> mid{
+              (sparse[le].first + sparse[(le + 1) % sparse.size()].first) * 0.5,
+              (sparse[le].second + sparse[(le + 1) % sparse.size()].second) * 0.5};
+          std::rotate(sparse.begin(),
+                      sparse.begin() + static_cast<std::ptrdiff_t>((le + 1) % sparse.size()),
+                      sparse.end());
+          sparse.insert(sparse.begin(), mid);
+          sparse.push_back(mid);
+          // Fillet every corner sharper than ~30° with a forward arc (floored at
+          // min_turn_radius so MPPI/FTC can track it); corners that cannot be
+          // rounded in-bounds are left sharp, as before.
+          const auto& fillet_boundary =
+              plan.safe_boundary.size() >= 3 ? plan.safe_boundary : field_outer_pts;
+          constexpr double kRingCornerThreshold = 30.0 * M_PI / 180.0;
+          auto rounded = roundSharpCorners(sparse,
+                                           fillet_boundary,
+                                           plan.safe_holes,
+                                           kRingCornerThreshold,
+                                           std::max(2.0 * min_turn_radius, min_turn_radius),
+                                           std::max(0.02, min_turn_radius),
+                                           0.03);
+          loop = densifyPolyline(rounded, kDensifyStep);
+        }
+      }
+
       ring_strip_area += perim * op_width;
       plan.rings.push_back(std::move(loop));
     }
@@ -866,13 +1009,81 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
 {
   // Flatten the plan into ordered drivable segments (densified polylines),
   // rings first (outermost → inner) then the swaths.
+  //
+  // Ring start alignment (field report 2026-07: "the robot stalls after every
+  // headland ring, oscillating, before moving on"). F2C starts every concentric
+  // ring at the same polygon corner, so the loop CLOSURE sits on that corner and
+  // the ring→ring junction demanded a 45–90° heading change across a ~op_width
+  // gap — no trackable Dubins fits, the join degenerates to a near-cusp, and FTC
+  // fights the drivetrain deadband pivoting through it (the observed stall +
+  // wz oscillation). Rotate each ring loop (they are CLOSED polylines, any
+  // vertex is a valid start) so it begins at the vertex nearest the previous
+  // ring's end: concentric rings are locally parallel there, so the junction
+  // becomes a gentle ~op_width sideways shift the connector joins tangentially.
+  // The first ring keeps F2C's start (TransitToStrip already targets it).
   std::vector<std::vector<std::pair<double, double>>> segs;
-  for (const auto& loop : plan.rings)
+  for (const auto& loop_in : plan.rings)
   {
-    if (loop.size() >= 2)
+    if (loop_in.size() < 2)
     {
-      segs.push_back(loop);
+      continue;
     }
+    std::vector<std::pair<double, double>> loop = loop_in;
+    if (!segs.empty() && loop.size() >= 4)
+    {
+      const auto& prev = segs.back();
+      const auto& prev_end = prev.back();
+      // Exit heading of the previous ring (its last step direction).
+      const double ex = prev_end.first - prev[prev.size() - 2].first;
+      const double ey = prev_end.second - prev[prev.size() - 2].second;
+      const double en = std::hypot(ex, ey);
+      // Drop the duplicated closure vertex, rotate, then re-close.
+      loop.pop_back();
+      // Nearest vertex ALONE is not enough: F2C closes every concentric ring at
+      // the same polygon corner, so the nearest vertex IS that corner and the
+      // junction still demanded the full corner turn (measured 112° — the stall).
+      // Require the candidate's OUTGOING heading to align with the previous
+      // ring's exit heading (within 45°): concentric rings have a parallel edge
+      // there, so the join becomes a tangent ~op_width sideways shift. Fall back
+      // to plain nearest if nothing aligns (degenerate tiny ring).
+      const double kAlignCos = 0.7071;  // cos(45°)
+      std::size_t best = 0;
+      double best_d2 = std::numeric_limits<double>::max();
+      bool found_aligned = false;
+      for (int pass = 0; pass < 2 && !found_aligned; ++pass)
+      {
+        for (std::size_t j = 0; j < loop.size(); ++j)
+        {
+          if (pass == 0 && en > 1e-9)
+          {
+            const auto& nxt = loop[(j + 1) % loop.size()];
+            const double ox = nxt.first - loop[j].first;
+            const double oy = nxt.second - loop[j].second;
+            const double on = std::hypot(ox, oy);
+            if (on < 1e-9 || (ex * ox + ey * oy) / (en * on) < kAlignCos)
+            {
+              continue;  // outgoing heading not parallel to the previous exit
+            }
+          }
+          const double dx = loop[j].first - prev_end.first;
+          const double dy = loop[j].second - prev_end.second;
+          const double d2 = dx * dx + dy * dy;
+          if (d2 < best_d2)
+          {
+            best_d2 = d2;
+            best = j;
+            found_aligned = (pass == 0);
+          }
+        }
+        if (pass == 0 && !found_aligned)
+        {
+          best_d2 = std::numeric_limits<double>::max();  // retry unfiltered
+        }
+      }
+      std::rotate(loop.begin(), loop.begin() + static_cast<std::ptrdiff_t>(best), loop.end());
+      loop.push_back(loop.front());
+    }
+    segs.push_back(std::move(loop));
   }
 
   // Nearest-endpoint chaining of the swath pieces. BoustrophedonOrder's
@@ -890,12 +1101,18 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
   {
     const auto& sw_in = plan.swaths;
     std::vector<bool> used(sw_in.size(), false);
-    // Seed from where the robot will actually be: the innermost ring's end, or
-    // the first swath's start when the plan has no rings.
+    // Seed from BoustrophedonOrder's OWN first swath, NOT from the last ring's
+    // end. Seeding from the ring end couples the serpentine direction to where
+    // the ring closure happens to sit (the mid-longest-edge rotation above moved
+    // it), and a flipped serpentine relocates every U-turn to the opposite swath
+    // ends — where the turn-around teardrop may no longer fit inside the safety
+    // inset (measured on the recorded garden: 7 extra cusp-splits from bottom-
+    // edge U-turns that no longer had headland room). BoustrophedonOrder's own
+    // start reproduces the field-proven serpentine regardless of ring layout;
+    // the ring→first-swath hop is then joined blade-on when short or bridged by
+    // one Nav2 transit when long.
     std::pair<double, double> cur =
-        !segs.empty()
-            ? segs.back().back()
-            : (!sw_in.empty() ? sw_in.front().first : std::pair<double, double>{0.0, 0.0});
+        !sw_in.empty() ? sw_in.front().first : std::pair<double, double>{0.0, 0.0};
     ordered_swaths.reserve(sw_in.size());
     for (std::size_t n = 0; n < sw_in.size(); ++n)
     {

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -383,6 +383,11 @@ void CoverageServer::planCoverage()
 
     f2c::types::Cell cell = buildCellFromGoal(*goal);
 
+    // Robot's minimum trackable turning radius — floors both the ring-corner
+    // fillets inside the planner and the turn-around connectors below. Read
+    // live so it stays field-tunable per plan.
+    const double min_turning_radius = get_parameter("min_turning_radius").as_double();
+
     BoustrophedonPlan plan = planBoustrophedon(cell,
                                                operation_width_,
                                                default_headland_width_,
@@ -390,7 +395,8 @@ void CoverageServer::planCoverage()
                                                effective_inset,
                                                mow_angle_rad,
                                                min_swath_length,
-                                               ring_direction);
+                                               ring_direction,
+                                               min_turning_radius);
 
     // Instrumentation (no behaviour change): surface every piece the planner
     // dropped (slivers, tiny rings, micro-cells) and the planned-coverage
@@ -484,9 +490,6 @@ void CoverageServer::planCoverage()
         plan.safe_boundary.size() >= 3 ? plan.safe_boundary : outer;
     constexpr double kConnectorTurnRadius = 0.30;  // nominal turn-around arc radius (m)
     constexpr double kConnectorStep = 0.03;  // connector densify step (m)
-    // Floor on every turn-around / fillet arc — never plan a loop tighter than
-    // the robot can track (read live so it's field-tunable per plan).
-    const double min_turning_radius = get_parameter("min_turning_radius").as_double();
     // Build the plan as one or more HOLE-FREE continuous sub-paths. A single
     // forward turn-around connector can't route around a large interior hole, so
     // the path breaks where it would otherwise cross one; the BT drives each

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -532,6 +532,44 @@ TEST(CoverageContinuousPath, NotchFieldLobeChainedNoMidFieldJoins)
   }
   // No blade-on pose out of bounds (the straight-through-the-bite fallback).
   EXPECT_EQ(oob, 0u) << oob << " blade-on poses outside the safety inset";
+  // Field report 2026-07 ("robot stalls after every headland ring"): F2C closed
+  // every ring on the same polygon corner, so the ring CLOSURE vertex and the
+  // ring→ring junctions carried ~112° near-cusps FTC fought the drivetrain
+  // deadband through. Pin the fixed geometry directly on plan.rings: every
+  // closure must sit on a straight (mid-longest-edge rotation) and every
+  // ring→ring junction must be a near-parallel sideways shift.
+  auto stepHeading = [](const std::pair<double, double>& a, const std::pair<double, double>& b)
+  {
+    return std::atan2(b.second - a.second, b.first - a.first);
+  };
+  auto turnDeg = [](double h_in, double h_out)
+  {
+    double d = h_out - h_in;
+    while (d > M_PI)
+      d -= 2.0 * M_PI;
+    while (d < -M_PI)
+      d += 2.0 * M_PI;
+    return std::fabs(d) * 180.0 / M_PI;
+  };
+  for (std::size_t i = 0; i < plan.rings.size(); ++i)
+  {
+    const auto& L = plan.rings[i];
+    ASSERT_GE(L.size(), 4u);
+    // Closure smoothness: heading into the closure vs heading out of the start.
+    const double closure_turn =
+        turnDeg(stepHeading(L[L.size() - 2], L[L.size() - 1]), stepHeading(L[0], L[1]));
+    EXPECT_LT(closure_turn, 30.0) << "ring " << i << " closes with a " << closure_turn
+                                  << "° corner — closure not on a straight edge";
+    if (i + 1 < plan.rings.size())
+    {
+      const auto& N = plan.rings[i + 1];
+      const double junction_turn =
+          turnDeg(stepHeading(L[L.size() - 2], L[L.size() - 1]), stepHeading(N[0], N[1]));
+      EXPECT_LT(junction_turn, 30.0)
+          << "ring " << i << "→" << i + 1 << " junction turns " << junction_turn
+          << "° — rings no longer chain on parallel edges (the FTC stall geometry)";
+    }
+  }
   // Turn-around teardrops are ~1.5 m of connector; the old mid-field diagonals
   // were 10–25 m. Anything beyond 3.5 m is a relocation being mowed.
   EXPECT_LT(worst_conn_run, 3.5)


### PR DESCRIPTION
Field report: **after every headland ring the robot stalls (oscillating) before moving on**.

## Root cause (measured on a replica of the reported field)
1. F2C closes **every concentric ring at the same polygon corner** → the closure vertex sits ON a corner and the ring→ring junction demands a 45–90° heading change across a ~op_width gap → no trackable Dubins fits → a **~112° near-cusp** that FTC fights the drivetrain deadband through, once per ring = the observed stall + wz oscillation.
2. Those corners could **never** be filleted: `roundSharpCorners`' trim budget (0.49 × incoming edge) fed the **densified** loop (0.10 m steps) caps the fillet radius at ~0.03 m — below the `min_turning_radius` floor — so every ring-corner fillet has silently failed since the pass was introduced.

## Fix (planner-level, in `planBoustrophedon`)
- **Close each ring on the midpoint of its longest edge** (any vertex of a closed loop is a valid start) → closures on straights, consecutive rings chain on parallel edges → junction = tangent ~op_width sideways shift.
- **Fillet at sparse level**: collapse collinear densified runs, fillet with true edge lengths (floored at the robot's `min_turning_radius`, now threaded from the server's live param), re-densify.
- **Decouple the swath serpentine seed** from the ring layout (seed = BoustrophedonOrder's own first swath) — the rotation had flipped the serpentine and relocated U-turns to ends without teardrop room (7 extra cusp-splits on the recorded garden).

## Measurements
| | avant | après |
|---|---|---|
| Pire virage conduit (champ encoche) | 112,5° | **63,4°** |
| Virages > 100° | 2 | **0** |
| Rings | ruptures/cusps par ring | **un seul sous-chemin continu** |
| Jardin réel (sous-chemins) | 10 (régression intermédiaire) / 3 (dev) | **2** |

New assertions pin closure + junction turns < 30° on `plan.rings`. 33/33 tests green.

Note: the user's *other* stall (logs showing a 35 s+ pivot loop during a Nav2 transit with 1 Hz replans and `Failed to make progress`) is a separate issue — that's the transit-pivot oscillation PR #305 targets; analysis to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)