### PR TITLE
fix(coverage): shrink swath turn-around loops via connector_turn_radius

### DIFF
--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -354,6 +354,15 @@ def generate_launch_description() -> LaunchDescription:
     # looped/hesitated at corners — the bug this knob prevents. Injected into
     # coverage_server.min_turning_radius; operator-tunable via mowgli_robot.yaml.
     min_turning_radius = 0.15
+    # connector_turn_radius: nominal radius of the swath-to-swath turn-around
+    # arcs in the continuous coverage path. A forward 180° reversal at op_width
+    # spacing always loops (a clean U needs r ≤ op_width/2 ≈ 0.09, below the
+    # min_turning_radius floor), but the loop SIZE scales with this radius: 0.30
+    # balloons a big teardrop into the headland (the "turning loops" seen with
+    # >2 headland passes); ~op_width (0.18) collapses it to a compact U-turn.
+    # Injected into coverage_server.connector_turn_radius; operator-tunable via
+    # mowgli_robot.yaml (raise toward 0.30 if the tighter turns hesitate).
+    connector_turn_radius = 0.18
     progress_timeout_sec = 300.0
     # num_headland_passes: 0 = auto (ceil(headland_width / tool_width)),
     # >0 forces exactly that many concentric perimeter rings.
@@ -466,6 +475,8 @@ def generate_launch_description() -> LaunchDescription:
         swath_overlap = float(rt_rp.get("swath_overlap", swath_overlap))
         min_turning_radius = float(rt_rp.get(
             "min_turning_radius", min_turning_radius))
+        connector_turn_radius = float(rt_rp.get(
+            "connector_turn_radius", connector_turn_radius))
         # Operator override wins; otherwise fall back to chassis_width/2
         # (cw was already read above from the same runtime config).
         if "chassis_safety_inset" in rt_rp:
@@ -692,6 +703,12 @@ def generate_launch_description() -> LaunchDescription:
         # turn is ever tighter than the robot can track (clamp to the tuned
         # [0.10, 0.50] band; sub-0.10 loops are untrackable, >0.50 bulges OOB).
         cov_params["min_turning_radius"] = min(0.50, max(0.10, min_turning_radius))
+        # Nominal turn-around radius for the continuous path (compact U vs big
+        # teardrop). Clamp to a sane band and never below the trackable floor:
+        # buildConnector floors it at min_turning_radius anyway, but keep the
+        # injected value coherent.
+        cov_params["connector_turn_radius"] = min(
+            0.50, max(min(0.50, max(0.10, min_turning_radius)), connector_turn_radius))
 
         tmp = tempfile.NamedTemporaryFile(
             mode="w", prefix="mowgli_nav2_", suffix=".yaml", delete=False)

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -46,6 +46,19 @@ nav2_util::CallbackReturn CoverageServer::on_configure(const rclcpp_lifecycle::S
   // robot's minimum MPPI-trackable turning radius (mowgli_robot.yaml). Read live
   // in planCoverage so it can be field-tuned between plans.
   declare_parameter<double>("min_turning_radius", 0.15);
+  // Nominal turn-around arc radius for the continuous-path connectors. A forward
+  // 180° swath-to-swath reversal at op_width spacing (~0.18 m) cannot avoid a
+  // loop (a clean U needs r ≤ op_width/2 ≈ 0.09 m, below the min_turning_radius
+  // floor), so buildConnector always LOOPS — but the loop SIZE scales with this
+  // nominal radius: at 0.30 m it balloons into a big teardrop that overshoots
+  // deep into the headland (the "turning loops" users see with >2 headland
+  // passes, where there's room for the big loop); at ~op_width it collapses to a
+  // compact, tight U-turn. Default 0.18 (≈ op_width) for compact turns. Floored
+  // at min_turning_radius by buildConnector, so it never goes sub-trackable.
+  // TUNING TRADE-OFF: smaller = compact turns but nearer the trackable floor
+  // (a deadband diff-drive may track a 0.30 m arc more smoothly than a 0.18 m
+  // one); raise toward 0.30 if tight turns induce hesitation. Read live.
+  declare_parameter<double>("connector_turn_radius", 0.18);
 
   // Action server result timeout. Keep this >= the BT client's per-plan wait
   // (PlanCoverageArea, 12 s): if the server expires the result first the
@@ -488,7 +501,11 @@ void CoverageServer::planCoverage()
     // to the raw boundary only when no inset was applied.
     const std::vector<std::pair<double, double>>& connector_boundary =
         plan.safe_boundary.size() >= 3 ? plan.safe_boundary : outer;
-    constexpr double kConnectorTurnRadius = 0.30;  // nominal turn-around arc radius (m)
+    // Nominal turn-around arc radius (m), read live. Smaller => compact U-turns
+    // instead of big teardrop loops; floored at min_turning_radius by
+    // buildConnector. See the connector_turn_radius declaration for the tuning
+    // trade-off.
+    const double connector_turn_radius = get_parameter("connector_turn_radius").as_double();
     constexpr double kConnectorStep = 0.03;  // connector densify step (m)
     // Build the plan as one or more HOLE-FREE continuous sub-paths. A single
     // forward turn-around connector can't route around a large interior hole, so
@@ -497,7 +514,7 @@ void CoverageServer::planCoverage()
     // routes around the obstacle (issue #333). full_path is their concatenation
     // (GUI viz); drivable_subpaths is what the BT follows.
     const auto subpaths = buildContinuousSubPaths(
-        plan, connector_boundary, kConnectorTurnRadius, min_turning_radius, kConnectorStep);
+        plan, connector_boundary, connector_turn_radius, min_turning_radius, kConnectorStep);
 
     result->full_path.header = header;
     result->drivable_subpaths.clear();

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -347,7 +347,7 @@ TEST(CoverageContinuousPath, ContinuousPathAvoidsHole)
   constexpr double kHeadland = 0.18;
   constexpr double kInset = 0.15;
   constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.30;
+  constexpr double kTurnRadius = 0.18;  // deployed connector_turn_radius default
   constexpr double kMinTurnRadius = 0.15;
   constexpr double kStep = 0.03;
 
@@ -441,7 +441,7 @@ TEST(CoverageContinuousPath, NotchFieldLobeChainedNoMidFieldJoins)
   constexpr double kHeadland = 0.18;
   constexpr double kInset = 0.15;
   constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.30;
+  constexpr double kTurnRadius = 0.18;  // deployed connector_turn_radius default
   constexpr double kMinTurnRadius = 0.15;
   constexpr double kStep = 0.03;
 
@@ -889,7 +889,7 @@ TEST(CoverageContinuousPath, RecordedArea1NoCuspInBounds)
   constexpr double kHeadland = 0.18;
   constexpr double kInset = 0.15;
   constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.30;
+  constexpr double kTurnRadius = 0.18;  // deployed connector_turn_radius default
   constexpr double kMinTurnRadius = 0.15;  // robot's min MPPI-trackable radius
   constexpr double kStep = 0.03;
 


### PR DESCRIPTION
## Problème

Signalé en terrain : **des « turning loops » apparaissent en fin de chaque swath dès que `num_headland_passes > 2`** ; avec ≤2 passes il n'y en a pas.

## Diagnostic (harness standalone sur le vrai `coverage_planning.cpp`)

Les connecteurs de demi-tour du chemin continu (`buildContinuousSubPaths` → `buildConnector`) utilisaient un rayon nominal codé en dur de **0,30 m**. Un demi-tour à 180° **vers l'avant** entre deux swaths anti-parallèles espacés de `op_width` (~0,18 m) ne peut **jamais** être un U propre — il faudrait r ≤ op_width/2 ≈ 0,09 m, sous le plancher `min_turning_radius` (0,15 m). `buildConnector` produit donc **toujours une boucle**, et à 0,30 m cette boucle **gonfle en gros teardrop** qui déborde loin dans la tournière.

- `passes=1` : peu de tournière ⇒ pas la place ⇒ virage compact (pas de boucle visible).
- `passes≥2` : 0,36–0,90 m de place ⇒ le gros teardrop se déploie ⇒ **les boucles**.

Retirer les mots Dubins RLR/LRL **ne corrige pas** (les boucles reviennent, pires). Le vrai levier est le **rayon nominal**.

## Correctif

`kConnectorTurnRadius = 0.30` (constante) → **paramètre réglable terrain `connector_turn_radius` (défaut 0,18 ≈ op_width)**, lu live, câblé via `navigation.launch.py` depuis `mowgli_robot.yaml` à côté de `min_turning_radius`. À 0,18 le demi-tour redevient un **U compact**. Toujours **planché à `min_turning_radius`** par `buildConnector` → jamais sous-trackable.

### Compromis (documenté dans le code)
0,18 m rapproche les virages du plancher trackable ; un châssis diff-drive à deadband suit peut-être un arc de 0,30 m plus proprement. **Remonter vers 0,30 si les virages serrés hésitent** — sans rebuild (`ros2 param set` / mowgli_robot.yaml).

## Validation

- **21/21 tests unitaires `mowgli_coverage` passent à 0,18** (call-sites de test mis à jour au défaut déployé).
- RecordedArea1 chemin continu @ tr=0,18 : max turn **97,7° < 120°**, **0 out-of-bounds**, `max_tight_arc_run` **2 < 3**, clearance **0,155 ≥ inset**.
- **Couverture et évitement d'obstacle inchangés** — sur les 3 zones réelles de l'utilisateur : >98 % du tondable, **0 obstacle traversé**, distance quasi identique (859→857 m).

⚠️ **À valider en sim/terrain** avant merge : c'est un changement de comportement de trajet sur un châssis à deadband. Le paramètre est réglable pour revenir à 0,30 sans rebuild si besoin.

## Notes
- Sur les zones **irrégulières à trous**, l'effet est surtout visuel (demi-tours plus nets) ; sur les champs **réguliers / haute-tournière** (le cas signalé) le gain est net.
- PR#2 à venir : réduire les **longues diagonales traversantes** (connecteurs anneau→anneau), le dominant visuel sur les vraies zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)