### PR TITLE
fix(bt): mow-specific-area, idle-debounce, swath progress, stop-in-place

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
@@ -53,6 +53,23 @@ public:
 
 private:
   rclcpp::Publisher<mowgli_interfaces::msg::HighLevelStatus>::SharedPtr pub_;
+
+  // --- Transient-IDLE debounce -------------------------------------------
+  // The published state is recomputed from tree traversal every tick with no
+  // latch, so a one-tick reactive deselection of MowingSequence (or a cleared
+  // current_command) makes the IdleSequence fall-through publish state=IDLE for
+  // a single tick during an active mission — the GUI then flashes "idle" mid-mow.
+  // We hold the last published state and require a transition INTO idle from an
+  // active state (AUTONOMOUS/RECORDING/MANUAL_MOWING) to persist for
+  // kIdleDebounceTicks consecutive ticks before we actually publish idle;
+  // otherwise we re-publish the previous active state. Transitions into motion
+  // states and into EMERGENCY/NULL (state=0) are published immediately.
+  static constexpr uint8_t kStateNull = 0;  // HIGH_LEVEL_STATE_NULL / emergency
+  static constexpr uint8_t kStateIdle = 1;  // HIGH_LEVEL_STATE_IDLE
+  static constexpr int kIdleDebounceTicks = 3;  // ~0.3 s at 10 Hz
+  bool have_published_{false};
+  uint8_t last_published_state_{0};
+  int pending_idle_ticks_{0};
 };
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -959,6 +959,15 @@ BT::NodeStatus GetNextUnmowedArea::onStart()
       {
         current_area_idx_ = static_cast<uint32_t>(target);
         max_areas_ = current_area_idx_ + 1;
+        // Explicit single-area re-mow: clear any stale completed/attempted flag
+        // for THIS target so the skip loop below cannot advance past it. Without
+        // this, re-selecting an area already mown this session (sets are only
+        // cleared by EndSession) makes the skip loop overshoot max_areas_ →
+        // "all areas completed" → FAILURE → the requested area never mows.
+        // Guarded to the explicit-target path only, so normal COMMAND_START
+        // iteration still honors completed/attempted skipping.
+        ctx->completed_areas.erase(current_area_idx_);
+        ctx->attempted_areas.erase(current_area_idx_);
         RCLCPP_INFO(ctx->node->get_logger(),
                     "GetNextUnmowedArea: targeted run — mowing only area %u (single-area mode)",
                     current_area_idx_);

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -53,13 +53,49 @@ BT::NodeStatus PublishHighLevelStatus::tick()
                                                                              10);
   }
 
+  // Debounce transient IDLE. The requested state is recomputed from tree
+  // traversal each tick; a single-tick reactive deselection of MowingSequence
+  // (or a momentarily cleared current_command) makes the IdleSequence
+  // fall-through request IDLE for one tick mid-mission. Only publish IDLE after
+  // it has persisted for kIdleDebounceTicks ticks when coming FROM an active
+  // state (AUTONOMOUS/RECORDING/MANUAL_MOWING). All other transitions —
+  // including into motion states and into EMERGENCY/NULL — publish immediately.
+  const uint8_t requested_state = state_res.value();
+  uint8_t published_state = requested_state;
+  const bool was_active =
+      have_published_ && last_published_state_ != kStateIdle && last_published_state_ != kStateNull;
+  if (requested_state == kStateIdle && was_active)
+  {
+    if (++pending_idle_ticks_ < kIdleDebounceTicks)
+    {
+      // Hold the previous active state until IDLE proves persistent.
+      published_state = last_published_state_;
+    }
+    // else: IDLE has persisted long enough — accept it (published_state stays IDLE).
+  }
+  else
+  {
+    // Not a debounced IDLE transition — reset the counter and publish as-is.
+    pending_idle_ticks_ = 0;
+  }
+
   mowgli_interfaces::msg::HighLevelStatus msg;
-  msg.state = state_res.value();
+  msg.state = published_state;
   msg.state_name = name_res.value();
+  last_published_state_ = published_state;
+  have_published_ = true;
   msg.sub_state_name = "";
   msg.current_area = static_cast<int16_t>(ctx->current_area);
-  msg.current_path = -1;
-  msg.current_path_index = static_cast<int16_t>(ctx->coverage_percent);
+  // Real per-area swath progress. The GUI computes progress as
+  // current_path_index / current_path * 100 (MowerStatus.tsx,
+  // MowgliNextPage.tsx), so current_path is the DENOMINATOR (total swaths in
+  // the current area's plan) and current_path_index the NUMERATOR (completed
+  // swaths). Both are tracked by PlanCoverageArea/FollowStrip in coverage_nodes
+  // (ctx->total_swaths / ctx->completed_swaths). Previously current_path was
+  // hardcoded to -1, which made the GUI ratio divide by a negative and never
+  // render a real percentage.
+  msg.current_path = static_cast<int16_t>(ctx->total_swaths);
+  msg.current_path_index = static_cast<int16_t>(ctx->completed_swaths);
   msg.total_swaths = static_cast<int16_t>(ctx->total_swaths);
   msg.completed_swaths = static_cast<int16_t>(ctx->completed_swaths);
   msg.skipped_swaths = static_cast<int16_t>(ctx->skipped_swaths);

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -847,7 +847,24 @@
         </ReactiveSequence>
 
         <!-- ============================================================
-             f. Idle default
+             f. Stop-in-place / hold (COMMAND_STOP = 8)
+             ============================================================
+             "Stop Manual" and "Pause" route here (NOT COMMAND_HOME, which
+             drives to the dock). Halt motion + mower off and stay put while
+             the command is latched at 8. Unlike IdleSequence this does NOT
+             PAUSE the Nav2 lifecycle, so a paused mission can resume promptly.
+             ReactiveSequence so a new command (e.g. START/HOME) deselects this
+             branch on the next tick. -->
+        <ReactiveSequence name="StopHoldSequence">
+          <IsCommand command="8"/>
+          <SetMowerEnabled enabled="false"/>
+          <StopMoving/>
+          <PublishHighLevelStatus state="1" state_name="IDLE"/>
+          <WaitForDuration duration_sec="0.5"/>
+        </ReactiveSequence>
+
+        <!-- ============================================================
+             g. Idle default
              ============================================================ -->
         <Sequence name="IdleSequence">
           <SetMowerEnabled enabled="false"/>

--- a/ros2/src/mowgli_interfaces/srv/HighLevelControl.srv
+++ b/ros2/src/mowgli_interfaces/srv/HighLevelControl.srv
@@ -6,6 +6,10 @@ uint8 COMMAND_RECORD_AREA=3
 uint8 COMMAND_RECORD_FINISH=5
 uint8 COMMAND_RECORD_CANCEL=6
 uint8 COMMAND_MANUAL_MOW=7
+# Stop-in-place / hold: halt motion, mower off, stay put — does NOT drive to the
+# dock (that is COMMAND_HOME). Routes to the StopHold/IdleSequence branch. Used
+# by the GUI's "Stop Manual" and "Pause" buttons.
+uint8 COMMAND_STOP=8
 uint8 COMMAND_RESET_EMERGENCY=254
 uint8 COMMAND_DELETE_MAPS=255
 


### PR DESCRIPTION
Fixes 4 BT/node defects from the GUI audit (`docs/audits/gui_frontback_audit_2026_07.md`). Addresses 3 of the 4 user-reported bugs on the backend side.

| # | Bug | Fix (file) |
|---|-----|-----|
| 1 | **Mow a specific area does nothing** when re-mowing an area already done this session | `coverage_nodes.cpp` — targeted branch erases the target from completed/attempted sets before the skip loop (scoped to explicit-target only) |
| 2 | **Shows idle while mowing** (backend contributor) | `status_nodes.cpp` — debounce: a transition to IDLE(1) from an active state must persist 3 ticks before publishing; motion + NULL/EMERGENCY publish immediately |
| 3 | **Per-area progress never renders** | `status_nodes.cpp` — publish real swath progress (current_path=total_swaths, current_path_index=completed_swaths) instead of -1 |
| 4 | **Pause / Stop Manual just drive to the dock** | `HighLevelControl.srv` + `main_tree.xml` — new `COMMAND_STOP=8` routes to a StopHoldSequence (mower off, halt in place, no dock). Latent until the GUI wires Stop/Pause to command 8 (follow-up frontend PR) |

**Validated:** `mowgli_behavior` builds; `colcon test` 10/10 (incl. xmllint on the edited main_tree.xml). `COMMAND_STOP=8` is a pure srv constant not emitted to Go/TS/firmware headers, so no codegen needed (sync check drift on GnssStatus/Status/WheelTick is pre-existing, unrelated).

Pairs with the frontend state-display PR (numeric-state derivation) which fixes the frontend half of #2.