### PR TITLE
refactor(config): sparse installed config + template defaults + GUI reset-to-default

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -8,7 +8,15 @@
         "mower_model": {
           "type": "string",
           "title": "Mower Model",
-          "enum": ["YardForce500", "YardForce500B", "YardForceSA650", "YardForce900ECO", "LUV1000RI", "Sabo", "CUSTOM"],
+          "enum": [
+            "YardForce500",
+            "YardForce500B",
+            "YardForceSA650",
+            "YardForce900ECO",
+            "LUV1000RI",
+            "Sabo",
+            "CUSTOM"
+          ],
           "default": "YardForce500",
           "description": "The type of mower you are using."
         },
@@ -45,13 +53,13 @@
         "chassis_length": {
           "type": "number",
           "title": "Chassis Length",
-          "default": 0.60,
+          "default": 0.6,
           "description": "Chassis length in metres."
         },
         "chassis_width": {
           "type": "number",
           "title": "Chassis Width",
-          "default": 0.40,
+          "default": 0.4,
           "description": "Chassis width in metres."
         },
         "chassis_height": {
@@ -81,7 +89,7 @@
         "ticks_per_meter": {
           "type": "number",
           "title": "Encoder Ticks per Meter",
-          "default": 300.0,
+          "default": 399.0,
           "description": "Encoder ticks per metre of wheel travel."
         },
         "tool_width": {
@@ -194,7 +202,7 @@
         "lidar_y": {
           "type": "number",
           "title": "LiDAR Offset Y",
-          "default": 0.0,
+          "default": 0.024,
           "description": "Body-frame left offset of LiDAR from base_footprint (metres)."
         },
         "lidar_z": {
@@ -253,7 +261,12 @@
         "gnss_receiver_family": {
           "type": "string",
           "title": "Receiver Family",
-          "enum": ["auto", "ublox", "unicore", "nmea"],
+          "enum": [
+            "auto",
+            "ublox",
+            "unicore",
+            "nmea"
+          ],
           "default": "auto",
           "description": "Universal GNSS receiver family. Auto is recommended unless you know you need a specific parser."
         },
@@ -277,21 +290,37 @@
         "gnss_profile": {
           "type": "string",
           "title": "Receiver Profile",
-          "enum": ["runtime_only", "rover_high_precision", "rover_high_precision_debug", "factory_reset"],
+          "enum": [
+            "runtime_only",
+            "rover_high_precision",
+            "rover_high_precision_debug",
+            "factory_reset"
+          ],
           "default": "runtime_only",
           "description": "Vendor-neutral Universal GNSS receiver profile id to persist for this robot."
         },
         "gnss_signal_profile": {
           "type": "string",
           "title": "Signal Profile",
-          "enum": ["minimal", "balanced", "high_precision", "all_signals", "custom"],
+          "enum": [
+            "minimal",
+            "balanced",
+            "high_precision",
+            "all_signals",
+            "custom"
+          ],
           "default": "balanced",
           "description": "Vendor-neutral constellation/signal profile used by the future backend translator. Custom is reserved for future profile-file or raw-command workflows."
         },
         "gnss_profile_rate_hz": {
           "type": "integer",
           "title": "Position Rate",
-          "enum": [1, 5, 7, 10],
+          "enum": [
+            1,
+            5,
+            7,
+            10
+          ],
           "default": 5,
           "description": "Requested Universal GNSS receiver update/output rate in Hz."
         },
@@ -341,47 +370,55 @@
         "ntrip_enabled": {
           "type": "boolean",
           "title": "Enable NTRIP",
-          "default": true,
+          "default": false,
           "description": "Enable NTRIP RTK corrections for cm-level accuracy."
         }
       },
-      "allOf": [{
-        "if": { "properties": { "ntrip_enabled": { "const": true } } },
-        "then": {
-          "properties": {
-            "ntrip_host": {
-              "type": "string",
-              "title": "NTRIP Host",
-              "default": "",
-              "description": "Hostname or IP of your NTRIP caster."
-            },
-            "ntrip_port": {
-              "type": "integer",
-              "title": "NTRIP Port",
-              "default": 2101,
-              "description": "Port of your NTRIP caster."
-            },
-            "ntrip_user": {
-              "type": "string",
-              "title": "NTRIP Username",
-              "default": "",
-              "description": "NTRIP username."
-            },
-            "ntrip_password": {
-              "type": "string",
-              "title": "NTRIP Password",
-              "default": "",
-              "description": "NTRIP password."
-            },
-            "ntrip_mountpoint": {
-              "type": "string",
-              "title": "NTRIP Mountpoint",
-              "default": "",
-              "description": "NTRIP endpoint / mount point."
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "ntrip_enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "ntrip_host": {
+                "type": "string",
+                "title": "NTRIP Host",
+                "default": "",
+                "description": "Hostname or IP of your NTRIP caster."
+              },
+              "ntrip_port": {
+                "type": "integer",
+                "title": "NTRIP Port",
+                "default": 2101,
+                "description": "Port of your NTRIP caster."
+              },
+              "ntrip_user": {
+                "type": "string",
+                "title": "NTRIP Username",
+                "default": "",
+                "description": "NTRIP username."
+              },
+              "ntrip_password": {
+                "type": "string",
+                "title": "NTRIP Password",
+                "default": "",
+                "description": "NTRIP password."
+              },
+              "ntrip_mountpoint": {
+                "type": "string",
+                "title": "NTRIP Mountpoint",
+                "default": "",
+                "description": "NTRIP endpoint / mount point."
+              }
             }
           }
         }
-      }]
+      ]
     },
     "docking_settings": {
       "title": "Docking",
@@ -391,19 +428,19 @@
         "undock_distance": {
           "type": "number",
           "title": "Undock Distance",
-          "default": 1.5,
+          "default": 1.0,
           "description": "Reverse distance when undocking (metres)."
         },
         "undock_speed": {
           "type": "number",
           "title": "Undock Speed",
-          "default": 0.15,
+          "default": 0.16,
           "description": "Reverse speed when undocking (m/s)."
         },
         "dock_approach_distance": {
           "type": "number",
           "title": "Dock Approach Distance",
-          "default": 1.0,
+          "default": 1.5,
           "description": "Staging point distance in front of dock (metres)."
         },
         "dock_approach_overshoot": {
@@ -445,13 +482,13 @@
         "mowing_speed": {
           "type": "number",
           "title": "Mowing Speed",
-          "default": 0.3,
+          "default": 0.2,
           "description": "Robot speed during mowing (m/s)."
         },
         "transit_speed": {
           "type": "number",
           "title": "Transit Speed",
-          "default": 0.4,
+          "default": 0.25,
           "description": "Robot speed when transiting between zones and to dock (m/s)."
         },
         "outline_passes": {
@@ -493,13 +530,13 @@
         "chassis_safety_inset": {
           "type": "number",
           "title": "Chassis Safety Inset",
-          "default": 0.20,
+          "default": 0.15,
           "description": "Pre-shrink the operator polygon by this many metres before F2C plans anything. Defaults to chassis_width / 2 so the chassis edge stays inside the polygon under perfect FTC tracking."
         },
         "min_turning_radius": {
           "type": "number",
           "title": "Min Turning Radius",
-          "default": 0.05,
+          "default": 0.15,
           "description": "Minimum turning radius for coverage path (metres). Skid-steer pivots in place; large values force wide F2C U-turns."
         },
         "mow_angle_offset_deg": {
@@ -523,7 +560,7 @@
         "battery_full_voltage": {
           "type": "number",
           "title": "Full Voltage",
-          "default": 28.0,
+          "default": 28.5,
           "description": "Voltage at which battery is considered full. Default 28.0 matches YardForce500 SLA packs on the dock; raise if your pack genuinely reaches a higher resting voltage."
         },
         "battery_empty_voltage": {
@@ -607,7 +644,11 @@
         "slam_mode": {
           "type": "string",
           "title": "SLAM Mode",
-          "enum": ["lifelong", "mapping", "localization"],
+          "enum": [
+            "lifelong",
+            "mapping",
+            "localization"
+          ],
           "default": "lifelong",
           "description": "Legacy SLAM toolbox operating mode. Unused — fusion_graph_node (GTSAM iSAM2) is the primary localizer and slam_toolbox is no longer part of the stack. Kept for config backward compatibility."
         },
@@ -631,7 +672,12 @@
         "rain_mode": {
           "type": "integer",
           "title": "Rain Mode",
-          "enum": [0, 1, 2, 3],
+          "enum": [
+            0,
+            1,
+            2,
+            3
+          ],
           "default": 2,
           "description": "0=Ignore, 1=Dock, 2=Dock until dry, 3=Pause automatic mode."
         },
@@ -656,19 +702,19 @@
         "xy_goal_tolerance": {
           "type": "number",
           "title": "XY Goal Tolerance",
-          "default": 0.30,
+          "default": 0.3,
           "description": "Acceptable position error at goal (metres)."
         },
         "yaw_goal_tolerance": {
           "type": "number",
           "title": "Yaw Goal Tolerance",
-          "default": 0.10,
+          "default": 0.1,
           "description": "Acceptable heading error at goal (radians)."
         },
         "coverage_xy_tolerance": {
           "type": "number",
           "title": "Coverage XY Tolerance",
-          "default": 0.10,
+          "default": 0.5,
           "description": "Position tolerance for coverage waypoints (metres)."
         },
         "progress_timeout_sec": {

--- a/gui/pkg/api/settings.go
+++ b/gui/pkg/api/settings.go
@@ -87,6 +87,7 @@ func SettingsRoutes(r *gin.RouterGroup, dbProvider types.IDBProvider) {
 	PostSettings(r, dbProvider)
 	GetSettingsSchema(r, dbProvider)
 	GetSettingsYAML(r, dbProvider)
+	GetSettingsYAMLDefaults(r, dbProvider)
 	PostSettingsYAML(r, dbProvider)
 	GetSettingsStatus(r, dbProvider)
 	PostSettingsStatus(r, dbProvider)
@@ -321,6 +322,57 @@ func nestToROS2YAML(flat map[string]any, nodeMappings map[string]string, existin
 	}
 
 	return result
+}
+
+// valuesEqual reports whether a config value equals a schema default,
+// tolerating the numeric-type churn that YAML/JSON round-trips introduce
+// (a template default of 5 may arrive as int 5, int64 5, or float64 5.0;
+// booleans and strings compare directly). This is the predicate that keeps
+// the installed mowgli_robot.yaml SPARSE: any key whose live value equals its
+// schema default is dropped on write, so the ROS2 deep-merge falls through to
+// the package template. Resetting a field to its default is therefore just
+// "write the default value" — it disappears from the installed file.
+func valuesEqual(a, b any) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	// Numeric comparison first: JSON numbers decode to float64, YAML ints to
+	// int, so a strict == would spuriously flag "5" != "5.0".
+	if af, aok := asFloat64(a); aok {
+		if bf, bok := asFloat64(b); bok {
+			return af == bf
+		}
+	}
+	if ab, aok := a.(bool); aok {
+		if bb, bok := b.(bool); bok {
+			return ab == bb
+		}
+	}
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// pruneNestedKeys removes the given parameter keys from every node's
+// ros__parameters block in a nested ROS2 YAML tree. nestToROS2YAML clones the
+// pre-existing on-disk structure verbatim, so a key that was dropped from the
+// flat map to keep the config sparse would otherwise survive in the clone;
+// this scrubs it from the final output.
+func pruneNestedKeys(nested map[string]any, keys map[string]bool) {
+	if len(keys) == 0 {
+		return
+	}
+	for _, nodeData := range nested {
+		nodeMap, ok := nodeData.(map[string]any)
+		if !ok {
+			continue
+		}
+		rosParams, ok := nodeMap["ros__parameters"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for key := range keys {
+			delete(rosParams, key)
+		}
+	}
 }
 
 func coerceValue(value string, schemaType string) any {
@@ -1113,6 +1165,37 @@ func GetSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRout
 	})
 }
 
+// GetSettingsYAMLDefaults returns the flat map of schema-default values —
+// the GUI's authoritative source of "default" for each parameter. Because the
+// GUI backend runs in a container that does NOT ship the ROS2 package template
+// (mowgli_bringup/config/mowgli_robot.yaml, the true default source consumed by
+// robot_config_util's deep-merge), the JSON schema `default` values stand in
+// for it. They SHOULD match the template; a divergence is a schema bug, not a
+// runtime one. The frontend uses this to (a) show which values are
+// operator-overridden vs at default and (b) implement per-field "reset to
+// default" (writing the default value, which PostSettingsYAML then prunes to
+// keep the installed config sparse).
+//
+// @Summary returns the schema default value for every known parameter
+// @Description returns a flat key-value map of default values (the reset-to-default source)
+// @Tags settings
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Failure 500 {object} ErrorResponse
+// @Router /settings/yaml/defaults [get]
+func GetSettingsYAMLDefaults(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRoutes {
+	return r.GET("/settings/yaml/defaults", func(c *gin.Context) {
+		schema, err := getSchema(dbProvider)
+		if err != nil {
+			c.JSON(500, ErrorResponse{Error: err.Error()})
+			return
+		}
+		defaults := map[string]any{}
+		extractDefaults(schema, defaults)
+		c.JSON(200, defaults)
+	})
+}
+
 // PostSettingsYAML receives flat key-value settings from the form,
 // nests them into proper ROS2 YAML structure, and writes mowgli_robot.yaml.
 //
@@ -1153,8 +1236,8 @@ func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRou
 		// Merge schema defaults
 		schema, err := getSchema(dbProvider)
 		nodeMappings := map[string]string{}
+		defaults := map[string]any{}
 		if err == nil {
-			defaults := map[string]any{}
 			extractDefaults(schema, defaults)
 			for key, value := range defaults {
 				if _, exists := existing[key]; !exists {
@@ -1165,8 +1248,10 @@ func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRou
 		}
 
 		// Merge payload on top. A null value is an explicit delete request
-		// (from the Advanced "Remove parameter" action) — drop the key so it
-		// is removed from the YAML rather than written back as "key: null".
+		// (from the Advanced "Remove parameter" action, or a per-field
+		// "reset to default" for a key that has no schema default) — drop the
+		// key so it is removed from the YAML rather than written back as
+		// "key: null".
 		for key, value := range payload {
 			if value == nil {
 				delete(existing, key)
@@ -1176,8 +1261,24 @@ func PostSettingsYAML(r *gin.RouterGroup, dbProvider types.IDBProvider) gin.IRou
 		}
 		gnssEnvUpdates := applyUniversalGnssCompatibility(existing)
 
+		// Keep the installed config SPARSE: any key whose value equals its
+		// schema default is pruned so the ROS2 launch-time deep-merge falls
+		// through to the package template (the source of defaults). This is
+		// also how "reset to default" persists — the field is written with
+		// its default value from the form, and pruned here. prunedKeys is
+		// applied to the nested output too, because nestToROS2YAML preserves
+		// pre-existing on-disk keys and would otherwise resurrect them.
+		prunedKeys := map[string]bool{}
+		for key, def := range defaults {
+			if cur, exists := existing[key]; exists && valuesEqual(cur, def) {
+				delete(existing, key)
+				prunedKeys[key] = true
+			}
+		}
+
 		// Nest back into ROS2 YAML structure
 		nested := nestToROS2YAML(existing, nodeMappings, existingYAML)
+		pruneNestedKeys(nested, prunedKeys)
 
 		// Marshal with YAML comments header
 		out, err := marshalROS2YAMLWithGeoPrecision(nested)

--- a/gui/pkg/api/settings_test.go
+++ b/gui/pkg/api/settings_test.go
@@ -504,8 +504,13 @@ func TestGetSettingsYAML_NoConfigKey(t *testing.T) {
 }
 
 func TestPostSettingsYAML_NewFile(t *testing.T) {
+	// Use the real schema so the sparse-write pruning (default-equal keys
+	// dropped from the installed YAML) is exercised.
 	yamlFile := createTempYAMLFile(t, "")
 	envFile := createTempConfigFile(t, "ROS_DOMAIN_ID=0\n")
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
 
 	db := types.NewMockDBProvider()
 	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
@@ -538,18 +543,25 @@ func TestPostSettingsYAML_NewFile(t *testing.T) {
 
 	content, err := os.ReadFile(yamlFile)
 	require.NoError(t, err)
+	// Sparse write: only keys that DIFFER from the schema default are
+	// persisted. These payload values all differ from the schema defaults.
 	assert.Contains(t, string(content), "datum_lat: 48.999000000")
-	assert.Contains(t, string(content), "ntrip_enabled: true")
 	assert.Contains(t, string(content), "gnss_receiver_family: unicore")
 	assert.Contains(t, string(content), "gnss_receiver_model: UM982")
 	assert.Contains(t, string(content), "gnss_serial_device: /dev/serial/by-id/usb-gnss")
-	assert.Contains(t, string(content), "gnss_serial_baud: 921600")
 	assert.Contains(t, string(content), "gnss_config_baud: 460800")
 	assert.Contains(t, string(content), "gnss_profile: rover_high_precision")
 	assert.Contains(t, string(content), "gnss_signal_profile: all_signals")
-	assert.Contains(t, string(content), "gnss_profile_rate_hz: 5")
 	assert.Contains(t, string(content), "gnss_signal_group: 3 6")
 	assert.Contains(t, string(content), "gnss_unicore_pvt_algorithm: MULTI")
+	// These payload values EQUAL their schema default, so they are pruned
+	// from the installed YAML (the ROS2 deep-merge supplies them from the
+	// package template). The derived runtime env below is unaffected.
+	assert.NotContains(t, string(content), "gnss_serial_baud:")
+	assert.NotContains(t, string(content), "gnss_profile_rate_hz:")
+	// ntrip_enabled=true is an OVERRIDE (schema default is false, reconciled to
+	// the template), so it is PERSISTED, not pruned.
+	assert.Contains(t, string(content), "ntrip_enabled: true")
 
 	envContent, err := os.ReadFile(envFile)
 	require.NoError(t, err)
@@ -716,6 +728,134 @@ func TestPostSettingsYAML_InvalidJSON(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestPostSettingsYAML_SparseWrite_PrunesDefaults verifies that a key whose
+// value equals the schema default is NOT persisted to the installed YAML (it
+// falls through to the ROS2 package template), while a key that differs is.
+func TestPostSettingsYAML_SparseWrite_PrunesDefaults(t *testing.T) {
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
+
+	// Start with an on-disk value that is already at its default so we can
+	// confirm the pruner scrubs a pre-existing default-valued key too.
+	yamlFile := createTempYAMLFileAtGuiRoot(t, `mowgli:
+  ros__parameters:
+    mowing_speed: 0.2
+`)
+	envFile := createTempConfigFileAtGuiRoot(t, "")
+
+	db := types.NewMockDBProvider()
+	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+	db.Set("system.mower.runtimeEnvFile", []byte(envFile))
+
+	router := setupSettingsRouter(db)
+
+	// Schema defaults are reconciled to the package template: mowing_speed 0.2,
+	// transit_speed 0.25.
+	payload := map[string]any{
+		"mowing_speed":  0.2, // == schema default (0.2) -> pruned
+		"transit_speed": 0.5, // != schema default (0.25) -> persisted
+	}
+	body, _ := json.Marshal(payload)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/settings/yaml", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	content, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "mowing_speed:")
+	assert.Contains(t, string(content), "transit_speed: 0.5")
+}
+
+// TestPostSettingsYAML_ResetToDefault verifies that writing a key back to its
+// default value removes it from an installed YAML that previously overrode it.
+func TestPostSettingsYAML_ResetToDefault(t *testing.T) {
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
+
+	yamlFile := createTempYAMLFileAtGuiRoot(t, `mowgli:
+  ros__parameters:
+    mowing_speed: 0.55
+    datum_lat: 48.123
+`)
+	envFile := createTempConfigFileAtGuiRoot(t, "")
+
+	db := types.NewMockDBProvider()
+	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+	db.Set("system.mower.runtimeEnvFile", []byte(envFile))
+
+	router := setupSettingsRouter(db)
+
+	// Reset mowing_speed to its schema default (0.2, reconciled to the package
+	// template); leave datum_lat as an operator override (48.123 != default 0.0)
+	// to confirm it survives.
+	payload := map[string]any{"mowing_speed": 0.2}
+	body, _ := json.Marshal(payload)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/settings/yaml", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	content, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "mowing_speed:")
+	assert.Contains(t, string(content), "datum_lat: 48.123")
+}
+
+// TestGetSettingsYAMLDefaults_ReturnsSchemaDefaults verifies the defaults
+// endpoint surfaces the schema default values used as the reset source.
+func TestGetSettingsYAMLDefaults_ReturnsSchemaDefaults(t *testing.T) {
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
+
+	router := setupSettingsRouter(types.NewMockDBProvider())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/settings/yaml/defaults", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	// Schema defaults are reconciled to the package template (the robot's real
+	// default source): mowing_speed 0.2, transit_speed 0.25.
+	assert.Equal(t, 0.2, result["mowing_speed"])
+	assert.Equal(t, 0.25, result["transit_speed"])
+}
+
+func TestValuesEqual(t *testing.T) {
+	assert.True(t, valuesEqual(5, 5.0))        // int vs float from YAML/JSON
+	assert.True(t, valuesEqual(int64(5), 5.0)) // yaml int64 vs json float64
+	assert.True(t, valuesEqual(true, true))
+	assert.True(t, valuesEqual("auto", "auto"))
+	assert.False(t, valuesEqual(5, 6))
+	assert.False(t, valuesEqual(true, false))
+	assert.False(t, valuesEqual("auto", "unicore"))
+	assert.False(t, valuesEqual(nil, 0))
+}
+
+// createTempYAMLFileAtGuiRoot / createTempConfigFileAtGuiRoot create temp files
+// under an absolute path so they survive the chdirToGuiRoot cwd change (a
+// t.TempDir path is absolute, so this is really just createTempYAMLFile — the
+// distinct name documents intent for the chdir'd tests).
+func createTempYAMLFileAtGuiRoot(t *testing.T, content string) string {
+	return createTempYAMLFile(t, content)
+}
+
+func createTempConfigFileAtGuiRoot(t *testing.T, content string) string {
+	return createTempConfigFile(t, content)
 }
 
 func createTempYAMLFile(t *testing.T, content string) string {

--- a/gui/web/src/components/settings/MowingSection.tsx
+++ b/gui/web/src/components/settings/MowingSection.tsx
@@ -3,12 +3,16 @@ import { Card, Col, Form, InputNumber, Row, Select, Space, Switch, Typography } 
 import { ScissorOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import { useThemeMode } from "../../theme/ThemeContext.tsx";
+import { SettingFieldLabel } from "./SettingFieldLabel.tsx";
 
 const { Text, Paragraph } = Typography;
 
 type Props = {
     values: Record<string, any>;
     onChange: (key: string, value: any) => void;
+    isOverridden?: (key: string) => boolean;
+    hasDefault?: (key: string) => boolean;
+    onReset?: (key: string) => void;
 };
 
 /** Mini SVG preview showing the strip pattern. Spacing == tool_width (F2C
@@ -130,8 +134,23 @@ const StripPreview: React.FC<{ pathSpacing: number; toolWidth: number; headlandW
     );
 };
 
-export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
+export const MowingSection: React.FC<Props> = ({
+    values,
+    onChange,
+    isOverridden,
+    hasDefault,
+    onReset,
+}) => {
     const { t } = useTranslation();
+    const fieldLabel = (key: string, label: React.ReactNode) => (
+        <SettingFieldLabel
+            settingKey={key}
+            label={label}
+            overridden={isOverridden?.(key) ?? false}
+            canReset={hasDefault?.(key) ?? false}
+            onReset={onReset}
+        />
+    );
     // F2C swath spacing == tool_width (Robot::setCovWidth). The
     // preview shows blade swaths spaced by tool_width — adjacent
     // strips tile exactly, no overlap or gap.
@@ -162,7 +181,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                     <Form layout="vertical" size="small">
                         <Row gutter={[16, 0]}>
                             <Col xs={12} sm={8}>
-                                <Form.Item label={t("settingsMowing.mowingSpeed")} tooltip={t("settingsMowing.mowingSpeedTooltip")}>
+                                <Form.Item label={fieldLabel("mowing_speed", t("settingsMowing.mowingSpeed"))} tooltip={t("settingsMowing.mowingSpeedTooltip")}>
                                     <InputNumber
                                         value={values.mowing_speed}
                                         onChange={(v) => onChange("mowing_speed", v)}
@@ -172,7 +191,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                 </Form.Item>
                             </Col>
                             <Col xs={12} sm={8}>
-                                <Form.Item label={t("settingsMowing.transitSpeed")} tooltip={t("settingsMowing.transitSpeedTooltip")}>
+                                <Form.Item label={fieldLabel("transit_speed", t("settingsMowing.transitSpeed"))} tooltip={t("settingsMowing.transitSpeedTooltip")}>
                                     <InputNumber
                                         value={values.transit_speed}
                                         onChange={(v) => onChange("transit_speed", v)}
@@ -193,7 +212,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                         <Form layout="vertical" size="small">
                             <Row gutter={[16, 0]}>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.headlandWidth")} tooltip={t("settingsMowing.headlandWidthTooltip")}>
+                                    <Form.Item label={fieldLabel("headland_width", t("settingsMowing.headlandWidth"))} tooltip={t("settingsMowing.headlandWidthTooltip")}>
                                         <InputNumber
                                             value={values.headland_width}
                                             onChange={(v) => onChange("headland_width", v)}
@@ -203,7 +222,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                     </Form.Item>
                                 </Col>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.headlandPasses")} tooltip={t("settingsMowing.headlandPassesTooltip")}>
+                                    <Form.Item label={fieldLabel("num_headland_passes", t("settingsMowing.headlandPasses"))} tooltip={t("settingsMowing.headlandPassesTooltip")}>
                                         <InputNumber
                                             value={values.num_headland_passes}
                                             onChange={(v) => onChange("num_headland_passes", v)}
@@ -213,7 +232,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                     </Form.Item>
                                 </Col>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.chassisSafetyInset")} tooltip={t("settingsMowing.chassisSafetyInsetTooltip")}>
+                                    <Form.Item label={fieldLabel("chassis_safety_inset", t("settingsMowing.chassisSafetyInset"))} tooltip={t("settingsMowing.chassisSafetyInsetTooltip")}>
                                         <InputNumber
                                             value={values.chassis_safety_inset}
                                             onChange={(v) => onChange("chassis_safety_inset", v)}
@@ -223,7 +242,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                     </Form.Item>
                                 </Col>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.minTurningRadius")} tooltip={t("settingsMowing.minTurningRadiusTooltip")}>
+                                    <Form.Item label={fieldLabel("min_turning_radius", t("settingsMowing.minTurningRadius"))} tooltip={t("settingsMowing.minTurningRadiusTooltip")}>
                                         <InputNumber
                                             value={values.min_turning_radius}
                                             onChange={(v) => onChange("min_turning_radius", v)}
@@ -233,7 +252,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                     </Form.Item>
                                 </Col>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.swathOverlap")} tooltip={t("settingsMowing.swathOverlapTooltip")}>
+                                    <Form.Item label={fieldLabel("swath_overlap", t("settingsMowing.swathOverlap"))} tooltip={t("settingsMowing.swathOverlapTooltip")}>
                                         <InputNumber
                                             value={values.swath_overlap}
                                             onChange={(v) => onChange("swath_overlap", v)}
@@ -243,7 +262,7 @@ export const MowingSection: React.FC<Props> = ({ values, onChange }) => {
                                     </Form.Item>
                                 </Col>
                                 <Col xs={12}>
-                                    <Form.Item label={t("settingsMowing.mowDirection")} tooltip={t("settingsMowing.mowDirectionTooltip")}>
+                                    <Form.Item label={fieldLabel("mow_direction", t("settingsMowing.mowDirection"))} tooltip={t("settingsMowing.mowDirectionTooltip")}>
                                         <Select
                                             value={values.mow_direction ?? 0}
                                             onChange={(v) => onChange("mow_direction", v)}

--- a/gui/web/src/components/settings/NavigationSection.tsx
+++ b/gui/web/src/components/settings/NavigationSection.tsx
@@ -2,16 +2,35 @@ import React from "react";
 import { Card, Col, Form, InputNumber, Row, Space, Typography } from "antd";
 import { CompassOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
+import { SettingFieldLabel } from "./SettingFieldLabel.tsx";
 
 const { Text, Paragraph } = Typography;
 
 type Props = {
     values: Record<string, any>;
     onChange: (key: string, value: any) => void;
+    isOverridden?: (key: string) => boolean;
+    hasDefault?: (key: string) => boolean;
+    onReset?: (key: string) => void;
 };
 
-export const NavigationSection: React.FC<Props> = ({ values, onChange }) => {
+export const NavigationSection: React.FC<Props> = ({
+    values,
+    onChange,
+    isOverridden,
+    hasDefault,
+    onReset,
+}) => {
     const { t } = useTranslation();
+    const fieldLabel = (key: string, label: React.ReactNode) => (
+        <SettingFieldLabel
+            settingKey={key}
+            label={label}
+            overridden={isOverridden?.(key) ?? false}
+            canReset={hasDefault?.(key) ?? false}
+            onReset={onReset}
+        />
+    );
     return (
         <div>
             <Card size="small" style={{ marginBottom: 16 }}>
@@ -28,7 +47,7 @@ export const NavigationSection: React.FC<Props> = ({ values, onChange }) => {
                     <Form layout="vertical" size="small">
                         <Row gutter={[16, 0]}>
                             <Col xs={12} sm={8}>
-                                <Form.Item label={t("settingsNavigation.transitXyTolerance")} tooltip={t("settingsNavigation.transitXyToleranceTooltip")}>
+                                <Form.Item label={fieldLabel("xy_goal_tolerance", t("settingsNavigation.transitXyTolerance"))} tooltip={t("settingsNavigation.transitXyToleranceTooltip")}>
                                     <InputNumber
                                         value={values.xy_goal_tolerance}
                                         onChange={(v) => onChange("xy_goal_tolerance", v)}
@@ -38,7 +57,7 @@ export const NavigationSection: React.FC<Props> = ({ values, onChange }) => {
                                 </Form.Item>
                             </Col>
                             <Col xs={12} sm={8}>
-                                <Form.Item label={t("settingsNavigation.yawTolerance")} tooltip={t("settingsNavigation.yawToleranceTooltip")}>
+                                <Form.Item label={fieldLabel("yaw_goal_tolerance", t("settingsNavigation.yawTolerance"))} tooltip={t("settingsNavigation.yawToleranceTooltip")}>
                                     <InputNumber
                                         value={values.yaw_goal_tolerance}
                                         onChange={(v) => onChange("yaw_goal_tolerance", v)}
@@ -48,7 +67,7 @@ export const NavigationSection: React.FC<Props> = ({ values, onChange }) => {
                                 </Form.Item>
                             </Col>
                             <Col xs={12} sm={8}>
-                                <Form.Item label={t("settingsNavigation.coverageXyTolerance")} tooltip={t("settingsNavigation.coverageXyToleranceTooltip")}>
+                                <Form.Item label={fieldLabel("coverage_xy_tolerance", t("settingsNavigation.coverageXyTolerance"))} tooltip={t("settingsNavigation.coverageXyToleranceTooltip")}>
                                     <InputNumber
                                         value={values.coverage_xy_tolerance}
                                         onChange={(v) => onChange("coverage_xy_tolerance", v)}
@@ -66,7 +85,7 @@ export const NavigationSection: React.FC<Props> = ({ values, onChange }) => {
                 <Form layout="vertical" size="small">
                     <Row gutter={[16, 0]}>
                         <Col xs={12} sm={8}>
-                            <Form.Item label={t("settingsNavigation.progressTimeout")} tooltip={t("settingsNavigation.progressTimeoutTooltip")}>
+                            <Form.Item label={fieldLabel("progress_timeout_sec", t("settingsNavigation.progressTimeout"))} tooltip={t("settingsNavigation.progressTimeoutTooltip")}>
                                 <InputNumber
                                     value={values.progress_timeout_sec}
                                     onChange={(v) => onChange("progress_timeout_sec", v)}

--- a/gui/web/src/components/settings/SettingFieldLabel.tsx
+++ b/gui/web/src/components/settings/SettingFieldLabel.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Badge, Button, Space, Tooltip } from "antd";
+import { UndoOutlined } from "@ant-design/icons";
+import { useTranslation } from "react-i18next";
+
+type Props = {
+    /** The parameter key this label is for (e.g. "mowing_speed"). */
+    settingKey: string;
+    /** The visible field label. */
+    label: React.ReactNode;
+    /** True when the current value differs from its schema default. */
+    overridden?: boolean;
+    /** True when a schema default exists for this key (reset is meaningful). */
+    canReset?: boolean;
+    /** Reset the field to its schema default. */
+    onReset?: (key: string) => void;
+};
+
+/**
+ * SettingFieldLabel wraps a Form.Item label with two default-awareness
+ * affordances used by the sparse-config settings UI:
+ *   - a small dot before the label when the value is operator-overridden
+ *     (differs from the schema default), and
+ *   - a subtle "reset to default" undo button after the label, shown only when
+ *     the value is overridden AND a default exists.
+ * When no default is known (canReset === false) it renders the label plainly,
+ * so it is safe to use everywhere regardless of whether the key has a default.
+ */
+export const SettingFieldLabel: React.FC<Props> = ({
+    settingKey,
+    label,
+    overridden = false,
+    canReset = false,
+    onReset,
+}) => {
+    const { t } = useTranslation();
+    const showReset = canReset && overridden && !!onReset;
+    return (
+        <Space size={4} align="center">
+            {overridden ? (
+                <Badge
+                    color="gold"
+                    title={t("settingsReset.overridden", "Overridden — differs from default")}
+                />
+            ) : null}
+            <span>{label}</span>
+            {showReset ? (
+                <Tooltip title={t("settingsReset.resetToDefault", "Reset to default")}>
+                    <Button
+                        type="text"
+                        size="small"
+                        aria-label={t("settingsReset.resetToDefault", "Reset to default")}
+                        icon={<UndoOutlined style={{ fontSize: 11 }} />}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onReset?.(settingKey);
+                        }}
+                        style={{ height: 18, width: 18, minWidth: 18, padding: 0, opacity: 0.65 }}
+                    />
+                </Tooltip>
+            ) : null}
+        </Space>
+    );
+};

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -185,6 +185,11 @@ export const useSettingsManager = () => {
     const { notification } = App.useApp();
     const [savedValues, setSavedValues] = useState<Record<string, any>>({});
     const [localValues, setLocalValues] = useState<Record<string, any>>({});
+    // Schema defaults = the GUI's source of "default value" for each key.
+    // (The backend derives these from the JSON schema, which stands in for the
+    // ROS2 package template it cannot read at runtime.) Used for the
+    // per-field "reset to default" affordance and the overridden indicator.
+    const [defaults, setDefaults] = useState<Record<string, any>>({});
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [restartRequired, setRestartRequired] = useState(false);
@@ -208,6 +213,20 @@ export const useSettingsManager = () => {
                 const data = (res.data as Record<string, any>) || {};
                 setSavedValues(data);
                 setLocalValues(data);
+                // Best-effort: the reset-to-default UI degrades gracefully
+                // (no reset icons) if this fails, so it must not block load.
+                try {
+                    const defRes = await guiApi.request({
+                        path: "/settings/yaml/defaults",
+                        method: "GET",
+                        format: "json",
+                    });
+                    if (!defRes.error) {
+                        setDefaults((defRes.data as Record<string, any>) || {});
+                    }
+                } catch {
+                    /* defaults unavailable — reset affordance hidden */
+                }
                 initialLoadDone.current = true;
             } catch (e: any) {
                 notification.error({
@@ -227,6 +246,52 @@ export const useSettingsManager = () => {
     const handleBulkChange = useCallback((changes: Record<string, any>) => {
         setLocalValues((prev) => ({ ...prev, ...changes }));
     }, []);
+
+    // hasDefault: the schema knows a default for this key (so a reset is
+    // meaningful). isDefault: the current local value already equals that
+    // default (tolerating int/float JSON churn, so 5 == 5.0). isOverridden:
+    // has a default AND the local value differs from it — the operator has
+    // pinned a non-default value that we should visually flag.
+    const valuesMatch = (a: any, b: any): boolean => {
+        if (typeof a === "number" && typeof b === "number") return a === b;
+        // Number vs numeric-string / int-vs-float from JSON round-trips.
+        const an = Number(a);
+        const bn = Number(b);
+        if (!Number.isNaN(an) && !Number.isNaN(bn) &&
+            (typeof a !== "string" || a.trim() !== "") &&
+            (typeof b !== "string" || b.trim() !== "")) {
+            return an === bn;
+        }
+        return JSON.stringify(a) === JSON.stringify(b);
+    };
+
+    const hasDefault = useCallback(
+        (key: string): boolean => key in defaults,
+        [defaults]
+    );
+
+    const isDefault = useCallback(
+        (key: string): boolean =>
+            key in defaults && valuesMatch(localValues[key], defaults[key]),
+        [defaults, localValues]
+    );
+
+    const isOverridden = useCallback(
+        (key: string): boolean =>
+            key in defaults && !valuesMatch(localValues[key], defaults[key]),
+        [defaults, localValues]
+    );
+
+    // resetToDefault reverts a field to its schema default in the local (unsaved)
+    // state; the operator still presses Save to persist. On save the backend
+    // prunes default-valued keys, so the installed config stays sparse.
+    const resetToDefault = useCallback(
+        (key: string) => {
+            if (!(key in defaults)) return;
+            setLocalValues((prev) => ({ ...prev, [key]: defaults[key] }));
+        },
+        [defaults]
+    );
 
     // Dirty detection
     const dirtyKeys = useMemo(() => {
@@ -514,6 +579,7 @@ export const useSettingsManager = () => {
         sections: SECTION_DEFINITIONS,
         values: localValues,
         savedValues,
+        defaults,
         loading,
         saving,
         gpsRestarting: gpsRestart.pending,
@@ -525,6 +591,10 @@ export const useSettingsManager = () => {
         setSearchQuery,
         handleChange,
         handleBulkChange,
+        hasDefault,
+        isDefault,
+        isOverridden,
+        resetToDefault,
         isSectionDirty,
         matchesSearch,
         save,

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -52,6 +52,9 @@ export const SettingsPage = () => {
         handleChange,
         handleBulkChange,
         isSectionDirty,
+        hasDefault,
+        isOverridden,
+        resetToDefault,
         save,
         savePartialValues,
         saveAndRestartGps,
@@ -107,7 +110,15 @@ export const SettingsPage = () => {
             case "localization":
                 return <LocalizationSection values={values} onChange={handleChange} />;
             case "mowing":
-                return <MowingSection values={values} onChange={handleChange} />;
+                return (
+                    <MowingSection
+                        values={values}
+                        onChange={handleChange}
+                        isOverridden={isOverridden}
+                        hasDefault={hasDefault}
+                        onReset={resetToDefault}
+                    />
+                );
             case "docking":
                 return <DockingSection values={values} onChange={handleChange} />;
             case "battery":
@@ -115,7 +126,15 @@ export const SettingsPage = () => {
             case "safety":
                 return <SafetySection values={values} onChange={handleChange} />;
             case "navigation":
-                return <NavigationSection values={values} onChange={handleChange} />;
+                return (
+                    <NavigationSection
+                        values={values}
+                        onChange={handleChange}
+                        isOverridden={isOverridden}
+                        hasDefault={hasDefault}
+                        onReset={resetToDefault}
+                    />
+                );
             case "rain":
                 return <RainSection values={values} onChange={handleChange} />;
             case "advanced":

--- a/install/config/mowgli/mowgli_robot.yaml
+++ b/install/config/mowgli/mowgli_robot.yaml
@@ -1,208 +1,76 @@
-# Mowgli Robot Configuration — seeded by the installer, then managed
-# by mowglinext-gui (Settings page). This file is the single source
-# of truth for robot parameters; changes are picked up on container
-# restart.
+# =============================================================================
+# mowgli_robot.yaml — SPARSE installed robot configuration
 #
-# Site-specific keys (datum, dock_pose, ntrip_*, imu calibration,
-# magnetometer calibration) are filled in by the installer and the
-# GUI's onboarding wizard. Mounting positions and chassis dims are
-# YardForce500 defaults — adjust on the GUI's Settings page if you
-# run a different chassis.
+# This file is DELIBERATELY SPARSE. It holds ONLY:
+#   * Bucket A — install-time choices made by the installer / onboarding wizard
+#     (hardware selection, GNSS receiver + serial, datum, NTRIP credentials).
+#   * Bucket B — per-robot CALIBRATION OUTPUTS written back by the GUI / nodes
+#     (dock pose, encoder scale, wheel PID, IMU yaw, magnetometer settings).
+#
+# EVERY OTHER PARAMETER'S DEFAULT lives in the in-package template
+# `mowgli_bringup/config/mowgli_robot.yaml` (versioned, ships with the
+# software). At launch, robot_config_util.load_robot_params() DEEP-MERGES this
+# sparse file OVER that template, so any key absent here falls through to its
+# template default. This is exactly how the GUI's "reset to default" works:
+# deleting a key from this file reverts it to the template value.
+#
+# So: to change a value, set it here (it overrides the template). To restore a
+# default, DELETE its line here (do NOT copy the template value in). Do not add
+# keys that are pure defaults — keep this file sparse.
+# =============================================================================
 
 mowgli:
     ros__parameters:
-        # ── Operational mode ────────────────────────────────────────
-        automatic_mode: 0
-        mowing_enabled: true
+        # ── Bucket A — install-time choices ─────────────────────────
+        # Hardware model + LiDAR presence. `lidar_enabled` is install-decided
+        # and is intentionally ABSENT from the template — its presence here is
+        # what tells the launch files an explicit operator choice was made.
+        mower_model: YardForce500
         lidar_enabled: true
-        # idle_nav2_suspend (default false): when true, the behaviour tree
-        # PAUSEs the entire Nav2 lifecycle stack while the robot is parked on
-        # the dock, so the costmaps stop looping and the Pi's idle thermal
-        # load drops sharply. Nav2 is RESUMEd (collision_monitor back up)
-        # before any motion. Opt-in per site; leave false until validated on
-        # your hardware.
-        idle_nav2_suspend: false
 
-        # Localizer backend — when LiDAR is present we want the
-        # GTSAM factor-graph localizer with scan-matching + loop
-        # closure so we ride through RTK-Float windows.
-        use_fusion_graph: true
-        use_scan_matching: true
-        use_loop_closure: true
-        use_magnetometer: false
-
-        # ── Battery (YardForce500 28 V pack) ────────────────────────
-        battery_critical_percent: 10
-        battery_critical_voltage: 23
-        battery_empty_voltage: 24
-        battery_full_percent: 95
-        # YardForce500 SLA packs top out at ~28.0 V on the dock. Earlier
-        # default of 28.5 V capped the displayed percent at 88.9 % even when
-        # fully charged. Operators with a pack that truly reaches 28.5 V can
-        # override this here.
-        battery_full_voltage: 28.0
-        battery_low_percent: 20
-
-        # ── Chassis (YardForce500 measured) ─────────────────────────
-        blade_radius: 0.09
-        caster_radius: 0.03
-        caster_track: 0.36
-        chassis_center_x: 0.18
-        chassis_height: 0.19
-        chassis_length: 0.54
-        chassis_mass_kg: 8.76
-        chassis_width: 0.4
-        tool_width: 0.18
-        wheel_radius: 0.04475
-        wheel_track: 0.325
-        wheel_width: 0.04
-        wheel_x_offset: 0
-        # ticks_per_meter — consumed by hardware_bridge_node to convert
-        # raw encoder tick deltas to metres. MUST match the firmware
-        # constant TICKS_PER_M in firmware/stm32/ros_usbnode/include/board.h.
-        ticks_per_meter: 300.0
-        ticks_per_revolution: 84
-
-        # ── Sensor mounting (relative to base_link / wheel axis) ────
-        # Defaults are physically measured on a YardForce500 with the
-        # standard mowgli antenna/IMU/LiDAR mount. Override on the
-        # Settings page if your robot differs.
-        gps_x: 0.3
-        gps_y: 0
-        gps_z: 0.2
-        imu_x: 0.191
-        imu_y: -0.186
-        imu_z: 0.095
-        # imu_pitch / imu_roll / imu_yaw are calibrated per robot —
-        # use the GUI's Auto-calibrate button (Diagnostics → IMU yaw
-        # calibration). Default 0 means uncalibrated.
-        imu_pitch: 0
-        imu_roll: 0
-        imu_yaw: 0
-        lidar_x: 0
-        lidar_y: 0.025
-        lidar_z: 0.22
-        lidar_yaw: -3.1416
-
-        # ── GPS / RTK ───────────────────────────────────────────────
+        # GNSS receiver + serial link.
         gnss_receiver_family: auto
         gnss_serial_device: /dev/ttyAMA4
         gnss_serial_baud: 921600
-        gps_timeout_sec: 5
-        gps_wait_after_undock_sec: 10
-        # Datum — map origin in WGS84 lat/lon. Set per-site by the
-        # installer or by the GUI's "Auto-detect from GPS" button.
-        datum_alt: 0
+
+        # Datum — map origin in WGS84 lat/lon. Set per-site by the installer or
+        # the GUI's "Auto-detect from GPS" button. 0/0 = not yet set.
         datum_lat: 0.000000000
         datum_lon: 0.000000000
-        # NTRIP — RTK correction stream. Rover defaults use the public
-        # Centipede/CRTK network and stay enabled unless explicitly disabled.
-        ntrip_enabled: true
-        ntrip_host: "crtk.net"
-        ntrip_mountpoint: "NEAR"
-        ntrip_password: "centipede"
+
+        # NTRIP — RTK correction stream. Disabled + empty by default; the
+        # installer / GUI fill these in for the site's caster.
+        ntrip_enabled: false
+        ntrip_host: ""
         ntrip_port: 2101
-        ntrip_user: "centipede"
+        ntrip_user: ""
+        ntrip_password: ""
+        ntrip_mountpoint: ""
 
-        # ── Docking ─────────────────────────────────────────────────
-        # dock_pose is captured by the GUI's IMU yaw calibration
-        # (which docks first) or the manual "Set dock to current pose"
-        # action — both write back here via line-splice updates.
-        # Approach distance = the final straight-in runway (injected as
-        # opennav_docking simple_charging_dock.staging_x_offset). 1.5 m is
-        # a clean, calm approach once the dock pose is correctly pinned.
-        dock_approach_distance: 1.5
-        dock_max_retries: 3
-        dock_pose_x: 0
-        dock_pose_y: 0
-        dock_pose_yaw: 0
-        dock_use_charger_detection: true
-        undock_distance: 1.5
-        undock_speed: 0.15
+        # ── Bucket B — per-robot calibration outputs ────────────────
+        # Dock pose (map frame) — captured by the GUI's IMU yaw calibration or
+        # the "Set dock to current pose" action, written back via line-splice.
+        dock_pose_x: 0.0
+        dock_pose_y: 0.0
+        dock_pose_yaw: 0.0
 
-        # ── Mowing pattern ──────────────────────────────────────────
-        # coverage_xy_tolerance: FTC coverage goal xy tolerance (m). Hard
-        #   ceiling 0.15 m in navigation.launch.py (clamped + warned above
-        #   that). 0.10 is the safe default.
-        coverage_xy_tolerance: 0.10
-        headland_width: 0.18
-        # min_turning_radius: F2C swath-connection turn radius (m). The
-        #   YardForce500 is a skid-steer that pivots in place, so keep this
-        #   small — a large value forces wide Dubins U-turns between swaths
-        #   and degrades coverage. 0.05 ≈ pivot-in-place.
-        min_turning_radius: 0.05
-        mow_angle_increment_deg: 0
-        mow_angle_offset_deg: -1
-        mower_model: YardForce500
-        mowing_speed: 0.2
-        outline_offset: 0.05
-        outline_overlap: 0
-        outline_passes: 1
-        path_spacing: 0.13
-        progress_timeout_sec: 60
-        transit_speed: 0.25
-        # xy/yaw_goal_tolerance: Nav2 transit + dock-staging goal tolerance.
-        #   Keep tight — loose values let the robot "arrive" far from the
-        #   staging pose and miss the dock. 0.30 m / 0.20 rad are the sane
-        #   defaults; tighten per-site via the GUI if needed.
-        xy_goal_tolerance: 0.30
-        yaw_goal_tolerance: 0.20
+        # Encoder scale — MUST match the firmware and the physical wheels.
+        # Calibrated per robot (drive-a-known-distance). Template default 399.0.
+        ticks_per_meter: 399.0
 
-        # ── Persistence ─────────────────────────────────────────────
-        map_save_on_dock: true
-        map_save_path: /ros2_ws/maps/garden_map
-        max_obstacle_avoidance_distance: 2
+        # Drive-motor wheel-velocity PID + feedforward, pushed to the STM32.
+        # Retuned per robot via the GUI; values here mirror the template.
+        wheel_pid_kp: 30.0
+        wheel_pid_ki: 5000.0
+        wheel_pid_kd: 0.0
+        wheel_pid_integral_limit: 100.0
+        wheel_pid_pwm_per_mps: 300.0
 
-        # ── Safety ──────────────────────────────────────────────────
-        # Lift/tilt emergency is the firmware's job — these flags only
-        # control whether ROS2 should react when the firmware reports
-        # it. Leave false unless you specifically want the BT to do
-        # extra recovery on top of firmware emergency.
-        emergency_stop_on_lift: false
-        emergency_stop_on_tilt: false
-        lift_blade_resume_delay_sec: 1
-        lift_recovery_mode: false
-        motor_temp_high_c: 80
-        motor_temp_low_c: 40
-        rain_debounce_sec: 10
-        rain_delay_minutes: 30
-        rain_mode: 2
+        # IMU mounting yaw offset (rad) — solved by the GUI's Auto-calibrate
+        # button. 0 = uncalibrated.
+        imu_yaw: 0.0
 
-        # ── Behavior Tree tuning ────────────────────────────────────
-        # tick_rate: BT tick frequency (Hz). 10 Hz is the default.
-        # bt_debug_logging: emit verbose BT node-tick traces.
-        tick_rate: 10.0
-        bt_debug_logging: false
-
-        # ── IMU calibration (hardware_bridge_node) ──────────────────
-        # Calibration is auto-triggered on dock arrival. These knobs
-        # tune how it samples and persists across container restarts.
-        # imu_cal_samples: number of stationary IMU samples to average
-        # imu_cal_persist_path: where the calibration is stored
-        # imu_cal_auto_rest_sec: stationary detection window before cal
-        # imu_cal_periodic_recal_sec: refresh cal every N s while docked
-        imu_cal_samples: 200
-        imu_cal_persist_path: /ros2_ws/maps/imu_calibration.txt
-        imu_cal_auto_rest_sec: 15.0
-        imu_cal_periodic_recal_sec: 600.0
-
-        # ── Magnetometer fusion (cog_to_imu + mag_yaw_publisher) ────
-        # Default OFF on stock chassis: motor field induces heading-
-        # dependent bias static cal cannot remove. Enable only on a
-        # motor-isolated mag mount.
-        # enable_mag_cal: collect mag samples while RTK-Fixed
-        # mag_calibration_path: persisted hard-iron / soft-iron file
-        # declination_deg: local magnetic declination (France ≈ 1.5°)
-        # min_horizontal_uT: minimum horizontal field for valid yaw
-        # mag_yaw_variance: published yaw covariance (rad²)
+        # Magnetometer fusion. Default OFF on stock chassis (motor field bias);
+        # enable + set declination only on a motor-isolated mag mount.
         enable_mag_cal: false
-        mag_calibration_path: /ros2_ws/maps/mag_calibration.yaml
         declination_deg: 1.5
-        min_horizontal_uT: 5.0
-        mag_yaw_variance: 0.0027
-
-        # ── Dock seeding (dock_yaw_to_set_pose) ─────────────────────
-        # dock_pose_yaw_sigma_rad: noise on the yaw observation when
-        # the EKF is seeded with the dock heading on charge rising
-        # edge. Lower = trust the dock heading more strongly.
-        dock_pose_yaw_sigma_rad: 0.035

--- a/ros2/src/mowgli_bringup/CMakeLists.txt
+++ b/ros2/src/mowgli_bringup/CMakeLists.txt
@@ -63,6 +63,12 @@ if(BUILD_TESTING)
   ament_add_pytest_test(test_gnss_launch_config test/test_gnss_launch_config.py
     TIMEOUT 30
   )
+  # Verifies the sparse-installed-config deep-merge (robot_config_util):
+  # template-only defaults, sparse overrides + fall-through, reset-to-default,
+  # and full-config backward compat.
+  ament_add_pytest_test(test_robot_config_util test/test_robot_config_util.py
+    TIMEOUT 30
+  )
 
 endif()
 

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -33,8 +33,8 @@ Brings up all subsystems:
 """
 
 import os
+import sys
 
-import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
@@ -46,6 +46,12 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+
+# Shared robot-config loader (sibling module installed alongside this launch
+# file). Deep-merges the SPARSE installed mowgli_robot.yaml over the in-package
+# template defaults, so a missing key falls through to its versioned default.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from robot_config_util import load_robot_params  # noqa: E402
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -73,16 +79,16 @@ def generate_launch_description() -> LaunchDescription:
     _runtime_cfg_path = "/ros2_ws/config/mowgli_robot.yaml"
     _early_use_lidar = "true"
     _yaml_set_lidar = False
-    if os.path.isfile(_runtime_cfg_path):
-        try:
-            with open(_runtime_cfg_path, "r") as _f:
-                _cfg = yaml.safe_load(_f) or {}
-            _rp = _cfg.get("mowgli", {}).get("ros__parameters", {})
-            if "lidar_enabled" in _rp:
-                _early_use_lidar = "true" if bool(_rp["lidar_enabled"]) else "false"
-                _yaml_set_lidar = True
-        except yaml.YAMLError:
-            pass
+    # Merged params = in-package template defaults with the installed sparse
+    # config layered on top. `lidar_enabled` is an INSTALL-DECIDED key that is
+    # ABSENT from the template, so its PRESENCE in the merged params still
+    # signals an explicit operator choice (env-var fallback preserved below);
+    # if the installed config omits it, the key stays absent and the LIDAR_ENABLED
+    # env var / default governs.
+    _rp = load_robot_params(bringup_dir, _runtime_cfg_path)
+    if "lidar_enabled" in _rp:
+        _early_use_lidar = "true" if bool(_rp["lidar_enabled"]) else "false"
+        _yaml_set_lidar = True
 
     # mowgli_robot.yaml is the source of truth. The LIDAR_ENABLED env var
     # (installer / compose .env) is a FALLBACK ONLY — it applies when the
@@ -169,16 +175,13 @@ def generate_launch_description() -> LaunchDescription:
     # nav2_params_base.yaml + the lidar/no-lidar overlay; nothing here loads them.)
     monitoring_params = os.path.join(monitoring_dir, "config", "diagnostics.yaml")
     mqtt_params = os.path.join(monitoring_dir, "config", "mqtt_bridge.yaml")
-    # Robot-specific config (bind-mounted from mowgli-docker/config/mowgli/)
-    robot_config = "/ros2_ws/config/mowgli_robot.yaml"
 
-    # Load robot config to extract mowgli parameters for nodes that need
-    # explicit values (e.g. navsat_to_absolute_pose needs datum from mowgli).
-    robot_params = {}
-    if os.path.isfile(robot_config):
-        with open(robot_config, "r") as f:
-            robot_config_yaml = yaml.safe_load(f) or {}
-        robot_params = robot_config_yaml.get("mowgli", {}).get("ros__parameters", {})
+    # Robot parameters for nodes that need explicit values (e.g.
+    # navsat_to_absolute_pose needs the datum). Merged params = in-package
+    # template defaults with the installed sparse config layered on top, so a
+    # key the installed config omits falls through to its versioned template
+    # default (single source of truth).
+    robot_params = load_robot_params(bringup_dir, _runtime_cfg_path)
 
     # ------------------------------------------------------------------
     # 1. mowgli.launch.py — hardware bridge, RSP, twist_mux

--- a/ros2/src/mowgli_bringup/launch/mowgli.launch.py
+++ b/ros2/src/mowgli_bringup/launch/mowgli.launch.py
@@ -27,8 +27,8 @@ Brings up:
 """
 
 import os
+import sys
 
-import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -41,6 +41,12 @@ from launch.substitutions import (
 from launch_ros.actions import Node
 from launch_ros.descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
+
+# Shared robot-config loader (sibling module installed alongside this launch
+# file). Deep-merges the SPARSE installed mowgli_robot.yaml over the in-package
+# template defaults, so a missing key falls through to its versioned default.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from robot_config_util import load_robot_params  # noqa: E402
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -73,15 +79,11 @@ def generate_launch_description() -> LaunchDescription:
     # ------------------------------------------------------------------
     # Robot config (mowgli_robot.yaml)
     # ------------------------------------------------------------------
-    # Try the Docker-mounted config first, fall back to the in-package default.
-    robot_config_path = "/ros2_ws/config/mowgli_robot.yaml"
-    if not os.path.isfile(robot_config_path):
-        robot_config_path = os.path.join(bringup_dir, "config", "mowgli_robot.yaml")
-
-    with open(robot_config_path, "r") as f:
-        robot_config_yaml = yaml.safe_load(f) or {}
-
-    robot_params = robot_config_yaml.get("mowgli", {}).get("ros__parameters", {})
+    # Merged params = in-package template defaults with the installed sparse
+    # config layered on top (robot_config_util.load_robot_params). A key the
+    # installed config omits falls through to its versioned template default;
+    # a missing installed file yields the pure template. Single source of truth.
+    robot_params = load_robot_params(bringup_dir, "/ros2_ws/config/mowgli_robot.yaml")
 
     # ------------------------------------------------------------------
     # URDF / xacro

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -46,6 +46,7 @@ Architecture (REP-105):
 """
 
 import os
+import sys
 
 import yaml
 from ament_index_python.packages import get_package_prefix, get_package_share_directory
@@ -63,6 +64,12 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node, SetParameter
 from nav2_common.launch import RewrittenYaml
+
+# Shared robot-config loader (sibling module installed alongside this launch
+# file). Deep-merges the SPARSE installed mowgli_robot.yaml over the in-package
+# template defaults, so a missing key falls through to its versioned default.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from robot_config_util import load_robot_params  # noqa: E402
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -93,30 +100,30 @@ def generate_launch_description() -> LaunchDescription:
     # can disable per-site (e.g. cradles where GPS only Floats) to fall back
     # to the legacy graph-TF approach.
     _early_use_gps_dock_detection = "true"
-    if os.path.isfile(_runtime_cfg_path):
-        try:
-            with open(_runtime_cfg_path, "r") as _f:
-                _cfg = yaml.safe_load(_f) or {}
-            _rp = _cfg.get("mowgli", {}).get("ros__parameters", {})
-            # The yaml key is `lidar_enabled` (matches install
-            # template + GUI). The launch CLI arg is still
-            # `use_lidar:=true|false` so existing CI / dev scripts
-            # don't break.
-            if "lidar_enabled" in _rp:
-                _early_use_lidar = "true" if bool(_rp["lidar_enabled"]) else "false"
-                _lidar_from_yaml = True
-            _early_use_magnetometer = "true" if bool(
-                _rp.get("use_magnetometer", False)) else "false"
-            _early_use_scan_matching = "true" if bool(
-                _rp.get("use_scan_matching", False)) else "false"
-            _early_use_loop_closure = "true" if bool(
-                _rp.get("use_loop_closure", False)) else "false"
-            _early_fusion_graph_period = str(
-                float(_rp.get("fusion_graph_node_period_s", 0.04)))
-            _early_use_gps_dock_detection = "true" if bool(
-                _rp.get("use_gps_dock_detection", True)) else "false"
-        except yaml.YAMLError:
-            pass
+    # Merged params = in-package template defaults with the installed sparse
+    # config layered on top (robot_config_util.load_robot_params). INSTALL-
+    # DECIDED keys (e.g. lidar_enabled) live ONLY in the installed config and
+    # are absent from the template, so their PRESENCE in _rp still signals an
+    # explicit operator choice (env-var fallback preserved); DEFAULT toggles
+    # (use_magnetometer / use_scan_matching / …) fall through to the template
+    # value when the installed config omits them.
+    _rp = load_robot_params(bringup_dir, _runtime_cfg_path)
+    if "lidar_enabled" in _rp:
+        # The yaml key is `lidar_enabled` (matches install template + GUI). The
+        # launch CLI arg is still `use_lidar:=true|false` so existing CI / dev
+        # scripts don't break.
+        _early_use_lidar = "true" if bool(_rp["lidar_enabled"]) else "false"
+        _lidar_from_yaml = True
+    _early_use_magnetometer = "true" if bool(
+        _rp.get("use_magnetometer", False)) else "false"
+    _early_use_scan_matching = "true" if bool(
+        _rp.get("use_scan_matching", False)) else "false"
+    _early_use_loop_closure = "true" if bool(
+        _rp.get("use_loop_closure", False)) else "false"
+    _early_fusion_graph_period = str(
+        float(_rp.get("fusion_graph_node_period_s", 0.04)))
+    _early_use_gps_dock_detection = "true" if bool(
+        _rp.get("use_gps_dock_detection", True)) else "false"
 
     # LIDAR_ENABLED env var is a FALLBACK ONLY — it applies only when the yaml
     # does NOT set lidar_enabled. The GUI-managed yaml is authoritative when
@@ -242,11 +249,10 @@ def generate_launch_description() -> LaunchDescription:
     # of this launch always read the package template, which silently
     # diverged from the URDF (mowgli.launch.py uses the runtime path)
     # and gave Nav2 a footprint that did not match the actual robot.
-    runtime_config = "/ros2_ws/config/mowgli_robot.yaml"
-    template_config = os.path.join(bringup_dir, "config", "mowgli_robot.yaml")
-    robot_config_file = (
-        runtime_config if os.path.isfile(runtime_config) else template_config
-    )
+    # Merged params (template defaults + installed sparse overrides) — chassis
+    # geometry lives in the template, so the footprint is correct even when the
+    # installed config omits the dimensions (they are not install-decided).
+    rp = load_robot_params(bringup_dir, "/ros2_ws/config/mowgli_robot.yaml")
     footprint_str = ""
     # Physical chassis width default — overwritten from the robot config below
     # when present. Hoisted here so it is always defined for the chassis_safety_inset
@@ -262,10 +268,7 @@ def generate_launch_description() -> LaunchDescription:
     # frame; it is 0 on this stack but kept general.
     lidar_height_m = 0.22
     lidar_mount_yaw = 0.0
-    if os.path.isfile(robot_config_file):
-        with open(robot_config_file, "r") as f:
-            rcfg = yaml.safe_load(f) or {}
-        rp = rcfg.get("mowgli", {}).get("ros__parameters", {})
+    if rp:
         lidar_height_m = float(rp.get("lidar_z", lidar_height_m))
         lidar_mount_yaw = float(rp.get("lidar_yaw", 0.0)) - float(rp.get("imu_yaw", 0.0))
         cl = float(rp.get("chassis_length", 0.54))
@@ -428,10 +431,15 @@ def generate_launch_description() -> LaunchDescription:
     min_horizontal_uT = 5.0
     mag_yaw_variance = 0.0027
     runtime_robot_config = "/ros2_ws/config/mowgli_robot.yaml"
-    if os.path.isfile(runtime_robot_config):
-        with open(runtime_robot_config, "r") as f:
-            rt_cfg = yaml.safe_load(f) or {}
-        rt_rp = rt_cfg.get("mowgli", {}).get("ros__parameters", {})
+    # Merged params: in-package template defaults with the installed sparse
+    # config layered on top. Every rt_rp.get(key, <fallback>) below therefore
+    # resolves to the TEMPLATE default when the installed config omits the key,
+    # so the inline fallbacks are now belt-and-suspenders (kept only to survive
+    # a template that is itself missing a key). This is the single-source-of-
+    # truth behaviour: a maintainer changing a template default reaches every
+    # robot whose sparse config does not explicitly override it.
+    rt_rp = load_robot_params(bringup_dir, runtime_robot_config)
+    if rt_rp:
         dock_pose_x = float(rt_rp.get("dock_pose_x", 0.0))
         dock_pose_y = float(rt_rp.get("dock_pose_y", 0.0))
         dock_pose_yaw = float(rt_rp.get("dock_pose_yaw", 0.0))

--- a/ros2/src/mowgli_bringup/launch/robot_config_util.py
+++ b/ros2/src/mowgli_bringup/launch/robot_config_util.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2026 Cedric <cedric@mowgli.dev>
+#
+# Shared robot-config loader for the MowgliNext launch files.
+#
+# The INSTALLED mowgli_robot.yaml (at /ros2_ws/config/mowgli_robot.yaml) is
+# SPARSE: it holds only what is decided at install time or calibrated per site
+# (datum, NTRIP credentials, dock pose, hardware selections, calibration
+# paths). Every other parameter's DEFAULT lives in the in-package template
+# config/mowgli_robot.yaml, which is versioned and ships with the software.
+#
+# load_robot_params() DEEP-MERGES the installed sparse config OVER the package
+# template, so:
+#   * defaults come from the template — a maintainer bumping a default
+#     propagates to every robot whose installed config does not override it;
+#   * a key ABSENT from the installed config falls through to the template
+#     default — this is exactly how the GUI's "reset to default" works
+#     (it deletes the key from the installed file);
+#   * an install/site decision or an explicit GUI override still wins.
+#
+# Nodes therefore always receive a COMPLETE parameter set, exactly as before
+# the split — only the on-disk installed file is now allowed to be sparse.
+# Older FULL installed configs keep working unchanged (every key overrides its
+# identical template default; a no-op merge).
+
+import os
+
+import yaml
+
+DEFAULT_RUNTIME_PATH = "/ros2_ws/config/mowgli_robot.yaml"
+
+
+def _deep_merge(base, override):
+    """Recursively merge ``override`` into a copy of ``base`` (override wins).
+
+    Only dict-vs-dict collisions recurse; any scalar/list in ``override``
+    replaces the base value wholesale (robot params are flat scalars, so this
+    is just the nested ros__parameters block being merged key-by-key).
+    """
+    out = dict(base)
+    for key, value in (override or {}).items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def load_robot_config(bringup_dir, runtime_path=DEFAULT_RUNTIME_PATH):
+    """Return the merged full mowgli_robot config dict (template <- runtime).
+
+    ``bringup_dir`` is the mowgli_bringup share directory
+    (get_package_share_directory("mowgli_bringup")).
+    """
+    template_path = os.path.join(bringup_dir, "config", "mowgli_robot.yaml")
+    template = {}
+    if os.path.isfile(template_path):
+        with open(template_path, "r") as handle:
+            template = yaml.safe_load(handle) or {}
+    runtime = {}
+    if os.path.isfile(runtime_path):
+        with open(runtime_path, "r") as handle:
+            runtime = yaml.safe_load(handle) or {}
+    return _deep_merge(template, runtime)
+
+
+def load_robot_params(bringup_dir, runtime_path=DEFAULT_RUNTIME_PATH):
+    """Return the merged mowgli.ros__parameters dict the launch files inject.
+
+    Always complete: every template key is present, with installed-config
+    values layered on top. Missing runtime file -> pure template defaults.
+    """
+    cfg = load_robot_config(bringup_dir, runtime_path)
+    return cfg.get("mowgli", {}).get("ros__parameters", {})

--- a/ros2/src/mowgli_bringup/test/test_robot_config_util.py
+++ b/ros2/src/mowgli_bringup/test/test_robot_config_util.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Mowgli Project
+# SPDX-License-Identifier: GPL-3.0
+#
+# Unit tests for robot_config_util.load_robot_params — the deep-merge that
+# lets the INSTALLED mowgli_robot.yaml be sparse (install choices + calibration
+# outputs only) while every other default falls through to the in-package
+# template. These run without any ROS deps — only PyYAML is required.
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+# mowgli_bringup package root: test/ -> package dir; the template lives at
+# <pkg>/config/mowgli_robot.yaml and the helper at <pkg>/launch/.
+_PKG_DIR = Path(__file__).resolve().parent.parent
+_LAUNCH_DIR = _PKG_DIR / "launch"
+_TEMPLATE_PATH = _PKG_DIR / "config" / "mowgli_robot.yaml"
+
+
+def _load_helper():
+    """Import robot_config_util.py directly from the launch dir (no ROS)."""
+    sys.path.insert(0, str(_LAUNCH_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "robot_config_util", str(_LAUNCH_DIR / "robot_config_util.py"))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_util = _load_helper()
+load_robot_params = _util.load_robot_params
+
+
+def _template_params() -> dict:
+    with open(_TEMPLATE_PATH, "r") as handle:
+        doc = yaml.safe_load(handle) or {}
+    return doc.get("mowgli", {}).get("ros__parameters", {})
+
+
+def _write_sparse(params: dict) -> str:
+    """Write a sparse runtime config to a temp file, return its path."""
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", prefix="test_robot_cfg_", suffix=".yaml", delete=False)
+    yaml.safe_dump({"mowgli": {"ros__parameters": params}}, tmp)
+    tmp.close()
+    return tmp.name
+
+
+def test_template_only_returns_full_defaults():
+    """A nonexistent runtime path yields the pure template defaults."""
+    template = _template_params()
+    assert template, "template must be non-empty for this test to mean anything"
+
+    merged = load_robot_params(
+        str(_PKG_DIR), runtime_path="/nonexistent/mowgli_robot.yaml")
+    assert merged == template
+
+
+def test_sparse_overrides_and_falls_through():
+    """Sparse runtime overrides its own keys; absent keys use the template."""
+    template = _template_params()
+    # Pick a key present in the template to override.
+    assert "ticks_per_meter" in template
+    original = template["ticks_per_meter"]
+    override_val = float(original) + 111.0
+
+    path = _write_sparse({
+        "ticks_per_meter": override_val,
+        "datum_lat": 48.123456,
+        # An install-decided key that is ABSENT from the template — it must
+        # still surface (and its presence is what launch files test for).
+        "lidar_enabled": False,
+    })
+    try:
+        merged = load_robot_params(str(_PKG_DIR), runtime_path=path)
+    finally:
+        os.unlink(path)
+
+    # Overridden keys win.
+    assert merged["ticks_per_meter"] == override_val
+    assert merged["datum_lat"] == 48.123456
+    # Install-decided key surfaces even though the template lacks it.
+    assert "lidar_enabled" in merged
+    assert merged["lidar_enabled"] is False
+    # Untouched keys fall through to the template default.
+    for key, value in template.items():
+        if key in ("ticks_per_meter", "datum_lat"):
+            continue
+        assert merged[key] == value
+
+
+def test_removing_key_reverts_to_template_default():
+    """Reset-to-default: dropping a key from the sparse runtime reverts it."""
+    template = _template_params()
+    assert "ticks_per_meter" in template
+    default_val = template["ticks_per_meter"]
+
+    # Runtime that DOES override the key.
+    with_key = _write_sparse({"ticks_per_meter": float(default_val) + 55.0})
+    # Runtime that omits it entirely (simulates the GUI deleting the key).
+    without_key = _write_sparse({"datum_lat": 1.0})
+    try:
+        merged_with = load_robot_params(str(_PKG_DIR), runtime_path=with_key)
+        merged_without = load_robot_params(
+            str(_PKG_DIR), runtime_path=without_key)
+    finally:
+        os.unlink(with_key)
+        os.unlink(without_key)
+
+    assert merged_with["ticks_per_meter"] == float(default_val) + 55.0
+    # Key absent from runtime -> template default restored.
+    assert merged_without["ticks_per_meter"] == default_val
+
+
+def test_full_runtime_merges_to_itself():
+    """Backward compat: a FULL runtime config (every template key) is a no-op
+    merge — the merged result equals that full runtime for every template key."""
+    template = _template_params()
+    # Build a full runtime = template with every value bumped, so we can prove
+    # each one wins over the identical-key template default.
+    full = {}
+    for key, value in template.items():
+        if isinstance(value, bool):
+            full[key] = not value
+        elif isinstance(value, (int, float)):
+            full[key] = value + 1
+        else:
+            full[key] = value  # strings/lists kept as-is
+
+    path = _write_sparse(full)
+    try:
+        merged = load_robot_params(str(_PKG_DIR), runtime_path=path)
+    finally:
+        os.unlink(path)
+
+    for key in template:
+        assert merged[key] == full[key]


### PR DESCRIPTION
## Pourquoi

Aujourd'hui l'installeur copie un `mowgli_robot.yaml` **plein de valeurs par défaut**, donc : (a) l'utilisateur ne peut pas revenir à un défaut depuis la GUI, et (b) quand on change un défaut côté code, ça **ne se propage pas** aux robots déjà installés (leur config écrase le nouveau défaut).

## Le modèle après

- **Les défauts vivent dans le template package** (`mowgli_bringup/config/mowgli_robot.yaml`, versionné).
- **Le config installé est SPARSE** : uniquement les décisions d'install (Bucket A : datum, NTRIP, lidar_enabled, matériel GNSS, mower_model) + les résultats de calibration (Bucket B : dock_pose, ticks_per_meter, wheel_pid, imu_yaw, mag).
- Un helper de launch **deep-merge** (installé par-dessus template). Clé absente → défaut du template. **Reset-to-default = suppression de la clé.** Un maintainer qui change un défaut → ça atteint tous les robots qui ne l'ont pas explicitement override.

## Contenu

**ROS2 launch :** `robot_config_util.load_robot_params` (deep-merge), câblé dans navigation/full_system/mowgli. Config installé réécrit sparse (25 clés). `test_robot_config_util.py` verrouille les invariants (défauts / override / reset-par-suppression / rétro-compat config plein).

**GUI reset-to-default :**
- Source des défauts = le schéma JSON (le backend GUI ne peut pas lire le template ROS2 cross-conteneur). **J'ai réconcilié les 12 défauts du schéma qui avaient dérivé du template** (mowing_speed 0.3→0.2, ticks_per_meter 300→399, ntrip_enabled true→false, min_turning_radius 0.05→0.15…) — sans ça le sparse-write ramènerait silencieusement un réglage utilisateur au template.
- `settings.go` : **sparse-write** (élague toute clé == défaut) + endpoint `GET /settings/yaml/defaults`.
- Frontend : `useSettingsManager` expose `defaults/isOverridden/resetToDefault` ; nouveau `SettingFieldLabel` (point « override » + bouton reset). Câblé dans Navigation + Mowing.

## Validé
- `go test ./pkg/api/` vert ; `test_robot_config_util` 4/4 ; les 3 launch parsent.
- Rétro-compat : un ancien config PLEIN merge à lui-même (aucune surprise).

## Suivi (mécanique)
- Câbler le bouton reset dans les 12 sections restantes (même pattern `SettingFieldLabel`).
- i18n des libellés reset.