### PR TITLE
fix(ci): migrate Claude workflows to claude-code-action v1 auth/inputs

### DIFF
--- a/.github/workflows/claude-improve.yml
+++ b/.github/workflows/claude-improve.yml
@@ -56,9 +56,9 @@ jobs:
         id: analysis
         uses: anthropics/claude-code-action@v1
         with:
-          model: claude-sonnet-4-6
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
             You are a robotics software architect reviewing the MowgliNext project — an open-source ROS2 autonomous robot mower.
 
             Analyze the current state of the project and propose 2-3 concrete improvements.
@@ -66,55 +66,37 @@ jobs:
             Context:
             ${{ steps.context.outputs.data }}
 
-            For each proposal, output EXACTLY this format (the workflow will parse it):
-
-            ---PROPOSAL---
-            TITLE: <concise issue title with conventional prefix like feat: or fix: or refactor:>
-            LABELS: <comma-separated labels from: ros2, gui, firmware, docker, sensors, docs, ci, enhancement, bug>
-            BODY:
-            <markdown body with:
-            ## Motivation
-            Why this matters
-
-            ## Proposed Approach
-            How to implement it
-
-            ## Effort Estimate
-            Small / Medium / Large
-
-            🤖 *Proposed by Claude — review and discuss before implementing*
-            >
-            ---END---
-
             Rules:
             - Only propose things that are NOT already covered by open issues
             - Focus on safety, reliability, developer experience, or community growth
             - Be specific and actionable — no vague "improve testing" suggestions
             - Consider the project is a real robot mower that runs outdoors
-          timeout_minutes: 5
+
+            Return a `proposals` array (at most 3; empty if nothing is worth proposing).
+            For each proposal provide:
+            - title: concise issue title with a conventional prefix (feat:, fix:, refactor:)
+            - labels: array chosen from [ros2, gui, firmware, docker, sensors, docs, ci, enhancement, bug]
+            - body: markdown with sections "## Motivation", "## Proposed Approach", and
+              "## Effort Estimate" (Small / Medium / Large), ending with the line
+              "🤖 *Proposed by Claude — review and discuss before implementing*"
+          claude_args: |
+            --model claude-sonnet-4-6
+            --json-schema '{"type":"object","properties":{"proposals":{"type":"array","maxItems":3,"items":{"type":"object","properties":{"title":{"type":"string"},"labels":{"type":"array","items":{"type":"string"}},"body":{"type":"string"}},"required":["title","body"]}}},"required":["proposals"]}'
 
       - name: Create issues from proposals
-        if: steps.analysis.outputs.result != ''
-        run: |
-          echo '${{ steps.analysis.outputs.result }}' | \
-          awk '/---PROPOSAL---/{found=1; next} /---END---/{found=0; if(title && body) print title "\t" labels "\t" body; title=""; labels=""; body=""} found{
-            if(/^TITLE: /){title=substr($0,8)}
-            else if(/^LABELS: /){labels=substr($0,9)}
-            else if(/^BODY:/){inbody=1}
-            else if(inbody){body=body"\n"$0}
-          }' | while IFS=$'\t' read -r title labels body; do
-            if [ -n "$title" ]; then
-              LABEL_ARGS=""
-              IFS=',' read -ra LABEL_ARRAY <<< "$labels"
-              for label in "${LABEL_ARRAY[@]}"; do
-                label=$(echo "$label" | xargs)
-                LABEL_ARGS="$LABEL_ARGS --label $label"
-              done
-              echo "$body" | gh issue create \
-                --title "$title" \
-                $LABEL_ARGS \
-                --body-file - 2>/dev/null || echo "Failed to create: $title"
-            fi
-          done
+        if: steps.analysis.outputs.structured_output != ''
         env:
+          STRUCTURED_OUTPUT: ${{ steps.analysis.outputs.structured_output }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$STRUCTURED_OUTPUT" | jq -c '.proposals[]?' | while read -r proposal; do
+            title=$(printf '%s' "$proposal" | jq -r '.title')
+            [ -z "$title" ] && continue
+            label_args=()
+            while IFS= read -r label; do
+              [ -n "$label" ] && label_args+=(--label "$label")
+            done < <(printf '%s' "$proposal" | jq -r '.labels[]?')
+            printf '%s' "$proposal" | jq -r '.body' | \
+              gh issue create --title "$title" "${label_args[@]}" --body-file - \
+              || echo "Failed to create: $title"
+          done

--- a/.github/workflows/wiki-update.yml
+++ b/.github/workflows/wiki-update.yml
@@ -26,7 +26,8 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -37,10 +38,9 @@ jobs:
       - name: Generate wiki updates
         uses: anthropics/claude-code-action@v1
         with:
-          model: claude-sonnet-4-6
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          timeout_minutes: 15
-          direct_prompt: |
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
             You are updating the MowgliNext wiki to reflect the changes in this PR.
 
             1. Run `git diff origin/main...HEAD` to see what changed in this PR.
@@ -62,15 +62,9 @@ jobs:
             Do NOT create new wiki pages unless a major new feature warrants it.
             Do NOT update wiki pages just for minor bug fixes, dependency bumps, or CI tweaks.
             Focus on changes that affect how users interact with the project.
-          allowed_tools: |
-            Read
-            Write
-            Edit
-            Bash(git log:*)
-            Bash(git diff:*)
-            Bash(git show:*)
-            Glob
-            Grep
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "Read,Write,Edit,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Glob,Grep"
 
       - name: Commit wiki updates to PR branch
         env:


### PR DESCRIPTION
## Problem

Two Claude workflows were broken after the move to `anthropics/claude-code-action@v1`:

- **Suggest Wiki Updates** (`wiki-update.yml`) — **failed on every PR event** with:
  ```
  App token exchange failed: 401 Unauthorized - Invalid OIDC token
  ##[error]Action failed with error: Invalid OIDC token
  ```
  The action's OIDC → GitHub App token exchange is rejected in `pull_request`/`pull_request_target` contexts (it works for `schedule`/`workflow_dispatch` on `main`, which is why `claude-improve` looked green).

- **Propose Improvements** (`claude-improve.yml`) — reported *success* but was a **silent no-op**: `direct_prompt` is ignored in v1 (empty prompt) and the workflow read `steps.analysis.outputs.result`, which no longer exists in v1 (outputs are now `conclusion` / `execution_file` / `structured_output` / `session_id`).

## Fix

Per the [action docs](https://github.com/anthropics/claude-code-action/blob/main/CLAUDE.md), a user-provided `github_token` **takes precedence over the default GitHub App OIDC token**, and `claude_code_oauth_token` is only for the Claude API — not GitHub auth.

**`wiki-update.yml`**
- ➕ `github_token: ${{ secrets.GITHUB_TOKEN }}` → bypasses the failing OIDC exchange
- `direct_prompt:` → `prompt:` (v0 input was silently ignored)
- `model:` + `allowed_tools:` → `claude_args` (`--model` / `--allowedTools`)
- removed `timeout_minutes:` (no v1 equivalent)
- `if:` now skips `dependabot[bot]` (its runs can't see the secrets, and the prompt already excludes dependency bumps from wiki updates)

**`claude-improve.yml`**
- `prompt:` + `claude_args:` (`--model`, `--json-schema` for a `proposals` array)
- consumes `structured_output` via `jq` instead of the removed `result` output
- passes `github_token`; reads `structured_output` through an `env` var (no inline `${{ }}` interpolation in `run:`)

## Notes / testing

`pull_request_target` always uses the workflow definition from the **base branch**, so `wiki-update`'s fix only takes effect for PRs opened **after** this merges to `main`. Both files pass YAML validation. The other 15 workflows were reviewed and are healthy; the one-off `pages.yml` failure was a transient GitHub Pages API hiccup (re-run is green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)