### PR TITLE
perf(coverage): reorder sub-paths by nearest-neighbour to cut blade-off transit

### DIFF
--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -1315,6 +1315,88 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
       out.emplace_back(rounded.begin() + static_cast<std::ptrdiff_t>(begin), rounded.end());
     }
   }
+
+  // Sub-path DRIVE ORDER: minimize the blade-off Nav2 transit BETWEEN sub-paths.
+  // The sub-paths above come out in swath-chain order; on a multi-hole field that
+  // leaves the driver criss-crossing the lawn between lobes (measured 77 m of
+  // blade-off transit on the recorded 4-hole garden). Greedy nearest-neighbour
+  // over the FINISHED sub-path polylines, entering each at whichever end is
+  // nearer, mows spatially adjacent lobes consecutively (77 → 47 m there).
+  //   * Reversing a FINISHED polyline is safe: the points are identical, so every
+  //     turn-around / fillet stays exactly as in-bounds and trackable as before —
+  //     only reversing the swath ORDER *before* the path is built relocates
+  //     U-turns (the hazard the seed-from-BoustrophedonOrder note above guards);
+  //     driving the same polyline backwards moves nothing.
+  //   * Sub-path 0 stays the seed — TransitToStrip already drives the robot to
+  //     its start, and the BT resumes by sub-path index (deterministic: a fixed
+  //     plan yields a fixed NN order, so indices are stable across re-plans).
+  //   * Adopt the NN order ONLY when it actually shortens the transit, so a field
+  //     the chain order already sequenced well can never regress.
+  if (out.size() > 1)
+  {
+    auto gap = [](const std::pair<double, double>& a, const std::pair<double, double>& b)
+    {
+      return std::hypot(a.first - b.first, a.second - b.second);
+    };
+    double chain_transit = 0.0;
+    for (std::size_t i = 1; i < out.size(); ++i)
+    {
+      chain_transit += gap(out[i - 1].back(), out[i].front());
+    }
+    std::vector<std::size_t> order{0};
+    std::vector<bool> reversed_flag(out.size(), false);
+    std::vector<bool> used(out.size(), false);
+    used[0] = true;
+    std::pair<double, double> cur = out[0].back();
+    double nn_transit = 0.0;
+    for (std::size_t n = 1; n < out.size(); ++n)
+    {
+      std::size_t best = 0;
+      bool best_rev = false;
+      double best_d = std::numeric_limits<double>::max();
+      for (std::size_t j = 0; j < out.size(); ++j)
+      {
+        if (used[j])
+        {
+          continue;
+        }
+        const double ds = gap(cur, out[j].front());  // enter forward
+        const double de = gap(cur, out[j].back());  // enter reversed
+        if (ds < best_d)
+        {
+          best_d = ds;
+          best = j;
+          best_rev = false;
+        }
+        if (de < best_d)
+        {
+          best_d = de;
+          best = j;
+          best_rev = true;
+        }
+      }
+      used[best] = true;
+      reversed_flag[best] = best_rev;
+      order.push_back(best);
+      nn_transit += best_d;
+      cur = best_rev ? out[best].front() : out[best].back();
+    }
+    if (nn_transit + 1e-6 < chain_transit)
+    {
+      std::vector<std::vector<std::pair<double, double>>> reordered;
+      reordered.reserve(out.size());
+      for (const std::size_t idx : order)
+      {
+        std::vector<std::pair<double, double>> sp = std::move(out[idx]);
+        if (reversed_flag[idx])
+        {
+          std::reverse(sp.begin(), sp.end());
+        }
+        reordered.push_back(std::move(sp));
+      }
+      out = std::move(reordered);
+    }
+  }
   return out;
 }
 

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -401,6 +401,95 @@ TEST(CoverageContinuousPath, ContinuousPathAvoidsHole)
                          << " sub-path poses fall inside the obstacle hole";
 }
 
+// Sub-path DRIVE ORDER: on a multi-lobe field the sub-paths are reordered by
+// nearest-neighbour (entering each at whichever end is nearer) to cut the
+// blade-off Nav2 transit between them — measured 77 → 47 m on the recorded
+// 4-hole garden. Reversing a FINISHED sub-path polyline is safe (identical
+// points → every turn-around stays in-bounds), so the reorder must preserve two
+// safety-critical properties: (1) every sub-path is still hole-free, and (2) the
+// order is DETERMINISTIC — the BT resumes coverage by sub-path index, so a
+// re-plan of the same area must reproduce the identical sequence.
+TEST(CoverageContinuousPath, SubPathReorderStaysHoleFreeAndDeterministic)
+{
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kInset = 0.15;
+  constexpr double kMinSwath = 0.15;
+  constexpr double kTurnRadius = 0.18;
+  constexpr double kMinTurnRadius = 0.15;
+  constexpr double kStep = 0.03;
+
+  // 10 m square with two separated holes → several lobes, so the driver relocates
+  // between them and the NN reorder is exercised (> 2 sub-paths).
+  f2c::types::Cell cell = makeSquare(10.0);
+  auto add_hole = [&cell](double cx, double cy, double h)
+  {
+    f2c::types::LinearRing r;
+    r.addPoint(f2c::types::Point(cx - h, cy - h));
+    r.addPoint(f2c::types::Point(cx + h, cy - h));
+    r.addPoint(f2c::types::Point(cx + h, cy + h));
+    r.addPoint(f2c::types::Point(cx - h, cy + h));
+    r.addPoint(f2c::types::Point(cx - h, cy - h));
+    cell.addRing(r);
+  };
+  add_hole(3.0, 3.0, 0.9);
+  add_hole(7.0, 7.0, 0.9);
+
+  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
+  ASSERT_GE(plan.safe_holes.size(), 2u) << "both holes must reach the plan as safe_holes";
+  const auto subs =
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep);
+  ASSERT_GE(subs.size(), 3u) << "two holes should split the plan into >=3 lobes to reorder";
+
+  // (1) Hole-free preserved after reorder/reversal.
+  std::size_t in_hole = 0, total = 0;
+  for (const auto& sp : subs)
+  {
+    ASSERT_GE(sp.size(), 2u) << "degenerate sub-path after reorder";
+    for (const auto& p : sp)
+    {
+      ++total;
+      for (const auto& hole : plan.safe_holes)
+      {
+        if (pointInRing(p.first, p.second, hole))
+        {
+          ++in_hole;
+          break;
+        }
+      }
+    }
+  }
+  EXPECT_EQ(in_hole, 0u) << in_hole << "/" << total << " poses inside a hole after reorder";
+
+  // (2) Deterministic across re-plans (BT resume-by-index stability).
+  const auto subs2 =
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep);
+  ASSERT_EQ(subs.size(), subs2.size()) << "sub-path count not reproducible";
+  for (std::size_t i = 0; i < subs.size(); ++i)
+  {
+    ASSERT_EQ(subs[i].size(), subs2[i].size())
+        << "sub-path " << i << " length differs across re-plans";
+    EXPECT_NEAR(subs[i].front().first, subs2[i].front().first, 1e-9)
+        << "sub-path " << i << " start x";
+    EXPECT_NEAR(subs[i].front().second, subs2[i].front().second, 1e-9)
+        << "sub-path " << i << " start y";
+    EXPECT_NEAR(subs[i].back().first, subs2[i].back().first, 1e-9) << "sub-path " << i << " end x";
+  }
+
+  // (3) The realized inter-sub-path transit is finite and sane (a runaway order
+  // would criss-cross far more than a few field diagonals).
+  double transit = 0.0;
+  for (std::size_t i = 1; i < subs.size(); ++i)
+  {
+    transit += std::hypot(subs[i].front().first - subs[i - 1].back().first,
+                          subs[i].front().second - subs[i - 1].back().second);
+  }
+  const double field_diag = 10.0 * std::sqrt(2.0);
+  EXPECT_LT(transit, field_diag * static_cast<double>(subs.size()))
+      << "relocation transit " << transit << " m implausibly long for " << subs.size()
+      << " sub-paths — the NN order is not sequencing lobes locally";
+}
+
 // #335: ring_direction controls the perimeter/headland travel winding (blade
 // side). 1 = clockwise (negative shoelace area), 2 = counter-clockwise
 // (positive). The two produce the same ring geometry driven the opposite way.


### PR DESCRIPTION
## Contexte

Suite au diagnostic « diagonales » : le `buildContinuousSubPaths` actuel produit **déjà 0 diagonale lame-active** (toutes les relocalisations sont des transits Nav2 lame coupée, #333). Mais les sous-chemins sortent en **ordre de chaîne des swaths**, ce qui fait **zigzaguer** le robot entre lobes sur un champ à trous.

## Mesure (harness sur les 3 zones réelles)

| Zone | Transit blade-off AVANT | APRÈS (NN) | Gain |
|---|---|---|---|
| Pelouse terrasse | 38 m | 31 m | 7 m |
| **Grande pelouse (4 trous)** | **77 m** | **47 m** | **−40 %** |
| Pelouse garage | 4 m | 4 m | 0 (garde l'ordre) |

## Correctif

Plus-proche-voisin glouton sur les **sous-chemins finis** (entrée par l'extrémité la plus proche) → tond les lobes spatialement adjacents consécutivement.

### Sûreté / correction
- **Inverser un sous-chemin FINI est sûr** : points identiques ⇒ chaque demi-tour/fillet reste exactement aussi in-bounds et trackable. (Seul inverser l'ordre des swaths *avant* construction déplace les U-turns ; conduire la même polyligne à l'envers ne déplace rien.)
- **Sous-chemin 0 = graine** : TransitToStrip amène déjà le robot à son départ, et le BT reprend par **index de sous-chemin** — l'ordre NN est **déterministe** (plan fixe → ordre fixe), donc les index restent stables entre re-plans.
- **Adopté seulement si ça raccourcit** le transit ⇒ jamais de régression sur un champ déjà bien ordonné (Pelouse garage inchangé).

### Inchangé
Couverture, évitement d'obstacle, routage des transits (déjà lame-coupé, #333). **Seul l'ORDRE** de conduite des sous-chemins change.

## Validation
- Nouveau test `SubPathReorderStaysHoleFreeAndDeterministic` (champ 2 trous) : verrouille hole-free + déterminisme.
- **22/22 tests `mowgli_coverage` passent** (build worktree depuis origin/dev).

⚠️ **À valider en sim/terrain** : touche l'ordre de conduite (interaction reprise BT par index — déterminisme testé, mais comportement moteur à confirmer).

## Lien
Fait suite à #348 (`connector_turn_radius`). Indépendant : peut être mergé séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)