### PR TITLE
fix(map_server): boundary slack band is high-cost, not free — kills phantom corridors between areas

### DIFF
--- a/ros2/src/mowgli_map/src/costmap_filters.cpp
+++ b/ros2/src/mowgli_map/src/costmap_filters.cpp
@@ -30,6 +30,13 @@
 namespace mowgli_map
 {
 
+// OccupancyGrid value for the outside boundary-slack band. KeepoutFilter maps
+// mask values to cost as round(v × 254 / 100): 90 → ~229 — steep enough that
+// Smac never routes through the band when ANY legal route (navigation area)
+// exists, non-lethal so RTK drift a few cm outside the boundary does not read
+// as "in collision" and a last-resort crossing remains plannable.
+constexpr int8_t kBoundarySlackCost = 90;
+
 void MapServerNode::publish_keepout_mask()
 {
   if (areas_.empty())
@@ -143,9 +150,24 @@ void MapServerNode::publish_keepout_mask()
       bool inner_buffer = inside_any && boundary_inner_margin_m_ > 0.0 &&
                           inside_min_edge_dist < boundary_inner_margin_m_;
 
-      if ((inside_any || within_outside_margin) && !inner_buffer)
+      if (inside_any && !inner_buffer)
       {
         mask.data[flat_idx] = 0;
+      }
+      else if (within_outside_margin && !inner_buffer)
+      {
+        // The outside slack band exists so RTK drift at the boundary does not
+        // self-reject (the robot sitting a few cm outside must not be "in
+        // collision"). But leaving it FREE (0) created PHANTOM CORRIDORS: two
+        // areas whose edges run within 2×margin of each other exposed a free
+        // strip between them, and the planner shortcut THROUGH it instead of
+        // routing via the operator's navigation areas (field report 2026-07:
+        // "il passe direct d'une zone à une autre… 50 cm de chaque côté
+        // d'autorisé"). Make the band HIGH-COST instead: non-lethal (drift
+        // tolerated, a last-resort crossing still plans if NO legal route
+        // exists) but expensive enough that Smac always prefers any
+        // navigation-area route.
+        mask.data[flat_idx] = kBoundarySlackCost;
       }
     }
   }

--- a/ros2/src/mowgli_map/test/test_map_server.cpp
+++ b/ros2/src/mowgli_map/test/test_map_server.cpp
@@ -365,7 +365,10 @@ TEST_F(AreaTypeTest, NavigationAreaSurvivesSaveLoadRoundTrip)
 // rectangle from (-3,-2) to (3,2). With the default lethal_outside_areas=true
 // and enforce_boundary_margin_m=0.25, the mask must be:
 //   * FREE (0) for a point well INSIDE the rectangle,
-//   * FREE (0) for a point just OUTSIDE the edge but within 0.25 m,
+//   * HIGH-COST (90, non-lethal) just OUTSIDE the edge within 0.25 m — the
+//     RTK-drift slack must not read as collision, but leaving it FREE created
+//     phantom corridors between close-running areas (the planner shortcut
+//     through the slack instead of the operator's navigation areas),
 //   * LETHAL (100) for a point far OUTSIDE the rectangle (> 0.25 m past edge).
 // The mask is read back with the independent OccupancyGrid convention in
 // mask_at(), so a swapped width/height (the historical 90°-rotation bug,
@@ -384,12 +387,39 @@ TEST_F(AreaTypeTest, KeepoutMaskMarksOutsideAreasLethal)
   EXPECT_EQ(mask_at(mask, 0.0, 0.0), 0) << "interior of mowing area must be free";
   EXPECT_EQ(mask_at(mask, 2.0, 1.0), 0) << "interior corner of mowing area must be free";
 
-  // Just outside the +X edge but within enforce_boundary_margin_m (0.25) → FREE.
-  EXPECT_EQ(mask_at(mask, 3.10, 0.0), 0) << "RTK-drift slack band outside edge must be free";
+  // Just outside the +X edge but within enforce_boundary_margin_m (0.25):
+  // HIGH-COST (90) — traversable as a last resort, never preferred over a
+  // navigation-area route, and non-lethal so boundary RTK drift doesn't
+  // self-reject (phantom-corridor fix, field report 2026-07).
+  EXPECT_EQ(mask_at(mask, 3.10, 0.0), 90)
+      << "RTK-drift slack band outside edge must be high-cost, not free";
 
   // Far outside the rectangle (> 0.25 m past the edge) → LETHAL.
   EXPECT_EQ(mask_at(mask, 4.0, 0.0), 100) << "cell well outside all areas must be lethal";
   EXPECT_EQ(mask_at(mask, 0.0, 3.5), 100) << "cell well outside all areas must be lethal";
+}
+
+// PHANTOM-CORRIDOR regression (field report 2026-07): two mowing areas whose
+// edges run within 2×enforce_boundary_margin_m of each other used to expose a
+// FREE strip between them (each area's slack band overlapping), and the
+// planner shortcut through it instead of routing via the operator's
+// navigation areas. The strip must now be HIGH-COST (90): still non-lethal,
+// never preferred over a real route.
+TEST_F(AreaTypeTest, KeepoutMaskNoFreePhantomCorridorBetweenCloseAreas)
+{
+  // Two rectangles separated by a 0.30 m gap along X (< 2 × 0.25 m margin).
+  ASSERT_TRUE(add_area("west", make_rect(-3, -2, -0.15, 2), /*is_navigation=*/false));
+  ASSERT_TRUE(add_area("east", make_rect(0.15, -2, 3, 2), /*is_navigation=*/false));
+
+  const auto mask = node_->build_keepout_mask_for_test();
+  ASSERT_GT(mask.info.width, 0u);
+
+  // Inside both areas: free.
+  EXPECT_EQ(mask_at(mask, -1.5, 0.0), 0);
+  EXPECT_EQ(mask_at(mask, 1.5, 0.0), 0);
+  // The gap between them (covered by both slack bands) must be HIGH-COST —
+  // a free cell here is the phantom corridor.
+  EXPECT_EQ(mask_at(mask, 0.0, 0.0), 90) << "gap between close areas must not be a free corridor";
 }
 
 // Navigation areas count toward the allowed (free) region just like mowing


### PR DESCRIPTION
Field report: **the robot cuts directly from one area to another** wherever their edges run close, ignoring the operator's navigation areas ("50 cm de chaque côté d'autorisé").

**Root cause**: the outside boundary-slack band (`enforce_boundary_margin_m` = 0.25 m around **every** area, needed so RTK drift at the edge doesn't self-reject) was **FREE (0)** in the keepout mask. Two areas whose edges run within 2×margin expose a ~0.5 m free strip — a *phantom corridor* Smac happily shortcuts through instead of the navigation areas.

**Fix**: the slack band becomes **high-cost (90 → keepout cost ≈229)**:
- non-lethal → boundary RTK drift still tolerated, last-resort crossing still plannable if **no** legal route exists,
- expensive → the planner always prefers any navigation-area route.

Tests: existing keepout test updated to the new semantics + new `KeepoutMaskNoFreePhantomCorridorBetweenCloseAreas` regression (two rectangles 0.30 m apart → the gap must cost 90). 50/50 mowgli_map tests green.

Note (même rapport terrain): les "transits à travers les obstacles" visibles sur la capture sont les connecteurs lame-active du planificateur pré-#340 — corrigés par #340/#345 ; vérifié par simulation sur la carte réelle de l'utilisateur (3 zones, 7 obstacles) : **0 pose dans les obstacles** avec le planificateur actuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)