### PR TITLE
feat(obstacles): operator-tunable avoidance margins + GUI Obstacles section

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -617,12 +617,6 @@
           "default": 40.0,
           "description": "Resume blade below this motor temperature (C)."
         },
-        "max_obstacle_avoidance_distance": {
-          "type": "number",
-          "title": "Max Obstacle Detour",
-          "default": 2.0,
-          "description": "Maximum detour distance around obstacles (metres)."
-        },
         "lift_blade_resume_delay_sec": {
           "type": "number",
           "title": "Lift Blade Resume Delay",
@@ -634,6 +628,36 @@
           "title": "Lift Recovery Mode",
           "default": false,
           "description": "Allow autonomous resume after a lift event (default: stay stopped until operator ack)."
+        }
+      }
+    },
+    "obstacle_settings": {
+      "title": "Obstacles",
+      "type": "object",
+      "properties": {
+        "obstacle_inflation_radius": {
+          "type": "number",
+          "title": "Obstacle Inflation Radius",
+          "default": 0.6,
+          "description": "Buffer (m) kept around LiDAR-detected obstacles in the local costmap. Raise if the robot passes too close to trees it can see. Clamped to [0.58, 1.5] at launch."
+        },
+        "max_obstacle_avoidance_distance": {
+          "type": "number",
+          "title": "Max Obstacle Detour",
+          "default": 2.0,
+          "description": "Maximum lateral detour (m) around obstacles — drives both the coverage controller's skirting and the bypass give-up threshold."
+        },
+        "obstacle_margin": {
+          "type": "number",
+          "title": "Drawn Obstacle Margin",
+          "default": 0.0,
+          "description": "Extra margin (m) around obstacles drawn on the map, applied to both coverage and transit planning. Draw a tree trunk and set this to cover its roots (invisible to the 2D LiDAR)."
+        },
+        "obstacle_slowdown_ratio": {
+          "type": "number",
+          "title": "Approach Slowdown Ratio",
+          "default": 0.3,
+          "description": "Speed factor when a scan return enters the chassis+15 cm approach box (LiDAR variant). 0.3 = slow to 30% of commanded speed."
         }
       }
     },

--- a/gui/web/src/components/settings/ObstaclesSection.tsx
+++ b/gui/web/src/components/settings/ObstaclesSection.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Alert, Card, Col, Form, InputNumber, Row, Typography } from "antd";
+import { useTranslation } from "react-i18next";
+import { SettingFieldLabel } from "./SettingFieldLabel.tsx";
+
+const { Paragraph } = Typography;
+
+type Props = {
+    values: Record<string, any>;
+    onChange: (key: string, value: any) => void;
+    isOverridden?: (key: string) => boolean;
+    hasDefault?: (key: string) => boolean;
+    onReset?: (key: string) => void;
+};
+
+/**
+ * Obstacles section — operator-tunable obstacle-avoidance margins:
+ *   - obstacle_inflation_radius: local-costmap buffer around LiDAR-seen
+ *     obstacles (trunks, legs, walls),
+ *   - max_obstacle_avoidance_distance: max lateral detour for coverage
+ *     skirting + bypass give-up threshold (one knob, two consumers),
+ *   - obstacle_margin: extra margin grown around DRAWN map obstacles in both
+ *     coverage and transit planning (root zones the 2D LiDAR cannot see),
+ *   - obstacle_slowdown_ratio: collision_monitor approach slowdown factor.
+ * All keys live in mowgli_robot.yaml (sparse over template) and are injected
+ * into Nav2/coverage params at launch — changes need a ROS2 restart.
+ */
+export const ObstaclesSection: React.FC<Props> = ({
+    values,
+    onChange,
+    isOverridden,
+    hasDefault,
+    onReset,
+}) => {
+    const { t } = useTranslation();
+    const fieldLabel = (key: string, label: React.ReactNode) => (
+        <SettingFieldLabel
+            settingKey={key}
+            label={label}
+            overridden={isOverridden?.(key) ?? false}
+            canReset={hasDefault?.(key) ?? false}
+            onReset={onReset}
+        />
+    );
+
+    return (
+        <div>
+            <Alert
+                type="info"
+                showIcon
+                message={t("settingsObstacles.rootZoneHintTitle")}
+                description={t("settingsObstacles.rootZoneHintDescription")}
+                style={{ marginBottom: 16 }}
+            />
+
+            {/* Avoidance margins */}
+            <Card size="small" title={t("settingsObstacles.avoidanceMargins")} style={{ marginBottom: 16 }}>
+                <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 12 }}>
+                    {t("settingsObstacles.avoidanceMarginsDescription")}
+                </Paragraph>
+                <Form layout="vertical" size="small">
+                    <Row gutter={[16, 0]}>
+                        <Col xs={12} sm={8}>
+                            <Form.Item
+                                label={fieldLabel("obstacle_inflation_radius", t("settingsObstacles.inflationRadius"))}
+                                tooltip={t("settingsObstacles.inflationRadiusTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.obstacle_inflation_radius}
+                                    onChange={(v) => onChange("obstacle_inflation_radius", v)}
+                                    min={0.58} max={1.5} step={0.05} precision={2}
+                                    style={{ width: "100%" }} addonAfter="m"
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col xs={12} sm={8}>
+                            <Form.Item
+                                label={fieldLabel("max_obstacle_avoidance_distance", t("settingsObstacles.maxDetourDistance"))}
+                                tooltip={t("settingsObstacles.maxDetourDistanceTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.max_obstacle_avoidance_distance}
+                                    onChange={(v) => onChange("max_obstacle_avoidance_distance", v)}
+                                    min={0.5} max={10} step={0.5} precision={1}
+                                    style={{ width: "100%" }} addonAfter="m"
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col xs={12} sm={8}>
+                            <Form.Item
+                                label={fieldLabel("obstacle_margin", t("settingsObstacles.drawnObstacleMargin"))}
+                                tooltip={t("settingsObstacles.drawnObstacleMarginTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.obstacle_margin}
+                                    onChange={(v) => onChange("obstacle_margin", v)}
+                                    min={0} max={1} step={0.05} precision={2}
+                                    style={{ width: "100%" }} addonAfter="m"
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Form>
+            </Card>
+
+            {/* Approach slowdown */}
+            <Card size="small" title={t("settingsObstacles.approachSlowdown")} style={{ marginBottom: 16 }}>
+                <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 12 }}>
+                    {t("settingsObstacles.approachSlowdownDescription")}
+                </Paragraph>
+                <Form layout="vertical" size="small">
+                    <Row gutter={[16, 0]}>
+                        <Col xs={12} sm={8}>
+                            <Form.Item
+                                label={fieldLabel("obstacle_slowdown_ratio", t("settingsObstacles.slowdownRatio"))}
+                                tooltip={t("settingsObstacles.slowdownRatioTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.obstacle_slowdown_ratio}
+                                    onChange={(v) => onChange("obstacle_slowdown_ratio", v)}
+                                    min={0.05} max={1} step={0.05} precision={2}
+                                    style={{ width: "100%" }}
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Form>
+            </Card>
+        </div>
+    );
+};

--- a/gui/web/src/components/settings/SafetySection.tsx
+++ b/gui/web/src/components/settings/SafetySection.tsx
@@ -68,23 +68,9 @@ export const SafetySection: React.FC<Props> = ({ values, onChange }) => {
                 </Form>
             </Card>
 
-            {/* Obstacle avoidance */}
-            <Card size="small" title={t("settingsSafety.obstacleAvoidance")} style={{ marginBottom: 16 }}>
-                <Form layout="vertical" size="small">
-                    <Row gutter={[16, 0]}>
-                        <Col xs={12} sm={8}>
-                            <Form.Item label={t("settingsSafety.maxDetourDistance")} tooltip={t("settingsSafety.maxDetourDistanceTooltip")}>
-                                <InputNumber
-                                    value={values.max_obstacle_avoidance_distance}
-                                    onChange={(v) => onChange("max_obstacle_avoidance_distance", v)}
-                                    min={0.5} max={10} step={0.5} precision={1}
-                                    style={{ width: "100%" }} addonAfter="m"
-                                />
-                            </Form.Item>
-                        </Col>
-                    </Row>
-                </Form>
-            </Card>
+            {/* max_obstacle_avoidance_distance moved to the Obstacles
+                section (ObstaclesSection.tsx) alongside the other
+                obstacle-avoidance knobs. */}
         </div>
     );
 };

--- a/gui/web/src/components/settings/SettingsNav.tsx
+++ b/gui/web/src/components/settings/SettingsNav.tsx
@@ -14,6 +14,7 @@ import {
     ThunderboltOutlined,
     ToolOutlined,
     GlobalOutlined,
+    WarningOutlined,
     WifiOutlined,
 } from "@ant-design/icons";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
@@ -31,6 +32,7 @@ const SECTION_ICONS: Record<string, React.ReactNode> = {
     home: <HomeOutlined />,
     thunderbolt: <ThunderboltOutlined />,
     safety: <SafetyOutlined />,
+    warning: <WarningOutlined />,
     compass: <CompassOutlined />,
     cloud: <CloudOutlined />,
     code: <CodeOutlined />,

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -19,6 +19,7 @@ export type SettingsSection =
     | "docking"
     | "battery"
     | "safety"
+    | "obstacles"
     | "navigation"
     | "rain"
     | "advanced";
@@ -154,8 +155,17 @@ const SECTION_DEFINITIONS: SectionMeta[] = [
         description: "settingsSections.safety.description",
         keys: [
             "motor_temp_high_c", "motor_temp_low_c",
-            "max_obstacle_avoidance_distance",
             "lift_blade_resume_delay_sec", "lift_recovery_mode",
+        ],
+    },
+    {
+        id: "obstacles",
+        label: "settingsSections.obstacles.label",
+        icon: "warning",
+        description: "settingsSections.obstacles.description",
+        keys: [
+            "obstacle_inflation_radius", "max_obstacle_avoidance_distance",
+            "obstacle_margin", "obstacle_slowdown_ratio",
         ],
     },
     {

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2187,10 +2187,23 @@
     "stopAbove": "Stop Above",
     "stopAboveTooltip": "Stop blade motor above this temperature",
     "resumeBelow": "Resume Below",
-    "resumeBelowTooltip": "Resume blade motor below this temperature",
-    "obstacleAvoidance": "Obstacle Avoidance",
+    "resumeBelowTooltip": "Resume blade motor below this temperature"
+  },
+  "settingsObstacles": {
+    "rootZoneHintTitle": "Trees with large roots?",
+    "rootZoneHintDescription": "The 2D LiDAR cannot see roots below its scan plane (~10–20 cm). Draw the tree as an obstacle in the map editor and raise the drawn obstacle margin so mowing and transit keep off the root zone.",
+    "avoidanceMargins": "Avoidance Margins",
+    "avoidanceMarginsDescription": "How much distance the robot keeps from obstacles. Changes take effect after a ROS2 restart.",
+    "inflationRadius": "Obstacle Inflation Radius",
+    "inflationRadiusTooltip": "Buffer around LiDAR-detected obstacles (trunks, walls) in the local costmap. Raise if the robot passes too close to trees it can see.",
     "maxDetourDistance": "Max Detour Distance",
-    "maxDetourDistanceTooltip": "Maximum distance to detour around an obstacle before giving up"
+    "maxDetourDistanceTooltip": "Maximum lateral detour around an obstacle before giving up — drives both coverage skirting and the bypass give-up threshold",
+    "drawnObstacleMargin": "Drawn Obstacle Margin",
+    "drawnObstacleMarginTooltip": "Extra margin around obstacles drawn on the map, applied to both coverage and transit planning. Use for root zones invisible to the LiDAR.",
+    "approachSlowdown": "Approach Slowdown",
+    "approachSlowdownDescription": "The collision monitor slows the robot when a scan return enters the approach box around the chassis (LiDAR variant).",
+    "slowdownRatio": "Slowdown Ratio",
+    "slowdownRatioTooltip": "Speed factor near obstacles: 0.3 = slow to 30% of the commanded speed"
   },
   "settingsMowing": {
     "mowingMotor": "Mowing Motor",
@@ -2803,7 +2816,11 @@
     },
     "safety": {
       "label": "Safety",
-      "description": "Emergency stops, temperature limits, obstacle avoidance"
+      "description": "Emergency stops and temperature limits"
+    },
+    "obstacles": {
+      "label": "Obstacles",
+      "description": "Avoidance margins, drawn obstacle buffers, approach slowdown"
     },
     "navigation": {
       "label": "Navigation",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -2183,10 +2183,23 @@
     "stopAbove": "Arrêt au-dessus",
     "stopAboveTooltip": "Arrêter le moteur de lame au-dessus de cette température",
     "resumeBelow": "Reprise en dessous",
-    "resumeBelowTooltip": "Reprendre le moteur de lame en dessous de cette température",
-    "obstacleAvoidance": "Évitement d'obstacles",
+    "resumeBelowTooltip": "Reprendre le moteur de lame en dessous de cette température"
+  },
+  "settingsObstacles": {
+    "rootZoneHintTitle": "Arbres avec de grosses racines ?",
+    "rootZoneHintDescription": "Le LiDAR 2D ne voit pas les racines sous son plan de scan (~10–20 cm). Dessinez l'arbre comme obstacle dans l'éditeur de carte et augmentez la marge des obstacles dessinés pour que la tonte et les transits restent hors de la zone de racines.",
+    "avoidanceMargins": "Marges d'évitement",
+    "avoidanceMarginsDescription": "Distance que le robot conserve vis-à-vis des obstacles. Les changements prennent effet après un redémarrage ROS2.",
+    "inflationRadius": "Rayon d'inflation obstacles",
+    "inflationRadiusTooltip": "Tampon autour des obstacles détectés au LiDAR (troncs, murs) dans le costmap local. Augmentez si le robot passe trop près des arbres qu'il voit.",
     "maxDetourDistance": "Distance max de détour",
-    "maxDetourDistanceTooltip": "Distance maximale de détour autour d'un obstacle avant d'abandonner"
+    "maxDetourDistanceTooltip": "Détour latéral maximal autour d'un obstacle avant d'abandonner — pilote l'évitement en tonte et le seuil d'abandon du contournement",
+    "drawnObstacleMargin": "Marge des obstacles dessinés",
+    "drawnObstacleMarginTooltip": "Marge supplémentaire autour des obstacles dessinés sur la carte, appliquée à la tonte et aux transits. À utiliser pour les zones de racines invisibles au LiDAR.",
+    "approachSlowdown": "Ralentissement à l'approche",
+    "approachSlowdownDescription": "Le moniteur de collision ralentit le robot quand un retour de scan entre dans la boîte d'approche autour du châssis (variante LiDAR).",
+    "slowdownRatio": "Facteur de ralentissement",
+    "slowdownRatioTooltip": "Facteur de vitesse près des obstacles : 0,3 = ralentir à 30 % de la vitesse commandée"
   },
   "settingsMowing": {
     "mowingMotor": "Moteur de tonte",
@@ -2799,7 +2812,11 @@
     },
     "safety": {
       "label": "Sécurité",
-      "description": "Arrêts d'urgence, limites de température, évitement d'obstacles"
+      "description": "Arrêts d'urgence et limites de température"
+    },
+    "obstacles": {
+      "label": "Obstacles",
+      "description": "Marges d'évitement, tampons des obstacles dessinés, ralentissement à l'approche"
     },
     "navigation": {
       "label": "Navigation",

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -24,6 +24,7 @@ import { MowingSection } from "../components/settings/MowingSection.tsx";
 import { DockingSection } from "../components/settings/DockingSection.tsx";
 import { BatterySection } from "../components/settings/BatterySection.tsx";
 import { SafetySection } from "../components/settings/SafetySection.tsx";
+import { ObstaclesSection } from "../components/settings/ObstaclesSection.tsx";
 import { NavigationSection } from "../components/settings/NavigationSection.tsx";
 import { RainSection } from "../components/settings/RainSection.tsx";
 import { AdvancedSection } from "../components/settings/AdvancedSection.tsx";
@@ -158,6 +159,16 @@ export const SettingsPage = () => {
                 return <BatterySection values={values} onChange={handleChange} />;
             case "safety":
                 return <SafetySection values={values} onChange={handleChange} />;
+            case "obstacles":
+                return (
+                    <ObstaclesSection
+                        values={values}
+                        onChange={handleChange}
+                        isOverridden={isOverridden}
+                        hasDefault={hasDefault}
+                        onReset={resetToDefault}
+                    />
+                );
             case "navigation":
                 return (
                     <NavigationSection

--- a/ros2/scripts/check_config_drift.py
+++ b/ros2/scripts/check_config_drift.py
@@ -101,6 +101,7 @@ USER_OVERRIDE = {
     "outline_offset", "outline_overlap", "outline_passes",
     "path_spacing", "mow_angle_offset_deg", "mow_angle_increment_deg",
     "max_obstacle_avoidance_distance", "coverage_xy_tolerance",
+    "obstacle_inflation_radius", "obstacle_margin", "obstacle_slowdown_ratio",
     "xy_goal_tolerance", "yaw_goal_tolerance",
     "progress_timeout_sec",
     "motor_temp_low_c", "motor_temp_high_c",

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -308,7 +308,39 @@ mowgli:
     motor_temp_high_c: 80.0        # stop blade if motor exceeds
     motor_temp_low_c: 40.0         # resume blade below this
     # Lift/tilt emergency is handled by firmware (STM32), not ROS2
-    max_obstacle_avoidance_distance: 2.0  # how far to deviate from path
+
+    # -----------------------------------------------------------------
+    # Obstacles (GUI: Settings → Obstacles)
+    # -----------------------------------------------------------------
+    # How far the robot may deviate laterally from its path to skirt an
+    # obstacle. ONE knob, TWO consumers (injected at launch):
+    #   - FTCController max_lateral_deviation (coverage-time skirting)
+    #   - map_server bypass_max_length (give-up threshold for the mow-progress
+    #     bypass corridor)
+    # Clamped to [0.5, 10.0] by navigation.launch.py.
+    max_obstacle_avoidance_distance: 2.0
+    # Inflation radius (m) around LiDAR-detected obstacles in the LOCAL
+    # costmap — the buffer FTC/RPP keep from trunks, legs, walls seen by the
+    # scan. Injected into local_costmap.inflation_layer.inflation_radius.
+    # Clamped to [0.58, 1.50]: the nav2 inflation layer degrades
+    # footprint-cost semantics below the chassis circumscribed radius
+    # (~0.572 m), and FTC's deviation detector (cost threshold 253) assumes
+    # the inscribed band exists. Raise this if the robot passes too close to
+    # trees it can see. Does NOT affect the global costmap (its 0.20 m radius
+    # is pinned — larger values blocked transit paths, see nav2_params_base).
+    obstacle_inflation_radius: 0.60
+    # Extra margin (m) grown around DRAWN map obstacle polygons, applied in
+    # BOTH the coverage planner (F2C holes are buffered outward before swath
+    # planning) and the keepout mask (cells within the margin of an obstacle
+    # polygon are LETHAL for transit planning). Use it to keep the robot off
+    # root zones: draw the tree trunk as an obstacle and set the margin to
+    # cover the roots (the 2D LiDAR cannot see them — they are below the
+    # scan plane). Clamped to [0.0, 1.0].
+    obstacle_margin: 0.0
+    # collision_monitor PolygonSlow slowdown factor when a scan return is
+    # inside the chassis+15 cm approach box (LiDAR variant only). 0.3 = slow
+    # to 30 % of commanded speed. Clamped to [0.05, 1.0].
+    obstacle_slowdown_ratio: 0.3
 
     # -----------------------------------------------------------------
     # Navigation tolerances (garden terrain)

--- a/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
@@ -396,6 +396,11 @@ controller_server:
       # gives effective reach 0.12+0.14 ≈ 0.26 m ≈ the full footprint, no over-reach.
       obstacle_body_half_width: 0.12
       enable_obstacle_deviation: true
+      # OVERRIDDEN AT LAUNCH: navigation.launch.py injects
+      # mowgli_robot.yaml.max_obstacle_avoidance_distance (default 2.0,
+      # clamped [0.5, 10.0]) here — the same knob that drives
+      # map_server.bypass_max_length. The static value below only governs
+      # isolated runs/tests that load this yaml directly.
       max_lateral_deviation: 1.5
       deviation_step: 0.05
       deviation_blend_rate: 0.5

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -304,6 +304,12 @@ def generate_launch_description() -> LaunchDescription:
                     float(robot_params.get("chassis_width", 0.40)) / 2.0))},
             {"max_obstacle_avoidance_distance":
                 float(robot_params.get("max_obstacle_avoidance_distance", 2.0))},
+            # Extra LETHAL margin grown around drawn obstacle polygons in the
+            # keepout mask — mirrors coverage_server.obstacle_margin (injected
+            # by navigation.launch.py) so the transit planner and the swath
+            # planner keep the same distance from a drawn tree/root zone.
+            {"obstacle_margin": min(1.0, max(0.0, float(
+                robot_params.get("obstacle_margin", 0.0))))},
             # Hard area-boundary enforcement (operator intent: "lethal area
             # where there is no navigation or mowing area"). When true (default)
             # the keepout mask marks every cell outside the union of all areas

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -425,6 +425,14 @@ def generate_launch_description() -> LaunchDescription:
     # can edit them without an SSH session. Defaults match the C++ node
     # defaults; override on the Settings page.
     dock_pose_yaw_sigma_rad = 0.035
+    # Obstacle-avoidance knobs (GUI: Settings → Obstacles). Defaults match the
+    # template mowgli_robot.yaml; clamps applied at injection time below.
+    # max_obstacle_avoidance_distance drives BOTH FTC max_lateral_deviation
+    # (here) and map_server bypass_max_length (full_system.launch.py).
+    max_obstacle_avoidance_distance = 2.0
+    obstacle_inflation_radius = 0.60
+    obstacle_margin = 0.0
+    obstacle_slowdown_ratio = 0.3
     enable_mag_cal = False
     mag_cal_path = "/ros2_ws/maps/mag_calibration.yaml"
     declination_deg = 1.5
@@ -485,6 +493,13 @@ def generate_launch_description() -> LaunchDescription:
             "min_turning_radius", min_turning_radius))
         connector_turn_radius = float(rt_rp.get(
             "connector_turn_radius", connector_turn_radius))
+        max_obstacle_avoidance_distance = float(rt_rp.get(
+            "max_obstacle_avoidance_distance", max_obstacle_avoidance_distance))
+        obstacle_inflation_radius = float(rt_rp.get(
+            "obstacle_inflation_radius", obstacle_inflation_radius))
+        obstacle_margin = float(rt_rp.get("obstacle_margin", obstacle_margin))
+        obstacle_slowdown_ratio = float(rt_rp.get(
+            "obstacle_slowdown_ratio", obstacle_slowdown_ratio))
         # Operator override wins; otherwise fall back to chassis_width/2
         # (cw was already read above from the same runtime config).
         if "chassis_safety_inset" in rt_rp:
@@ -641,6 +656,35 @@ def generate_launch_description() -> LaunchDescription:
         if mowing_speed > ftc_speed_cap:
             fcp["max_cmd_vel_speed"] = mowing_speed
 
+        # Obstacle-avoidance knobs (GUI: Settings → Obstacles).
+        # max_obstacle_avoidance_distance historically only reached
+        # map_server.bypass_max_length (full_system.launch.py) while FTC's
+        # max_lateral_deviation stayed pinned at the static base-yaml value —
+        # the GUI slider silently did nothing for coverage-time skirting.
+        # One knob now drives both consumers.
+        fcp["max_lateral_deviation"] = min(
+            10.0, max(0.5, max_obstacle_avoidance_distance))
+        # LOCAL costmap inflation only. Floor 0.58: the nav2 inflation layer
+        # degrades footprint-cost semantics below the chassis circumscribed
+        # radius (~0.572 m) and FTC's deviation detector (threshold 253)
+        # assumes the inscribed band exists. The GLOBAL costmap radius (0.20)
+        # is deliberately untouched — 0.30 already blocked all transit paths
+        # on a 9×6 m polygon (see the inflation_layer comment in base.yaml).
+        lc_infl = (doc.setdefault("local_costmap", {})
+                      .setdefault("local_costmap", {})
+                      .setdefault("ros__parameters", {})
+                      .setdefault("inflation_layer", {}))
+        lc_infl["inflation_radius"] = min(
+            1.50, max(0.58, obstacle_inflation_radius))
+        # PolygonSlow only exists in the LiDAR overlay's collision_monitor —
+        # write the slowdown ratio only when the merged doc carries it so the
+        # no-lidar variant (pass-through monitor) stays untouched.
+        cm_params = (doc.get("collision_monitor", {})
+                        .get("ros__parameters", {}))
+        if "PolygonSlow" in cm_params:
+            cm_params["PolygonSlow"]["slowdown_ratio"] = min(
+                1.0, max(0.05, obstacle_slowdown_ratio))
+
         # Goal-checker tolerances. Two checkers live under
         # controller_server: stopped_goal_checker (used by FollowPath /
         # transit) and coverage_goal_checker (used by FollowCoveragePath
@@ -707,6 +751,11 @@ def generate_launch_description() -> LaunchDescription:
         # Perimeter/headland travel winding (blade-side, issue #335).
         cov_params["ring_direction"] = mow_direction
         cov_params["chassis_safety_inset"] = chassis_safety_inset
+        # Extra buffer grown around drawn map-obstacle polygons (holes) before
+        # swath planning — keeps the robot off root zones the 2D LiDAR cannot
+        # see. map_server applies the SAME key to its keepout mask
+        # (full_system.launch.py) so planner and keepout stay consistent.
+        cov_params["obstacle_margin"] = min(1.0, max(0.0, obstacle_margin))
         # Hard floor on the continuous path's turn-around / fillet arcs so no
         # turn is ever tighter than the robot can track (clamp to the tuned
         # [0.10, 0.50] band; sub-0.10 loops are untrackable, >0.50 bulges OOB).

--- a/ros2/src/mowgli_bringup/test/test_nav2_params.py
+++ b/ros2/src/mowgli_bringup/test/test_nav2_params.py
@@ -257,6 +257,115 @@ def test_base_coverage_goal_checker_xy_ge_ftc_park() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Obstacle-avoidance knob injection (GUI: Settings → Obstacles)
+# ---------------------------------------------------------------------------
+
+
+def _template_robot_params() -> dict:
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "..", "config", "mowgli_robot.yaml")
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)["mowgli"]["ros__parameters"]
+
+
+def test_navigation_launch_injects_ftc_max_lateral_deviation() -> None:
+    """max_obstacle_avoidance_distance must drive FTC's max_lateral_deviation.
+    Before 2026-07 it only reached map_server.bypass_max_length — the GUI
+    'Max Obstacle Detour' slider silently did nothing for coverage-time
+    skirting (FTC stayed pinned at the static base.yaml 1.5 m)."""
+    src = _read_text("launch/navigation.launch.py")
+    assert re.search(
+        r"fcp\[.max_lateral_deviation.\]\s*=.*max_obstacle_avoidance_distance",
+        src, re.DOTALL), (
+        "navigation.launch.py must inject max_obstacle_avoidance_distance into "
+        "FollowCoveragePath.max_lateral_deviation — otherwise the GUI knob is an "
+        "orphan and FTC keeps the static base.yaml deviation limit."
+    )
+
+
+def test_navigation_launch_injects_local_inflation_with_floor() -> None:
+    """obstacle_inflation_radius reaches ONLY the local costmap, floored at
+    0.58 m (chassis circumscribed radius ~0.572 — below it the inflation
+    layer degrades footprint-cost semantics and FTC's threshold-253 deviation
+    detector loses its inscribed band)."""
+    src = _read_text("launch/navigation.launch.py")
+    m = re.search(
+        r"lc_infl\[.inflation_radius.\]\s*=\s*min\(\s*([\d.]+),\s*max\(([\d.]+),"
+        r"\s*obstacle_inflation_radius", src)
+    assert m, (
+        "navigation.launch.py must clamp-inject obstacle_inflation_radius into the "
+        "local costmap inflation_layer (lc_infl['inflation_radius'] = min(hi, "
+        "max(lo, obstacle_inflation_radius)))."
+    )
+    assert float(m.group(2)) >= 0.58, (
+        f"inflation floor {m.group(2)} is below the chassis circumscribed radius "
+        "(~0.572 m) — footprint-cost semantics degrade below it."
+    )
+    # The GLOBAL costmap radius is pinned at 0.20 (0.30 blocked all transit
+    # paths on a 9×6 m polygon) — the LOCAL chain must be the only
+    # inflation_radius writer in the launch script.
+    writers = re.findall(r"(\w+)\[.inflation_radius.\]\s*=", src)
+    assert writers == ["lc_infl"], (
+        f"inflation_radius writers in navigation.launch.py: {writers} — only the "
+        "local-costmap chain (lc_infl) may write it; the 0.20 m global radius is "
+        "pinned (0.30 blocked transits, see base.yaml)."
+    )
+
+
+def test_navigation_launch_guards_polygon_slow_write() -> None:
+    """PolygonSlow only exists in the LiDAR overlay's collision_monitor. The
+    slowdown_ratio injection must be guarded so the no-lidar merge (pass-
+    through monitor) is not given a phantom polygon block."""
+    src = _read_text("launch/navigation.launch.py")
+    assert re.search(r"if\s+.PolygonSlow.\s+in\s+", src), (
+        "navigation.launch.py must guard the PolygonSlow.slowdown_ratio write "
+        "with a presence check — the no-lidar variant has no PolygonSlow."
+    )
+
+
+def test_navigation_launch_injects_coverage_obstacle_margin() -> None:
+    """obstacle_margin must reach coverage_server (F2C hole buffering). Its
+    keepout twin is injected by full_system.launch.py into map_server."""
+    src = _read_text("launch/navigation.launch.py")
+    assert re.search(
+        r"cov_params\[.obstacle_margin.\]\s*=.*obstacle_margin", src), (
+        "navigation.launch.py must inject obstacle_margin into coverage_server — "
+        "drawn-obstacle margins would otherwise only apply to transit (keepout), "
+        "not to the swath plan."
+    )
+    fs_src = _read_text("launch/full_system.launch.py")
+    assert re.search(r"obstacle_margin", fs_src), (
+        "full_system.launch.py must forward obstacle_margin to map_server so the "
+        "keepout mask keeps the same distance as the coverage plan."
+    )
+
+
+def test_obstacle_template_defaults_match_static_yaml() -> None:
+    """The template's obstacle knobs must default to the static yaml values so
+    a sparse installed file (no overrides) is behaviour-preserving."""
+    rp = _template_robot_params()
+    base = _load_yaml("nav2_params_base.yaml")
+    lidar = _load_yaml("nav2_params_lidar.yaml")
+    local_infl = (base["local_costmap"]["local_costmap"]["ros__parameters"]
+                  ["inflation_layer"]["inflation_radius"])
+    assert float(rp["obstacle_inflation_radius"]) == float(local_infl), (
+        f"template obstacle_inflation_radius={rp['obstacle_inflation_radius']} != "
+        f"base.yaml local inflation_radius={local_infl} — a fresh install would "
+        "silently change avoidance behaviour."
+    )
+    slow = (lidar["collision_monitor"]["ros__parameters"]["PolygonSlow"]
+            ["slowdown_ratio"])
+    assert float(rp["obstacle_slowdown_ratio"]) == float(slow), (
+        f"template obstacle_slowdown_ratio={rp['obstacle_slowdown_ratio']} != "
+        f"lidar overlay PolygonSlow.slowdown_ratio={slow}."
+    )
+    assert float(rp["obstacle_margin"]) == 0.0, (
+        "template obstacle_margin must default to 0.0 (no margin) so existing "
+        "sites' plans are unchanged until the operator opts in."
+    )
+
+
 def test_no_lidar_variant_uses_path_progress_goal_checker() -> None:
     """nav2_params_no_lidar.yaml is the GPS-only variant — it must use the
     same PathProgressGoalChecker plugin with a high progress threshold and

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
@@ -232,6 +232,14 @@ double distanceToRing(double x, double y, const std::vector<std::pair<double, do
 // normalised here. Pure function (no ROS deps) — unit-testable.
 f2c::types::LinearRing dedupClosedRing(const f2c::types::LinearRing& in);
 
+// Grow a drawn-obstacle ring outward by `margin` metres (GDAL Buffer, rounded
+// joins) and return it dedup-closed. Applied at goal-ingestion time so every
+// downstream consumer — headland growth, safe_holes, sub-path splitting,
+// connector routing — inherits the operator's obstacle_margin automatically.
+// margin < 1e-3 or a degenerate ring falls back to dedupClosedRing(in): the
+// obstacle is never dropped, only the extra margin. Pure function — testable.
+f2c::types::LinearRing bufferRingOutward(const f2c::types::LinearRing& in, double margin);
+
 }  // namespace mowgli_coverage
 
 #endif  // MOWGLI_COVERAGE__COVERAGE_PLANNING_HPP_

--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -10,7 +10,13 @@
 #include <cmath>
 #include <cstdio>
 #include <limits>
+#include <memory>
 #include <string>
+
+// GDAL/OGR (F2C's geometry backend) — bufferRingOutward grows drawn-obstacle
+// rings with OGRPolygon::Buffer. Explicit include: the transitive path via
+// fields2cover.h is an implementation detail of F2C.
+#include "ogr_geometry.h"
 
 namespace mowgli_coverage
 {
@@ -1462,6 +1468,69 @@ double distanceToRing(double x, double y, const std::vector<std::pair<double, do
     best = std::min(best, std::hypot(x - px, y - py));
   }
   return best;
+}
+
+f2c::types::LinearRing bufferRingOutward(const f2c::types::LinearRing& in, double margin)
+{
+  if (margin < 1e-3 || in.size() < 3)
+  {
+    return dedupClosedRing(in);
+  }
+  // Grow the ring's polygon outward with GDAL/OGR (F2C's own geometry
+  // backend): drawn map obstacles get an operator-tunable safety margin
+  // (obstacle_margin) so the planner keeps swaths, connectors and headlands
+  // off root zones the 2D LiDAR cannot see. Rounded joins (8 quadrant
+  // segments) avoid miter spikes on concave operator polygons.
+  OGRLinearRing ogr_ring;
+  for (std::size_t i = 0; i < in.size(); ++i)
+  {
+    const auto p = in.getGeometry(i);
+    ogr_ring.addPoint(p.getX(), p.getY());
+  }
+  ogr_ring.closeRings();
+  OGRPolygon poly;
+  poly.addRing(&ogr_ring);
+  std::unique_ptr<OGRGeometry> grown(poly.Buffer(margin, 8));
+  // Buffer degeneracies (self-intersecting input, collapsed area) fall back
+  // to the raw ring — the planner still avoids the drawn polygon itself,
+  // just without the extra margin. Never drop the obstacle.
+  if (!grown)
+  {
+    return dedupClosedRing(in);
+  }
+  const OGRPolygon* grown_poly = nullptr;
+  const auto flat_type = wkbFlatten(grown->getGeometryType());
+  if (flat_type == wkbPolygon)
+  {
+    grown_poly = grown->toPolygon();
+  }
+  else if (flat_type == wkbMultiPolygon)
+  {
+    // Outward buffering can merge lobes of a degenerate ring into several
+    // parts; keep the largest (the obstacle body).
+    double best_area = -1.0;
+    for (const auto* part : *grown->toMultiPolygon())
+    {
+      const double a = part->get_Area();
+      if (a > best_area)
+      {
+        best_area = a;
+        grown_poly = part;
+      }
+    }
+  }
+  if (!grown_poly || !grown_poly->getExteriorRing() ||
+      grown_poly->getExteriorRing()->getNumPoints() < 4)
+  {
+    return dedupClosedRing(in);
+  }
+  const OGRLinearRing* ext = grown_poly->getExteriorRing();
+  f2c::types::LinearRing out;
+  for (int i = 0; i < ext->getNumPoints(); ++i)
+  {
+    out.addPoint(f2c::types::Point(ext->getX(i), ext->getY(i)));
+  }
+  return dedupClosedRing(out);
 }
 
 f2c::types::LinearRing dedupClosedRing(const f2c::types::LinearRing& in)

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -409,8 +409,8 @@ void CoverageServer::planCoverage()
     // Drawn-obstacle margin, read live like the other geometry knobs. Clamp
     // mirrors the launch-injection band so a stray `ros2 param set` cannot
     // inflate holes past the field.
-    const double obstacle_margin = std::clamp(
-        get_parameter("obstacle_margin").as_double(), 0.0, 1.0);
+    const double obstacle_margin =
+        std::clamp(get_parameter("obstacle_margin").as_double(), 0.0, 1.0);
 
     f2c::types::Cell cell = buildCellFromGoal(*goal, obstacle_margin);
 

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -59,6 +59,12 @@ nav2_util::CallbackReturn CoverageServer::on_configure(const rclcpp_lifecycle::S
   // (a deadband diff-drive may track a 0.30 m arc more smoothly than a 0.18 m
   // one); raise toward 0.30 if tight turns induce hesitation. Read live.
   declare_parameter<double>("connector_turn_radius", 0.18);
+  // Extra buffer (m) grown around drawn map-obstacle polygons (holes) before
+  // planning — keeps swaths/connectors off root zones the 2D LiDAR cannot see.
+  // Injected at launch from mowgli_robot.yaml.obstacle_margin (GUI: Settings →
+  // Obstacles); map_server applies the same key to its keepout mask so transit
+  // and coverage keep the same distance. Read LIVE per plan.
+  declare_parameter<double>("obstacle_margin", 0.0);
 
   // Action server result timeout. Keep this >= the BT client's per-plan wait
   // (PlanCoverageArea, 12 s): if the server expires the result first the
@@ -122,7 +128,13 @@ constexpr double kSwathStep = 0.10;  // m between poses on a straight swath
 
 // Build the F2C cell from the goal's outer boundary + obstacle holes.
 // F2C wants closed rings (first == last); the BT passes open rings.
-f2c::types::Cell buildCellFromGoal(const mowgli_interfaces::action::PlanCoverage::Goal& goal)
+// obstacle_margin (m) grows each HOLE outward at ingestion (bufferRingOutward)
+// so the whole downstream pipeline — headlands, safe_holes, sub-path splits,
+// connectors — keeps that distance from drawn obstacles (root zones the 2D
+// LiDAR cannot see). The outer boundary is untouched (chassis_safety_inset
+// owns that margin).
+f2c::types::Cell buildCellFromGoal(const mowgli_interfaces::action::PlanCoverage::Goal& goal,
+                                   double obstacle_margin)
 {
   if (goal.outer_boundary.points.size() < 3)
   {
@@ -147,7 +159,7 @@ f2c::types::Cell buildCellFromGoal(const mowgli_interfaces::action::PlanCoverage
   {
     if (hole.points.size() >= 3)
     {
-      cell.addRing(make_ring(hole));
+      cell.addRing(bufferRingOutward(make_ring(hole), obstacle_margin));
     }
   }
   return cell;
@@ -394,7 +406,13 @@ void CoverageServer::planCoverage()
                   effective_inset);
     }
 
-    f2c::types::Cell cell = buildCellFromGoal(*goal);
+    // Drawn-obstacle margin, read live like the other geometry knobs. Clamp
+    // mirrors the launch-injection band so a stray `ros2 param set` cannot
+    // inflate holes past the field.
+    const double obstacle_margin = std::clamp(
+        get_parameter("obstacle_margin").as_double(), 0.0, 1.0);
+
+    f2c::types::Cell cell = buildCellFromGoal(*goal, obstacle_margin);
 
     // Robot's minimum trackable turning radius — floors both the ring-corner
     // fillets inside the planner and the turn-around connectors below. Read

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -1147,6 +1147,122 @@ TEST(RingDedup, DedupedDegenerateRingStillPlans)
       << "deduped degenerate ring produced an empty plan";
 }
 
+// ---------------------------------------------------------------------------
+// bufferRingOutward — drawn-obstacle margin (mowgli_robot.yaml.obstacle_margin)
+// ---------------------------------------------------------------------------
+
+TEST(ObstacleMargin, GrowsRingOutwardByMargin)
+{
+  // 1×1 m square obstacle centred at (2, 2).
+  f2c::types::LinearRing in;
+  in.addPoint(f2c::types::Point(1.5, 1.5));
+  in.addPoint(f2c::types::Point(2.5, 1.5));
+  in.addPoint(f2c::types::Point(2.5, 2.5));
+  in.addPoint(f2c::types::Point(1.5, 2.5));
+
+  const double margin = 0.3;
+  const auto out = mowgli_coverage::bufferRingOutward(in, margin);
+
+  ASSERT_GE(out.size(), 4u);
+  // Every grown vertex sits at least `margin` from the ORIGINAL ring (rounded
+  // joins mean edge midpoints sit exactly margin out, corners on the arc).
+  std::vector<std::pair<double, double>> orig = {
+      {1.5, 1.5}, {2.5, 1.5}, {2.5, 2.5}, {1.5, 2.5}, {1.5, 1.5}};
+  for (std::size_t i = 0; i < out.size(); ++i)
+  {
+    const auto p = out.getGeometry(i);
+    const double d = mowgli_coverage::distanceToRing(p.getX(), p.getY(), orig);
+    EXPECT_GE(d, margin - 1e-6)
+        << "grown vertex " << i << " at (" << p.getX() << ", " << p.getY()
+        << ") is only " << d << " m from the original obstacle ring";
+    EXPECT_LE(d, margin + 1e-6)
+        << "grown vertex " << i << " overshoots the requested margin";
+  }
+  // Closed ring (F2C requirement).
+  EXPECT_NEAR(out.getGeometry(0).getX(), out.getGeometry(out.size() - 1).getX(), 1e-9);
+  EXPECT_NEAR(out.getGeometry(0).getY(), out.getGeometry(out.size() - 1).getY(), 1e-9);
+}
+
+TEST(ObstacleMargin, ZeroMarginIsPassthrough)
+{
+  f2c::types::LinearRing in;
+  in.addPoint(f2c::types::Point(0.0, 0.0));
+  in.addPoint(f2c::types::Point(1.0, 0.0));
+  in.addPoint(f2c::types::Point(1.0, 1.0));
+  in.addPoint(f2c::types::Point(0.0, 1.0));
+
+  const auto out = mowgli_coverage::bufferRingOutward(in, 0.0);
+  // Same vertices, dedup-closed — identical to dedupClosedRing(in).
+  const auto expected = dedupClosedRing(in);
+  ASSERT_EQ(out.size(), expected.size());
+  for (std::size_t i = 0; i < out.size(); ++i)
+  {
+    EXPECT_NEAR(out.getGeometry(i).getX(), expected.getGeometry(i).getX(), 1e-9);
+    EXPECT_NEAR(out.getGeometry(i).getY(), expected.getGeometry(i).getY(), 1e-9);
+  }
+}
+
+TEST(ObstacleMargin, DegenerateRingFallsBackToInput)
+{
+  // Two-point "ring" cannot be buffered — must fall back, never drop.
+  f2c::types::LinearRing in;
+  in.addPoint(f2c::types::Point(0.0, 0.0));
+  in.addPoint(f2c::types::Point(1.0, 0.0));
+
+  const auto out = mowgli_coverage::bufferRingOutward(in, 0.3);
+  EXPECT_GE(out.size(), 2u) << "degenerate obstacle ring was dropped";
+}
+
+// End-to-end: with a margin, no planned ring point or swath sample may come
+// closer than the margin to the DRAWN obstacle ring (the planner's chassis
+// inset adds more on top; this pins the floor the margin itself guarantees).
+TEST(ObstacleMargin, PlanKeepsMarginOffDrawnObstacle)
+{
+  f2c::types::Cell cell = makeSquare(8.0);
+  f2c::types::LinearRing hole;
+  hole.addPoint(f2c::types::Point(3.5, 3.5));
+  hole.addPoint(f2c::types::Point(4.5, 3.5));
+  hole.addPoint(f2c::types::Point(4.5, 4.5));
+  hole.addPoint(f2c::types::Point(3.5, 4.5));
+  const double margin = 0.3;
+  cell.addRing(mowgli_coverage::bufferRingOutward(dedupClosedRing(hole), margin));
+
+  const auto plan = planDefault(cell);
+  ASSERT_FALSE(plan.swaths.empty()) << "field with grown hole produced no swaths";
+
+  const std::vector<std::pair<double, double>> obstacle = {
+      {3.5, 3.5}, {4.5, 3.5}, {4.5, 4.5}, {3.5, 4.5}, {3.5, 3.5}};
+  auto check_point = [&](double x, double y, const char* what) {
+    const double d = mowgli_coverage::distanceToRing(x, y, obstacle);
+    EXPECT_GE(d, margin - 1e-3)
+        << what << " point (" << x << ", " << y << ") is " << d
+        << " m from the drawn obstacle — margin " << margin << " violated";
+  };
+  for (const auto& ring : plan.rings)
+  {
+    for (const auto& p : ring)
+    {
+      check_point(p.first, p.second, "ring");
+    }
+  }
+  // Swaths are straight — sample along each segment, not just endpoints.
+  for (const auto& s : plan.swaths)
+  {
+    const double len = swathLen(s);
+    const int n = std::max(1, static_cast<int>(len / 0.05));
+    for (int i = 0; i <= n; ++i)
+    {
+      const double t = static_cast<double>(i) / n;
+      check_point(s.first.first + t * (s.second.first - s.first.first),
+                  s.first.second + t * (s.second.second - s.first.second),
+                  "swath");
+    }
+  }
+  // The grown hole must surface in safe_holes so the continuous-path
+  // connectors inherit the margin too.
+  EXPECT_FALSE(plan.safe_holes.empty()) << "grown hole missing from safe_holes";
+}
+
 // LARGE-FIELD AUTO-ANGLE FALLBACK: f2c::sg::BruteForce::generateBestSwaths
 // sweeps 180 candidate angles and regenerates the full swath set at each, so on
 // a big field it blows past the action/BT planning timeouts and the coverage

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -1172,11 +1172,9 @@ TEST(ObstacleMargin, GrowsRingOutwardByMargin)
   {
     const auto p = out.getGeometry(i);
     const double d = mowgli_coverage::distanceToRing(p.getX(), p.getY(), orig);
-    EXPECT_GE(d, margin - 1e-6)
-        << "grown vertex " << i << " at (" << p.getX() << ", " << p.getY()
-        << ") is only " << d << " m from the original obstacle ring";
-    EXPECT_LE(d, margin + 1e-6)
-        << "grown vertex " << i << " overshoots the requested margin";
+    EXPECT_GE(d, margin - 1e-6) << "grown vertex " << i << " at (" << p.getX() << ", " << p.getY()
+                                << ") is only " << d << " m from the original obstacle ring";
+    EXPECT_LE(d, margin + 1e-6) << "grown vertex " << i << " overshoots the requested margin";
   }
   // Closed ring (F2C requirement).
   EXPECT_NEAR(out.getGeometry(0).getX(), out.getGeometry(out.size() - 1).getX(), 1e-9);
@@ -1232,11 +1230,11 @@ TEST(ObstacleMargin, PlanKeepsMarginOffDrawnObstacle)
 
   const std::vector<std::pair<double, double>> obstacle = {
       {3.5, 3.5}, {4.5, 3.5}, {4.5, 4.5}, {3.5, 4.5}, {3.5, 3.5}};
-  auto check_point = [&](double x, double y, const char* what) {
+  auto check_point = [&](double x, double y, const char* what)
+  {
     const double d = mowgli_coverage::distanceToRing(x, y, obstacle);
-    EXPECT_GE(d, margin - 1e-3)
-        << what << " point (" << x << ", " << y << ") is " << d
-        << " m from the drawn obstacle — margin " << margin << " violated";
+    EXPECT_GE(d, margin - 1e-3) << what << " point (" << x << ", " << y << ") is " << d
+                                << " m from the drawn obstacle — margin " << margin << " violated";
   };
   for (const auto& ring : plan.rings)
   {

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -377,6 +377,13 @@ private:
   /// of ~0.7 m inside the polygon.
   double boundary_inner_margin_m_{0.3};
 
+  /// Extra LETHAL margin grown around drawn obstacle polygons in the keepout
+  /// mask (mowgli_robot.yaml.obstacle_margin, GUI: Settings → Obstacles).
+  /// Mirrors coverage_server.obstacle_margin — the coverage planner buffers
+  /// its F2C holes by the same value — so transit and swath planning keep an
+  /// identical distance from a drawn tree/root zone. 0 = polygon edge only.
+  double obstacle_margin_m_{0.0};
+
   /// How far inside the polygon strip endpoints must sit. Applied when the
   /// coverage planner generates strips: the axis-aligned bounding-box
   /// y-intersections are shrunk by this value on both ends. Must cover the

--- a/ros2/src/mowgli_map/src/costmap_filters.cpp
+++ b/ros2/src/mowgli_map/src/costmap_filters.cpp
@@ -151,6 +151,26 @@ void MapServerNode::publish_keepout_mask()
   }
 
   // Overlay obstacle polygons: cells inside any obstacle -> 100 (lethal).
+  // Two sources share this pass: obstacle_polygons_ (dynamic LiDAR-promoted)
+  // and every area's DRAWN entry.obstacles (whose interiors are also lethal
+  // via the classification NO_GO_ZONE overlay below — the polygon pass here
+  // is what carries the margin band). obstacle_margin_m_
+  // (mowgli_robot.yaml.obstacle_margin) additionally marks cells within that
+  // distance OUTSIDE each polygon — the transit-side twin of
+  // coverage_server's F2C hole buffering, so both planners keep the same
+  // distance from a drawn tree/root zone.
+  const auto cell_hits_obstacle =
+      [this](const geometry_msgs::msg::Point32& pt,
+             const geometry_msgs::msg::Polygon& obs) {
+        if (point_in_polygon(pt, obs))
+        {
+          return true;
+        }
+        return obstacle_margin_m_ > 0.0 &&
+               point_to_polygon_distance(static_cast<double>(pt.x),
+                                         static_cast<double>(pt.y),
+                                         obs) <= obstacle_margin_m_;
+      };
   for (int r = 0; r < nx; ++r)
   {
     for (int c = 0; c < ny; ++c)
@@ -167,15 +187,31 @@ void MapServerNode::publish_keepout_mask()
       pt.y = static_cast<float>(pos.y());
       pt.z = 0.0F;
 
+      bool lethal = false;
       for (const auto& obs : obstacle_polygons_)
       {
-        if (point_in_polygon(pt, obs))
+        if (cell_hits_obstacle(pt, obs))
         {
-          const int og_col = nx - 1 - r;
-          const int og_row = ny - 1 - c;
-          mask.data[static_cast<std::size_t>(og_row * nx + og_col)] = 100;
+          lethal = true;
           break;
         }
+      }
+      for (std::size_t a = 0; !lethal && a < areas_.size(); ++a)
+      {
+        for (const auto& obs : areas_[a].obstacles)
+        {
+          if (cell_hits_obstacle(pt, obs))
+          {
+            lethal = true;
+            break;
+          }
+        }
+      }
+      if (lethal)
+      {
+        const int og_col = nx - 1 - r;
+        const int og_row = ny - 1 - c;
+        mask.data[static_cast<std::size_t>(og_row * nx + og_col)] = 100;
       }
     }
   }

--- a/ros2/src/mowgli_map/src/costmap_filters.cpp
+++ b/ros2/src/mowgli_map/src/costmap_filters.cpp
@@ -160,17 +160,16 @@ void MapServerNode::publish_keepout_mask()
   // coverage_server's F2C hole buffering, so both planners keep the same
   // distance from a drawn tree/root zone.
   const auto cell_hits_obstacle =
-      [this](const geometry_msgs::msg::Point32& pt,
-             const geometry_msgs::msg::Polygon& obs) {
-        if (point_in_polygon(pt, obs))
-        {
-          return true;
-        }
-        return obstacle_margin_m_ > 0.0 &&
-               point_to_polygon_distance(static_cast<double>(pt.x),
-                                         static_cast<double>(pt.y),
-                                         obs) <= obstacle_margin_m_;
-      };
+      [this](const geometry_msgs::msg::Point32& pt, const geometry_msgs::msg::Polygon& obs)
+  {
+    if (point_in_polygon(pt, obs))
+    {
+      return true;
+    }
+    return obstacle_margin_m_ > 0.0 &&
+           point_to_polygon_distance(static_cast<double>(pt.x), static_cast<double>(pt.y), obs) <=
+               obstacle_margin_m_;
+  };
   for (int r = 0; r < nx; ++r)
   {
     for (int c = 0; c < ny; ++c)

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -121,6 +121,11 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   chassis_width_m_ = declare_parameter<double>("chassis_width", 0.40);
   bypass_safety_margin_m_ = declare_parameter<double>("bypass_safety_margin_m", 0.05);
   bypass_max_length_m_ = declare_parameter<double>("max_obstacle_avoidance_distance", 2.0);
+  // Extra LETHAL band around drawn obstacle polygons in the keepout mask.
+  // Same key drives coverage_server's F2C hole buffering (injected at launch
+  // from mowgli_robot.yaml.obstacle_margin) — keep the two in lockstep.
+  obstacle_margin_m_ =
+      std::clamp(declare_parameter<double>("obstacle_margin", 0.0), 0.0, 1.0);
 
   // Dock body (physical structure the robot cannot drive into). Cells
   // inside are marked OBSTACLE_PERMANENT — F2C strips stop at the body

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -124,8 +124,7 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   // Extra LETHAL band around drawn obstacle polygons in the keepout mask.
   // Same key drives coverage_server's F2C hole buffering (injected at launch
   // from mowgli_robot.yaml.obstacle_margin) — keep the two in lockstep.
-  obstacle_margin_m_ =
-      std::clamp(declare_parameter<double>("obstacle_margin", 0.0), 0.0, 1.0);
+  obstacle_margin_m_ = std::clamp(declare_parameter<double>("obstacle_margin", 0.0), 0.0, 1.0);
 
   // Dock body (physical structure the robot cannot drive into). Cells
   // inside are marked OBSTACLE_PERMANENT — F2C strips stop at the body

--- a/ros2/src/mowgli_map/test/test_map_server.cpp
+++ b/ros2/src/mowgli_map/test/test_map_server.cpp
@@ -461,8 +461,7 @@ protected:
 TEST_F(ObstacleMarginTest, DrawnObstacleGetsLethalMarginBand)
 {
   // 8×8 m lawn with a 1×1 m drawn obstacle (tree) centred at the origin.
-  ASSERT_TRUE(add_area_with_obstacle(make_rect(-4, -4, 4, 4),
-                                     make_rect(-0.5, -0.5, 0.5, 0.5)));
+  ASSERT_TRUE(add_area_with_obstacle(make_rect(-4, -4, 4, 4), make_rect(-0.5, -0.5, 0.5, 0.5)));
 
   const auto mask = node_->build_keepout_mask_for_test();
   ASSERT_FALSE(mask.data.empty());
@@ -470,11 +469,9 @@ TEST_F(ObstacleMarginTest, DrawnObstacleGetsLethalMarginBand)
   // Inside the drawn obstacle → LETHAL (classification NO_GO overlay).
   EXPECT_EQ(mask_at(mask, 0.0, 0.0), 100) << "inside drawn obstacle must be lethal";
   // 0.2 m outside the polygon edge, within the 0.3 m margin → LETHAL.
-  EXPECT_EQ(mask_at(mask, 0.75, 0.0), 100)
-      << "cell inside the obstacle_margin band must be lethal";
+  EXPECT_EQ(mask_at(mask, 0.75, 0.0), 100) << "cell inside the obstacle_margin band must be lethal";
   // Well outside the margin band (edge + 0.3 m + slack) → FREE lawn.
-  EXPECT_EQ(mask_at(mask, 1.5, 0.0), 0)
-      << "lawn beyond the margin band must stay free";
+  EXPECT_EQ(mask_at(mask, 1.5, 0.0), 0) << "lawn beyond the margin band must stay free";
 }
 
 TEST_F(AreaTypeTest, DrawnObstacleWithoutMarginIsEdgeTight)

--- a/ros2/src/mowgli_map/test/test_map_server.cpp
+++ b/ros2/src/mowgli_map/test/test_map_server.cpp
@@ -418,3 +418,82 @@ TEST_F(AreaTypeTest, KeepoutMaskEmptyWhenNoAreas)
   EXPECT_TRUE(mask.data.empty())
       << "with zero areas, no keepout mask is produced (world stays drivable)";
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Drawn-obstacle margin (mowgli_robot.yaml.obstacle_margin) — the keepout
+// twin of coverage_server's F2C hole buffering. A drawn obstacle (a tree)
+// must project a LETHAL band obstacle_margin wide around its polygon so
+// transit paths keep off root zones the 2D LiDAR cannot see.
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ObstacleMarginTest : public AreaTypeTest
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::NodeOptions opts;
+    opts.append_parameter_override("resolution", 0.1);
+    opts.append_parameter_override("map_size_x", 10.0);
+    opts.append_parameter_override("map_size_y", 10.0);
+    opts.append_parameter_override("map_frame", "map");
+    opts.append_parameter_override("tool_width", 0.2);
+    opts.append_parameter_override("map_file_path", "");
+    opts.append_parameter_override("areas_file_path", "");
+    opts.append_parameter_override("publish_rate", 1.0);
+    opts.append_parameter_override("obstacle_margin", 0.3);
+    node_ = std::make_shared<mowgli_map::MapServerNode>(opts);
+  }
+
+  bool add_area_with_obstacle(const geometry_msgs::msg::Polygon& area,
+                              const geometry_msgs::msg::Polygon& obstacle)
+  {
+    auto req = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Request>();
+    req->area.name = "lawn_with_tree";
+    req->area.area = area;
+    req->area.obstacles.push_back(obstacle);
+    req->is_navigation_area = false;
+    auto res = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Response>();
+    node_->add_area_for_test(req, res);
+    return res->success;
+  }
+};
+
+TEST_F(ObstacleMarginTest, DrawnObstacleGetsLethalMarginBand)
+{
+  // 8×8 m lawn with a 1×1 m drawn obstacle (tree) centred at the origin.
+  ASSERT_TRUE(add_area_with_obstacle(make_rect(-4, -4, 4, 4),
+                                     make_rect(-0.5, -0.5, 0.5, 0.5)));
+
+  const auto mask = node_->build_keepout_mask_for_test();
+  ASSERT_FALSE(mask.data.empty());
+
+  // Inside the drawn obstacle → LETHAL (classification NO_GO overlay).
+  EXPECT_EQ(mask_at(mask, 0.0, 0.0), 100) << "inside drawn obstacle must be lethal";
+  // 0.2 m outside the polygon edge, within the 0.3 m margin → LETHAL.
+  EXPECT_EQ(mask_at(mask, 0.75, 0.0), 100)
+      << "cell inside the obstacle_margin band must be lethal";
+  // Well outside the margin band (edge + 0.3 m + slack) → FREE lawn.
+  EXPECT_EQ(mask_at(mask, 1.5, 0.0), 0)
+      << "lawn beyond the margin band must stay free";
+}
+
+TEST_F(AreaTypeTest, DrawnObstacleWithoutMarginIsEdgeTight)
+{
+  // Default node (obstacle_margin = 0): the drawn obstacle is lethal but
+  // projects NO margin band — pre-existing behaviour preserved.
+  auto req = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Request>();
+  req->area.name = "lawn_with_tree";
+  req->area.area = make_rect(-4, -4, 4, 4);
+  req->area.obstacles.push_back(make_rect(-0.5, -0.5, 0.5, 0.5));
+  req->is_navigation_area = false;
+  auto res = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Response>();
+  node_->add_area_for_test(req, res);
+  ASSERT_TRUE(res->success);
+
+  const auto mask = node_->build_keepout_mask_for_test();
+  ASSERT_FALSE(mask.data.empty());
+
+  EXPECT_EQ(mask_at(mask, 0.0, 0.0), 100) << "inside drawn obstacle must be lethal";
+  EXPECT_EQ(mask_at(mask, 0.75, 0.0), 0)
+      << "without obstacle_margin the band outside the polygon stays free";
+}


### PR DESCRIPTION
## Problème

Le robot percute les arbres et s'enlise sur les zones de racines invisibles au LiDAR 2D (plan de scan ~0,10–0,22 m). Les marges d'évitement étaient figées dans `nav2_params_base.yaml`, et le slider GUI `max_obstacle_avoidance_distance` n'atteignait que `map_server.bypass_max_length` — le `max_lateral_deviation` de FTC restait épinglé à 1,5 m (slider orphelin).

## Changements

**Nouvelles clés template** (`mowgli_robot.yaml`, invariant 15), injectées au launch avec clamps :

| clé | défaut | clamp | consommateur |
|---|---|---|---|
| `obstacle_inflation_radius` | 0.60 | [0.58, 1.50] | inflation costmap **local** uniquement (le global reste épinglé à 0.20 — 0.30 bloquait les transits) |
| `max_obstacle_avoidance_distance` | 2.0 | [0.5, 10.0] | FTC `max_lateral_deviation` **(nouveau — corrige l'orphelin)** + map_server `bypass_max_length` |
| `obstacle_margin` | 0.0 | [0.0, 1.0] | buffer des trous F2C (coverage_server, nouveau `bufferRingOutward` via `OGRPolygon::Buffer`) + bande léthale keepout (map_server, obstacles dessinés ET promus) |
| `obstacle_slowdown_ratio` | 0.3 | [0.05, 1.0] | `PolygonSlow.slowdown_ratio` (écriture gardée — variante no-lidar intacte) |

**Cas racines** : dessiner le tronc comme obstacle sur la carte + régler `obstacle_margin` pour couvrir les racines — la tonte ET les transits gardent la même distance (les deux planners consomment la même clé).

**GUI** : nouvelle section Settings → Obstacles (groupe schéma `obstacle_settings`, `ObstaclesSection.tsx` avec point « overridden » + reset, i18n en+fr, alerte expliquant le cas racines). `max_obstacle_avoidance_distance` DÉPLACÉ de Safety vers Obstacles (nom de clé inchangé — yamls sparses non affectés).

⚠️ **Changement de comportement par défaut** : FTC `max_lateral_deviation` passe de 1,5 → 2,0 m (aligné sur le défaut template de `max_obstacle_avoidance_distance`).

## Tests

- [x] 5 nouveaux gates `test_nav2_params.py` (26/26 passent localement) : injection FTC, writer inflation local-only + plancher 0.58, garde PolygonSlow, lockstep défauts template↔yaml statiques
- [x] Suite `ObstacleMargin` dans `test_coverage_planning.cpp` (grow/passthrough/dégénéré + le plan respecte la marge autour d'un obstacle dessiné) — validée par CI (F2C requis)
- [x] `ObstacleMarginTest` bande keepout dans `test_map_server.cpp` — validée par CI
- [x] `check_config_drift.py` : clés ajoutées à USER_OVERRIDE, passe localement
- [x] `yarn build` + `go build` + `go test ./pkg/api/` OK (les 2 échecs vitest préexistent sur dev — hook manualMode, sans rapport)
- [ ] Test terrain : régler `obstacle_margin` ≈ 0,3–0,5 m sur un arbre dessiné, vérifier que swaths + transits gardent la distance

🤖 Generated with [Claude Code](https://claude.com/claude-code)