### PR TITLE
feat(behavior): wheel-slip/stall stuck detection — back up instead of digging in

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -658,6 +658,30 @@
           "title": "Approach Slowdown Ratio",
           "default": 0.3,
           "description": "Speed factor when a scan return enters the chassis+15 cm approach box (LiDAR variant). 0.3 = slow to 30% of commanded speed."
+        },
+        "stuck_detection_enabled": {
+          "type": "boolean",
+          "title": "Stuck Detection",
+          "default": true,
+          "description": "Back up automatically when the robot is commanded to move but its GPS pose does not (wheels spinning/stalled on roots invisible to the LiDAR)."
+        },
+        "stuck_window_sec": {
+          "type": "number",
+          "title": "Stuck Detection Window",
+          "default": 4.0,
+          "description": "Seconds of commanded-but-not-moving before the robot backs off. Clamped to [2, 30]."
+        },
+        "stuck_min_commanded_m": {
+          "type": "number",
+          "title": "Stuck Min Commanded Travel",
+          "default": 0.15,
+          "description": "Commanded/wheel travel (m) over the window needed to arm the detector. Clamped to [0.05, 1.0]."
+        },
+        "stuck_max_displacement_m": {
+          "type": "number",
+          "title": "Stuck Max Real Displacement",
+          "default": 0.05,
+          "description": "GPS-frame displacement (m) at or below which the robot counts as stuck. Must exceed RTK noise over the window. Clamped to [0.01, 0.3]."
         }
       }
     },

--- a/gui/web/src/components/settings/ObstaclesSection.tsx
+++ b/gui/web/src/components/settings/ObstaclesSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Alert, Card, Col, Form, InputNumber, Row, Typography } from "antd";
+import { Alert, Card, Col, Form, InputNumber, Row, Switch, Typography } from "antd";
 import { useTranslation } from "react-i18next";
 import { SettingFieldLabel } from "./SettingFieldLabel.tsx";
 
@@ -96,6 +96,71 @@ export const ObstaclesSection: React.FC<Props> = ({
                                     onChange={(v) => onChange("obstacle_margin", v)}
                                     min={0} max={1} step={0.05} precision={2}
                                     style={{ width: "100%" }} addonAfter="m"
+                                />
+                            </Form.Item>
+                        </Col>
+                    </Row>
+                </Form>
+            </Card>
+
+            {/* Stuck detection — wheels spinning/stalled on sub-scan-plane
+                obstacles (roots): back up instead of digging in. */}
+            <Card size="small" title={t("settingsObstacles.stuckDetection")} style={{ marginBottom: 16 }}>
+                <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 12 }}>
+                    {t("settingsObstacles.stuckDetectionDescription")}
+                </Paragraph>
+                <Form layout="vertical" size="small">
+                    <Row gutter={[16, 0]}>
+                        <Col xs={24} sm={6}>
+                            <Form.Item
+                                label={fieldLabel("stuck_detection_enabled", t("settingsObstacles.stuckEnabled"))}
+                                tooltip={t("settingsObstacles.stuckEnabledTooltip")}
+                            >
+                                <Switch
+                                    checked={values.stuck_detection_enabled !== false}
+                                    onChange={(v) => onChange("stuck_detection_enabled", v)}
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col xs={12} sm={6}>
+                            <Form.Item
+                                label={fieldLabel("stuck_window_sec", t("settingsObstacles.stuckWindow"))}
+                                tooltip={t("settingsObstacles.stuckWindowTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.stuck_window_sec}
+                                    onChange={(v) => onChange("stuck_window_sec", v)}
+                                    min={2} max={30} step={0.5} precision={1}
+                                    style={{ width: "100%" }} addonAfter="s"
+                                    disabled={values.stuck_detection_enabled === false}
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col xs={12} sm={6}>
+                            <Form.Item
+                                label={fieldLabel("stuck_min_commanded_m", t("settingsObstacles.stuckMinCommanded"))}
+                                tooltip={t("settingsObstacles.stuckMinCommandedTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.stuck_min_commanded_m}
+                                    onChange={(v) => onChange("stuck_min_commanded_m", v)}
+                                    min={0.05} max={1} step={0.05} precision={2}
+                                    style={{ width: "100%" }} addonAfter="m"
+                                    disabled={values.stuck_detection_enabled === false}
+                                />
+                            </Form.Item>
+                        </Col>
+                        <Col xs={12} sm={6}>
+                            <Form.Item
+                                label={fieldLabel("stuck_max_displacement_m", t("settingsObstacles.stuckMaxDisplacement"))}
+                                tooltip={t("settingsObstacles.stuckMaxDisplacementTooltip")}
+                            >
+                                <InputNumber
+                                    value={values.stuck_max_displacement_m}
+                                    onChange={(v) => onChange("stuck_max_displacement_m", v)}
+                                    min={0.01} max={0.3} step={0.01} precision={2}
+                                    style={{ width: "100%" }} addonAfter="m"
+                                    disabled={values.stuck_detection_enabled === false}
                                 />
                             </Form.Item>
                         </Col>

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -166,6 +166,8 @@ const SECTION_DEFINITIONS: SectionMeta[] = [
         keys: [
             "obstacle_inflation_radius", "max_obstacle_avoidance_distance",
             "obstacle_margin", "obstacle_slowdown_ratio",
+            "stuck_detection_enabled", "stuck_window_sec",
+            "stuck_min_commanded_m", "stuck_max_displacement_m",
         ],
     },
     {

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2203,7 +2203,17 @@
     "approachSlowdown": "Approach Slowdown",
     "approachSlowdownDescription": "The collision monitor slows the robot when a scan return enters the approach box around the chassis (LiDAR variant).",
     "slowdownRatio": "Slowdown Ratio",
-    "slowdownRatioTooltip": "Speed factor near obstacles: 0.3 = slow to 30% of the commanded speed"
+    "slowdownRatioTooltip": "Speed factor near obstacles: 0.3 = slow to 30% of the commanded speed",
+    "stuckDetection": "Stuck Detection",
+    "stuckDetectionDescription": "When the robot is commanded to move but its GPS position does not change — wheels spinning or stalled on roots invisible to the LiDAR — it turns the blade off and backs up instead of digging in.",
+    "stuckEnabled": "Enable",
+    "stuckEnabledTooltip": "Automatically back up when wheels spin or stall without the robot actually moving",
+    "stuckWindow": "Detection Window",
+    "stuckWindowTooltip": "Seconds of commanded-but-not-moving before backing off",
+    "stuckMinCommanded": "Min Commanded Travel",
+    "stuckMinCommandedTooltip": "Commanded/wheel travel over the window needed to arm the detector",
+    "stuckMaxDisplacement": "Max Real Displacement",
+    "stuckMaxDisplacementTooltip": "GPS displacement at or below which the robot counts as stuck (must exceed RTK noise)"
   },
   "settingsMowing": {
     "mowingMotor": "Mowing Motor",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -2199,7 +2199,17 @@
     "approachSlowdown": "Ralentissement à l'approche",
     "approachSlowdownDescription": "Le moniteur de collision ralentit le robot quand un retour de scan entre dans la boîte d'approche autour du châssis (variante LiDAR).",
     "slowdownRatio": "Facteur de ralentissement",
-    "slowdownRatioTooltip": "Facteur de vitesse près des obstacles : 0,3 = ralentir à 30 % de la vitesse commandée"
+    "slowdownRatioTooltip": "Facteur de vitesse près des obstacles : 0,3 = ralentir à 30 % de la vitesse commandée",
+    "stuckDetection": "Détection d'enlisement",
+    "stuckDetectionDescription": "Quand le robot reçoit une commande de mouvement mais que sa position GPS ne change pas — roues qui patinent ou calées sur des racines invisibles au LiDAR — il coupe la lame et recule au lieu de creuser.",
+    "stuckEnabled": "Activer",
+    "stuckEnabledTooltip": "Reculer automatiquement quand les roues patinent ou calent sans que le robot avance réellement",
+    "stuckWindow": "Fenêtre de détection",
+    "stuckWindowTooltip": "Secondes de commande-sans-mouvement avant de reculer",
+    "stuckMinCommanded": "Déplacement commandé min",
+    "stuckMinCommandedTooltip": "Distance commandée/roues sur la fenêtre nécessaire pour armer le détecteur",
+    "stuckMaxDisplacement": "Déplacement réel max",
+    "stuckMaxDisplacementTooltip": "Déplacement GPS en dessous duquel le robot est considéré enlisé (doit dépasser le bruit RTK)"
   },
   "settingsMowing": {
     "mowingMotor": "Moteur de tonte",

--- a/ros2/scripts/check_config_drift.py
+++ b/ros2/scripts/check_config_drift.py
@@ -102,6 +102,8 @@ USER_OVERRIDE = {
     "path_spacing", "mow_angle_offset_deg", "mow_angle_increment_deg",
     "max_obstacle_avoidance_distance", "coverage_xy_tolerance",
     "obstacle_inflation_radius", "obstacle_margin", "obstacle_slowdown_ratio",
+    "stuck_detection_enabled", "stuck_window_sec",
+    "stuck_min_commanded_m", "stuck_max_displacement_m",
     "xy_goal_tolerance", "yaw_goal_tolerance",
     "progress_timeout_sec",
     "motor_temp_low_c", "motor_temp_high_c",

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -156,6 +156,34 @@ if(BUILD_TESTING)
     tf2_geometry_msgs
   )
 
+  # ---- test_wheel_slip_stuck ----
+  # Exercises IsWheelSlipStuck by filling BTContext::motion_window the way
+  # behavior_tree_node's 5 Hz snapshot timer would (slip, stall, moving,
+  # stale/invalid TF, shared cap + cooldown with IsObstacleStuck).
+  ament_add_gtest(test_wheel_slip_stuck
+    test/test_wheel_slip_stuck.cpp
+    src/condition_nodes.cpp
+  )
+
+  target_include_directories(test_wheel_slip_stuck PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  ament_target_dependencies(test_wheel_slip_stuck
+    rclcpp
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+  )
+
   # ---- test_set_nav2_lifecycle ----
   # Exercises the SetNav2Lifecycle action node's idle-suspend gating
   # (disabled = no-op, PAUSE refused off-dock, idempotent transitions) and,

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -289,6 +290,40 @@ struct BTContext
   /// enforce a cooldown so we don't re-fire on the same wedge while
   /// the BackUp + costmap clear is still settling.
   std::chrono::steady_clock::time_point last_obstacle_backoff_time{};
+
+  // -----------------------------------------------------------------------
+  // Wheel-slip / stall stuck detection (IsWheelSlipStuck)
+  // -----------------------------------------------------------------------
+
+  /// One 5 Hz motion snapshot: monotonically-growing distance integrals of
+  /// |cmd_vel_monitored.linear.x| and |/wheel_odom vx| plus the map-frame
+  /// base_footprint position at snapshot time. IsWheelSlipStuck compares the
+  /// window's oldest and newest samples: lots of COMMANDED (or wheel) travel
+  /// with (near-)zero MAP displacement means the robot is digging in on a
+  /// root/obstacle the LiDAR cannot see. The map pose (GPS/graph-anchored) is
+  /// deliberately used instead of /odometry/filtered — the odom estimate is
+  /// wheel-fed dead-reckoning and happily "moves" while the wheels spin in
+  /// place. A fusion_graph map jump inflates displacement, which SUPPRESSES
+  /// firing — fail-safe.
+  struct MotionSample
+  {
+    std::chrono::steady_clock::time_point t{};
+    double cmd_dist{0.0};  ///< ∫|cmd_vel.linear.x| dt up to t (m)
+    double wheel_dist{0.0};  ///< ∫|wheel vx| dt up to t (m)
+    double map_x{0.0};
+    double map_y{0.0};
+    bool map_valid{false};  ///< map→base_footprint TF was available at t
+  };
+
+  /// Rolling window of motion samples (guarded by context_mutex like the
+  /// collision fields above). behavior_tree_node's 5 Hz timer appends and
+  /// trims to ~2× the largest window IsWheelSlipStuck reads.
+  std::deque<MotionSample> motion_window;
+
+  /// Running integrals updated by the /cmd_vel_monitored and /wheel_odom
+  /// subscribers; snapshotted into motion_window by the 5 Hz timer.
+  double cmd_dist_accum{0.0};
+  double wheel_dist_accum{0.0};
 
   // -----------------------------------------------------------------------
   // Per-session flags reset by ClearCommand at session end

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
@@ -583,6 +583,56 @@ public:
 };
 
 // ---------------------------------------------------------------------------
+// IsWheelSlipStuck
+// ---------------------------------------------------------------------------
+
+/// Fires (SUCCESS) when the robot has been COMMANDED to move but its
+/// GPS/graph-anchored map pose has not moved — wheels spinning on / stalled
+/// against an obstacle below the 2D LiDAR scan plane (tree roots, molehills):
+/// the digging-in failure mode IsObstacleStuck can never see because the
+/// collision_monitor never reports STOP for sub-scan-plane obstacles.
+///
+/// Detector: over the last `window_sec` of BTContext::motion_window samples,
+///   commanded = max(Δcmd_dist, Δwheel_dist)   (covers stall AND slip)
+///   displacement = hypot(Δmap_x, Δmap_y)
+///   stuck ⇔ commanded ≥ min_commanded_m AND displacement ≤ max_displacement_m
+/// Both window endpoints must have map_valid; a fusion_graph map jump only
+/// INFLATES displacement, suppressing the trigger (fail-safe).
+///
+/// Shares obstacle_backoff_count / last_obstacle_backoff_time with
+/// IsObstacleStuck: one per-session cap and one cooldown across both
+/// StuckBackoff triggers.
+class IsWheelSlipStuck : public BT::ConditionNode
+{
+public:
+  IsWheelSlipStuck(const std::string& name, const BT::NodeConfig& config)
+      : BT::ConditionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+        BT::InputPort<bool>("enabled", true, "Master toggle (stuck_detection_enabled)"),
+        BT::InputPort<double>("window_sec", 4.0, "Rolling window length (s)"),
+        BT::InputPort<double>("min_commanded_m",
+                              0.15,
+                              "Commanded/wheel travel over the window needed to arm (m)"),
+        BT::InputPort<double>(
+            "max_displacement_m",
+            0.05,
+            "Map-frame displacement at or below which the robot counts as stuck (m)"),
+        BT::InputPort<int>("max_count", 3, "Per-session cap shared with IsObstacleStuck"),
+        BT::InputPort<double>("cooldown_sec",
+                              8.0,
+                              "Minimum gap between firings, shared with IsObstacleStuck"),
+    };
+  }
+
+  BT::NodeStatus tick() override;
+};
+
+// ---------------------------------------------------------------------------
 // WasRecentlyInCollisionStop
 // ---------------------------------------------------------------------------
 

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -13,8 +13,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -25,6 +27,7 @@
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "behaviortree_cpp/behavior_tree.h"
 #include "behaviortree_cpp/loggers/bt_cout_logger.h"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "mowgli_behavior/action_nodes.hpp"
 #include "mowgli_behavior/bt_context.hpp"
 #include "mowgli_behavior/condition_nodes.hpp"
@@ -40,10 +43,12 @@
 #include "nav2_msgs/action/navigate_to_pose.hpp"
 #include "nav2_msgs/action/undock_robot.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
+#include "tf2/exceptions.hpp"
 
 using namespace std::chrono_literals;
 
@@ -335,6 +340,82 @@ private:
           }
         });
 
+    // Motion integrals for IsWheelSlipStuck. Two "trying to move" signals:
+    // /cmd_vel_monitored (post-collision_monitor command — accumulates even
+    // when the wheels are STALLED against a root, the case wheel odom misses)
+    // and /wheel_odom (accumulates when the wheels SPIN in place, the case a
+    // near-zero commanded speed could under-report). The condition node takes
+    // max(cmd, wheel) over its window. dt is wall-clock between messages,
+    // clamped so a stream hiccup can't inject a huge phantom distance.
+    cmd_vel_sub_ = create_subscription<geometry_msgs::msg::TwistStamped>(
+        "/cmd_vel_monitored",
+        10,
+        [this](geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
+        {
+          const auto now = std::chrono::steady_clock::now();
+          std::lock_guard<std::mutex> lock(context_->context_mutex);
+          if (last_cmd_vel_time_.time_since_epoch().count() != 0)
+          {
+            const double dt =
+                std::min(kMotionIntegrationMaxDtSec,
+                         std::chrono::duration<double>(now - last_cmd_vel_time_).count());
+            context_->cmd_dist_accum += std::fabs(msg->twist.linear.x) * dt;
+          }
+          last_cmd_vel_time_ = now;
+        });
+
+    wheel_odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
+        "/wheel_odom",
+        rclcpp::SensorDataQoS(),
+        [this](nav_msgs::msg::Odometry::ConstSharedPtr msg)
+        {
+          const auto now = std::chrono::steady_clock::now();
+          std::lock_guard<std::mutex> lock(context_->context_mutex);
+          if (last_wheel_odom_time_.time_since_epoch().count() != 0)
+          {
+            const double dt =
+                std::min(kMotionIntegrationMaxDtSec,
+                         std::chrono::duration<double>(now - last_wheel_odom_time_).count());
+            context_->wheel_dist_accum += std::fabs(msg->twist.twist.linear.x) * dt;
+          }
+          last_wheel_odom_time_ = now;
+        });
+
+    // 5 Hz snapshot of the motion integrals + the GPS/graph-anchored
+    // map→base_footprint position into the rolling window IsWheelSlipStuck
+    // reads. TF unavailability is recorded (map_valid=false) rather than
+    // skipped so the condition can refuse to fire on a stale window.
+    motion_window_timer_ = create_wall_timer(
+        std::chrono::milliseconds(200),
+        [this]()
+        {
+          BTContext::MotionSample sample;
+          sample.t = std::chrono::steady_clock::now();
+          try
+          {
+            const auto tf =
+                context_->tf_buffer->lookupTransform("map", "base_footprint", tf2::TimePointZero);
+            sample.map_x = tf.transform.translation.x;
+            sample.map_y = tf.transform.translation.y;
+            sample.map_valid = true;
+          }
+          catch (const tf2::TransformException&)
+          {
+            sample.map_valid = false;
+          }
+          std::lock_guard<std::mutex> lock(context_->context_mutex);
+          sample.cmd_dist = context_->cmd_dist_accum;
+          sample.wheel_dist = context_->wheel_dist_accum;
+          context_->motion_window.push_back(sample);
+          // Keep ~2× the largest window IsWheelSlipStuck can be configured
+          // with (30 s) so the oldest-sample lookup always has slack.
+          const auto horizon = sample.t - std::chrono::seconds(60);
+          while (!context_->motion_window.empty() && context_->motion_window.front().t < horizon)
+          {
+            context_->motion_window.pop_front();
+          }
+        });
+
     RCLCPP_DEBUG(get_logger(), "Topic subscribers created");
   }
 
@@ -568,6 +649,23 @@ private:
     const double undock_distance = declare_parameter<double>("undock_distance", 1.0);
     blackboard_->set("undock_distance", undock_distance);
 
+    // Wheel-slip / stall stuck detection (IsWheelSlipStuck, StuckBackoff).
+    // Template defaults in mowgli_bringup/config/mowgli_robot.yaml (GUI:
+    // Settings → Obstacles); forwarded here by full_system.launch.py. Clamps
+    // mirror the template comments so a stray override cannot make the
+    // detector hair-triggered (window < 2 s) or dead (displacement gate 0).
+    const bool stuck_enabled = declare_parameter<bool>("stuck_detection_enabled", true);
+    blackboard_->set("stuck_detection_enabled", stuck_enabled);
+    const double stuck_window_sec =
+        std::clamp(declare_parameter<double>("stuck_window_sec", 4.0), 2.0, 30.0);
+    blackboard_->set("stuck_window_sec", stuck_window_sec);
+    const double stuck_min_commanded_m =
+        std::clamp(declare_parameter<double>("stuck_min_commanded_m", 0.15), 0.05, 1.0);
+    blackboard_->set("stuck_min_commanded_m", stuck_min_commanded_m);
+    const double stuck_max_displacement_m =
+        std::clamp(declare_parameter<double>("stuck_max_displacement_m", 0.05), 0.01, 0.3);
+    blackboard_->set("stuck_max_displacement_m", stuck_max_displacement_m);
+
     // idle_nav2_suspend (default false): when true, the BT PAUSEs the Nav2
     // lifecycle stack (via SetNav2Lifecycle) while parked on the dock to cut
     // the idle CPU/thermal load of the always-looping costmaps, and RESUMEs
@@ -743,6 +841,15 @@ private:
   rclcpp::Subscription<mowgli_interfaces::msg::AbsolutePose>::SharedPtr gps_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::GnssStatus>::SharedPtr gnss_status_sub_;
   rclcpp::Subscription<nav2_msgs::msg::CollisionMonitorState>::SharedPtr collision_monitor_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr wheel_odom_sub_;
+  // Wall-clock stamps of the previous cmd_vel / wheel_odom message, for the
+  // |v|·dt motion integrals (guarded by context_mutex alongside the accums).
+  std::chrono::steady_clock::time_point last_cmd_vel_time_{};
+  std::chrono::steady_clock::time_point last_wheel_odom_time_{};
+  // Cap per-message integration dt: a stream that stalls then resumes must
+  // not inject a phantom |v|·gap distance into the stuck detector.
+  static constexpr double kMotionIntegrationMaxDtSec = 0.5;
 
   // Service server
   rclcpp::Service<mowgli_interfaces::srv::HighLevelControl>::SharedPtr high_level_control_srv_;
@@ -750,6 +857,7 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr clear_coverage_resume_srv_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr resume_available_pub_;
   rclcpp::TimerBase::SharedPtr resume_available_timer_;
+  rclcpp::TimerBase::SharedPtr motion_window_timer_;
   // Set by the ~/clear_coverage_resume service, consumed by tickTree() so the
   // actual map clearing happens on the BT tick thread (see the service comment).
   std::atomic<bool> clear_resume_requested_{false};

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -15,7 +15,9 @@
 
 #include "mowgli_behavior/condition_nodes.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <memory>
 #include <mutex>
@@ -704,6 +706,139 @@ BT::NodeStatus IsObstacleStuck::tick()
               "IsObstacleStuck: collision_monitor STOP active for %.1fs — "
               "triggering obstacle-backoff (%d/%d)",
               stop_age_sec,
+              ctx->obstacle_backoff_count,
+              max_count);
+
+  return BT::NodeStatus::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// IsWheelSlipStuck
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus IsWheelSlipStuck::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+
+  bool enabled = true;
+  if (auto res = getInput<bool>("enabled"))
+  {
+    enabled = res.value();
+  }
+  if (!enabled)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  double window_sec = 4.0;
+  if (auto res = getInput<double>("window_sec"))
+  {
+    window_sec = res.value();
+  }
+  double min_commanded_m = 0.15;
+  if (auto res = getInput<double>("min_commanded_m"))
+  {
+    min_commanded_m = res.value();
+  }
+  double max_displacement_m = 0.05;
+  if (auto res = getInput<double>("max_displacement_m"))
+  {
+    max_displacement_m = res.value();
+  }
+  int max_count = 3;
+  if (auto res = getInput<int>("max_count"))
+  {
+    max_count = res.value();
+  }
+  double cooldown_sec = 8.0;
+  if (auto res = getInput<double>("cooldown_sec"))
+  {
+    cooldown_sec = res.value();
+  }
+
+  std::lock_guard<std::mutex> lock(ctx->context_mutex);
+
+  const auto now = std::chrono::steady_clock::now();
+
+  // Newest sample must be fresh (the 5 Hz snapshot timer is alive) and
+  // map-valid; then walk back to the oldest sample still inside the window.
+  if (ctx->motion_window.size() < 2)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto& newest = ctx->motion_window.back();
+  if (!newest.map_valid || std::chrono::duration<double>(now - newest.t).count() > 1.0)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  const auto window_start = now - std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                      std::chrono::duration<double>(window_sec));
+  const BTContext::MotionSample* oldest = nullptr;
+  for (const auto& s : ctx->motion_window)
+  {
+    if (s.t >= window_start)
+    {
+      oldest = &s;
+      break;
+    }
+  }
+  if (oldest == nullptr || !oldest->map_valid || oldest == &newest)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  // The window must actually SPAN close to window_sec — right after startup
+  // (or a window purge) the oldest surviving sample may be much younger, and
+  // judging "no displacement" over half a window is hair-triggered.
+  const double span_sec = std::chrono::duration<double>(newest.t - oldest->t).count();
+  if (span_sec < 0.8 * window_sec)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Stall AND slip covered: wheels blocked by a root → wheel_dist ~0 but
+  // cmd_dist accumulates; wheels digging in place → both accumulate. Either
+  // way the map pose stays put.
+  const double commanded =
+      std::max(newest.cmd_dist - oldest->cmd_dist, newest.wheel_dist - oldest->wheel_dist);
+  const double displacement =
+      std::hypot(newest.map_x - oldest->map_x, newest.map_y - oldest->map_y);
+  if (commanded < min_commanded_m || displacement > max_displacement_m)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+
+  // Shared per-session cap + cooldown with IsObstacleStuck — one budget for
+  // the whole StuckBackoff recovery, whichever trigger fires.
+  if (ctx->obstacle_backoff_count >= max_count)
+  {
+    RCLCPP_WARN_THROTTLE(ctx->node->get_logger(),
+                         *ctx->node->get_clock(),
+                         5000,
+                         "IsWheelSlipStuck: backoff cap reached (%d/%d), "
+                         "deferring to MarkBlockedAndSkip",
+                         ctx->obstacle_backoff_count,
+                         max_count);
+    return BT::NodeStatus::FAILURE;
+  }
+  if (ctx->last_obstacle_backoff_time.time_since_epoch().count() != 0)
+  {
+    const double since_last_sec =
+        std::chrono::duration<double>(now - ctx->last_obstacle_backoff_time).count();
+    if (since_last_sec < cooldown_sec)
+    {
+      return BT::NodeStatus::FAILURE;
+    }
+  }
+
+  ctx->obstacle_backoff_count++;
+  ctx->last_obstacle_backoff_time = now;
+
+  RCLCPP_WARN(ctx->node->get_logger(),
+              "IsWheelSlipStuck: commanded %.2f m but map displacement only "
+              "%.2f m over %.1f s — wheels slipping/stalled (likely a "
+              "sub-scan-plane obstacle), triggering obstacle-backoff (%d/%d)",
+              commanded,
+              displacement,
+              span_sec,
               ctx->obstacle_backoff_count,
               max_count);
 

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -770,14 +770,27 @@ BT::NodeStatus IsWheelSlipStuck::tick()
   {
     return BT::NodeStatus::FAILURE;
   }
+  // Pick the sample BRACKETING the window boundary: the last one at or
+  // before now − window_sec, falling back to the first inside the window.
+  // Selecting only samples strictly inside the window drops the boundary
+  // sample (at 5 Hz the oldest in-window sample is ~0.2 s young, and a
+  // sample exactly window_sec old always loses the now-vs-snapshot race),
+  // silently shortening every judged window.
   const auto window_start = now - std::chrono::duration_cast<std::chrono::steady_clock::duration>(
                                       std::chrono::duration<double>(window_sec));
   const BTContext::MotionSample* oldest = nullptr;
   for (const auto& s : ctx->motion_window)
   {
-    if (s.t >= window_start)
+    if (s.t <= window_start)
     {
-      oldest = &s;
+      oldest = &s;  // keep advancing — we want the LAST pre-boundary sample
+    }
+    else
+    {
+      if (oldest == nullptr)
+      {
+        oldest = &s;  // no pre-boundary sample survived — first in-window one
+      }
       break;
     }
   }
@@ -785,11 +798,12 @@ BT::NodeStatus IsWheelSlipStuck::tick()
   {
     return BT::NodeStatus::FAILURE;
   }
-  // The window must actually SPAN close to window_sec — right after startup
-  // (or a window purge) the oldest surviving sample may be much younger, and
-  // judging "no displacement" over half a window is hair-triggered.
+  // The judged span must be CLOSE to window_sec on both sides: shorter
+  // (right after startup / a purge) is hair-triggered; much longer (a
+  // stalled snapshot timer bridging a gap) would accumulate commanded
+  // distance over motion the displacement check never saw.
   const double span_sec = std::chrono::duration<double>(newest.t - oldest->t).count();
-  if (span_sec < 0.8 * window_sec)
+  if (span_sec < 0.8 * window_sec || span_sec > 1.5 * window_sec)
   {
     return BT::NodeStatus::FAILURE;
   }

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -48,6 +48,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<PreFlightCheck>("PreFlightCheck");
   factory.registerNodeType<Nav2Active>("Nav2Active");
   factory.registerNodeType<IsObstacleStuck>("IsObstacleStuck");
+  factory.registerNodeType<IsWheelSlipStuck>("IsWheelSlipStuck");
   factory.registerNodeType<WasRecentlyInCollisionStop>("WasRecentlyInCollisionStop");
 
   // Action nodes

--- a/ros2/src/mowgli_behavior/test/test_wheel_slip_stuck.cpp
+++ b/ros2/src/mowgli_behavior/test/test_wheel_slip_stuck.cpp
@@ -1,0 +1,268 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_wheel_slip_stuck.cpp
+ * @brief Unit tests for the IsWheelSlipStuck condition node.
+ *
+ * Builds a BTContext in-process and fills motion_window the way
+ * behavior_tree_node's 5 Hz snapshot timer would, then ticks the node:
+ * slip (wheel odom advances, map pose doesn't), stall (cmd integral
+ * advances, wheels blocked), normal mowing, disabled toggle, stale/invalid
+ * TF, shared cap + cooldown with IsObstacleStuck.
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/condition_nodes.hpp"
+#include "nav2_msgs/msg/collision_monitor_state.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::IsObstacleStuck;
+using mowgli_behavior::IsWheelSlipStuck;
+using CollisionMonitorState = nav2_msgs::msg::CollisionMonitorState;
+
+// ---------------------------------------------------------------------------
+// Global ROS2 init/shutdown
+// ---------------------------------------------------------------------------
+
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+::testing::Environment* const rclcpp_env =
+    ::testing::AddGlobalTestEnvironment(new RclcppEnvironment());
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class IsWheelSlipStuckTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<BTContext> ctx;
+  BT::Blackboard::Ptr blackboard;
+  BT::BehaviorTreeFactory factory;
+  BT::Tree tree;
+
+  void SetUp() override
+  {
+    ctx = std::make_shared<BTContext>();
+    ctx->node = rclcpp::Node::make_shared("test_is_wheel_slip_stuck");
+
+    blackboard = BT::Blackboard::create();
+    blackboard->set("context", ctx);
+
+    factory.registerNodeType<IsWheelSlipStuck>("IsWheelSlipStuck");
+
+    static const char* xml = R"(
+      <root BTCPP_format="4">
+        <BehaviorTree ID="MainTree">
+          <IsWheelSlipStuck enabled="true" window_sec="4.0"
+                            min_commanded_m="0.15" max_displacement_m="0.05"
+                            max_count="3" cooldown_sec="8.0"/>
+        </BehaviorTree>
+      </root>
+    )";
+    tree = factory.createTreeFromText(xml, blackboard);
+  }
+
+  /// Fill motion_window with two endpoint samples the way the 5 Hz
+  /// snapshot timer would: `span_sec` apart, ending `end_age_sec` ago,
+  /// with the given per-window deltas. Absolute integrals are arbitrary —
+  /// only the deltas matter to the detector.
+  void fillWindow(double span_sec,
+                  double cmd_delta,
+                  double wheel_delta,
+                  double map_dx,
+                  double map_dy,
+                  bool oldest_valid = true,
+                  bool newest_valid = true,
+                  double end_age_sec = 0.0)
+  {
+    ctx->motion_window.clear();
+    const auto now = std::chrono::steady_clock::now();
+    const auto newest_t = now - std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                    std::chrono::duration<double>(end_age_sec));
+    const auto oldest_t =
+        newest_t - std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                       std::chrono::duration<double>(span_sec));
+    BTContext::MotionSample oldest;
+    oldest.t = oldest_t;
+    oldest.cmd_dist = 10.0;
+    oldest.wheel_dist = 10.0;
+    oldest.map_x = 5.0;
+    oldest.map_y = 5.0;
+    oldest.map_valid = oldest_valid;
+    BTContext::MotionSample newest;
+    newest.t = newest_t;
+    newest.cmd_dist = 10.0 + cmd_delta;
+    newest.wheel_dist = 10.0 + wheel_delta;
+    newest.map_x = 5.0 + map_dx;
+    newest.map_y = 5.0 + map_dy;
+    newest.map_valid = newest_valid;
+    ctx->motion_window.push_back(oldest);
+    ctx->motion_window.push_back(newest);
+  }
+
+  BT::NodeStatus tick()
+  {
+    return tree.tickOnce();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Wheels spinning in place (digging on a root): wheel integral advances,
+// map pose static → SUCCESS.
+TEST_F(IsWheelSlipStuckTest, FiresOnWheelSlip)
+{
+  fillWindow(4.0, /*cmd*/ 0.6, /*wheel*/ 0.6, /*dx*/ 0.02, /*dy*/ 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+}
+
+// Wheels BLOCKED by a root (firmware PID stalled): wheel integral ~0 but
+// the commanded integral advances → SUCCESS. This is the case a
+// wheel-odom-only detector misses.
+TEST_F(IsWheelSlipStuckTest, FiresOnStall)
+{
+  fillWindow(4.0, /*cmd*/ 0.6, /*wheel*/ 0.0, /*dx*/ 0.0, /*dy*/ 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+}
+
+// Normal mowing: commanded travel matched by real displacement → FAILURE.
+TEST_F(IsWheelSlipStuckTest, FailsWhenActuallyMoving)
+{
+  fillWindow(4.0, 0.6, 0.6, 0.55, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// Not commanded to move (idle, pivot, FTC deviation hold): below the
+// min-commanded arm threshold → FAILURE even with zero displacement.
+TEST_F(IsWheelSlipStuckTest, FailsBelowMinCommanded)
+{
+  fillWindow(4.0, 0.05, 0.05, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// map→base_footprint TF unavailable at a window endpoint: refuse to judge.
+TEST_F(IsWheelSlipStuckTest, FailsWithoutValidMapPose)
+{
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0, /*oldest_valid*/ false);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0, true, /*newest_valid*/ false);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// Newest sample stale (snapshot timer dead / node just started) → FAILURE.
+TEST_F(IsWheelSlipStuckTest, FailsOnStaleWindow)
+{
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0, true, true, /*end_age_sec*/ 3.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// Window that does not span (~80 % of) window_sec yet — right after startup
+// or a purge — must not fire.
+TEST_F(IsWheelSlipStuckTest, FailsOnShortSpan)
+{
+  fillWindow(/*span*/ 1.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// Empty / single-sample window → FAILURE.
+TEST_F(IsWheelSlipStuckTest, FailsOnEmptyWindow)
+{
+  ctx->motion_window.clear();
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+}
+
+// enabled=false master toggle.
+TEST_F(IsWheelSlipStuckTest, DisabledNeverFires)
+{
+  static const char* xml = R"(
+    <root BTCPP_format="4">
+      <BehaviorTree ID="MainTree">
+        <IsWheelSlipStuck enabled="false" window_sec="4.0"
+                          min_commanded_m="0.15" max_displacement_m="0.05"
+                          max_count="3" cooldown_sec="8.0"/>
+      </BehaviorTree>
+    </root>
+  )";
+  BT::BehaviorTreeFactory f2;
+  f2.registerNodeType<IsWheelSlipStuck>("IsWheelSlipStuck");
+  auto disabled_tree = f2.createTreeFromText(xml, blackboard);
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(disabled_tree.tickOnce(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
+// Cooldown: a second wedge within cooldown_sec of the first firing (from
+// EITHER trigger — the timestamps are shared with IsObstacleStuck) must wait.
+TEST_F(IsWheelSlipStuckTest, RespectsSharedCooldown)
+{
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+
+  // Same wedge immediately re-judged: cooldown blocks.
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 1);
+
+  // Simulate the cooldown having elapsed.
+  ctx->last_obstacle_backoff_time = std::chrono::steady_clock::now() - std::chrono::seconds(9);
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 2);
+}
+
+// Per-session cap shared with IsObstacleStuck: firings by the collision
+// trigger count against this node's budget too.
+TEST_F(IsWheelSlipStuckTest, RespectsSharedSessionCap)
+{
+  ctx->obstacle_backoff_count = 3;  // as if IsObstacleStuck fired 3× already
+  fillWindow(4.0, 0.6, 0.6, 0.0, 0.0);
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 3);
+}

--- a/ros2/src/mowgli_behavior/test/test_wheel_slip_stuck.cpp
+++ b/ros2/src/mowgli_behavior/test/test_wheel_slip_stuck.cpp
@@ -210,6 +210,16 @@ TEST_F(IsWheelSlipStuckTest, FailsOnShortSpan)
   EXPECT_EQ(ctx->obstacle_backoff_count, 0);
 }
 
+// Window whose surviving endpoints span FAR more than window_sec (a stalled
+// snapshot timer bridging a gap) must not fire either — the commanded
+// integral would cover motion the displacement check never saw.
+TEST_F(IsWheelSlipStuckTest, FailsOnOverlongSpan)
+{
+  fillWindow(/*span*/ 8.0, 1.2, 1.2, 0.0, 0.0);  // 8 s >> 1.5 × 4 s window
+  EXPECT_EQ(tick(), BT::NodeStatus::FAILURE);
+  EXPECT_EQ(ctx->obstacle_backoff_count, 0);
+}
+
 // Empty / single-sample window → FAILURE.
 TEST_F(IsWheelSlipStuckTest, FailsOnEmptyWindow)
 {

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -586,9 +586,28 @@
                              re-ticks FollowStrip, which resumes at the
                              first un-mowed segment index. -->
                         <Sequence name="StuckBackoff">
-                          <IsObstacleStuck min_duration_sec="4.0"
-                                           max_count="3"
-                                           cooldown_sec="8.0"/>
+                          <!-- Two independent stuck triggers, one shared
+                               per-session cap + cooldown (BTContext
+                               obstacle_backoff_count):
+                               - IsObstacleStuck: collision_monitor STOP wedge
+                                 (LiDAR-visible obstacle).
+                               - IsWheelSlipStuck: commanded-but-not-moving in
+                                 the MAP frame — wheels spinning on / stalled
+                                 against something BELOW the scan plane (tree
+                                 roots). Without it the robot kept forcing,
+                                 digging itself in; now it backs off, blade
+                                 already cut by the sequence below. -->
+                          <Fallback name="StuckTriggers">
+                            <IsObstacleStuck min_duration_sec="4.0"
+                                             max_count="3"
+                                             cooldown_sec="8.0"/>
+                            <IsWheelSlipStuck enabled="{stuck_detection_enabled}"
+                                              window_sec="{stuck_window_sec}"
+                                              min_commanded_m="{stuck_min_commanded_m}"
+                                              max_displacement_m="{stuck_max_displacement_m}"
+                                              max_count="3"
+                                              cooldown_sec="8.0"/>
+                          </Fallback>
                           <PublishHighLevelStatus state="2"
                                                   state_name="OBSTACLE_BACKOFF"/>
                           <SetMowerEnabled enabled="false"/>

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -341,6 +341,21 @@ mowgli:
     # inside the chassis+15 cm approach box (LiDAR variant only). 0.3 = slow
     # to 30 % of commanded speed. Clamped to [0.05, 1.0].
     obstacle_slowdown_ratio: 0.3
+    # Wheel-slip / stall stuck detection (IsWheelSlipStuck → StuckBackoff:
+    # blade off + BackUp 0.40 m + costmap clear, shared per-session cap with
+    # the collision-monitor trigger). Fires when the robot was COMMANDED to
+    # travel ≥ stuck_min_commanded_m over stuck_window_sec but its
+    # GPS/graph-anchored map pose moved ≤ stuck_max_displacement_m — wheels
+    # spinning on / stalled against something BELOW the 2D LiDAR scan plane
+    # (tree roots, molehills), the digging-in failure mode. Clamps in
+    # behavior_tree_node: window [2, 30] s, commanded [0.05, 1.0] m,
+    # displacement [0.01, 0.3] m. stuck_max_displacement_m must stay above
+    # RTK-Fixed + graph jitter over the window (σ_xy ~ mm-cm) but below real
+    # mowing progress (0.2 m/s × 4 s = 0.8 m).
+    stuck_detection_enabled: true
+    stuck_window_sec: 4.0
+    stuck_min_commanded_m: 0.15
+    stuck_max_displacement_m: 0.05
 
     # -----------------------------------------------------------------
     # Navigation tolerances (garden terrain)

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -230,6 +230,18 @@ def generate_launch_description() -> LaunchDescription:
             # references in main_tree.xml. See issue #191.
             {"undock_speed": float(robot_params.get("undock_speed", 0.15))},
             {"undock_distance": float(robot_params.get("undock_distance", 1.0))},
+            # Wheel-slip / stall stuck detection (IsWheelSlipStuck →
+            # StuckBackoff). Blackboard-forwarded like undock_* above;
+            # template defaults + GUI (Settings → Obstacles) in
+            # mowgli_robot.yaml. behavior_tree_node clamps.
+            {"stuck_detection_enabled": bool(
+                robot_params.get("stuck_detection_enabled", True))},
+            {"stuck_window_sec": float(
+                robot_params.get("stuck_window_sec", 4.0))},
+            {"stuck_min_commanded_m": float(
+                robot_params.get("stuck_min_commanded_m", 0.15))},
+            {"stuck_max_displacement_m": float(
+                robot_params.get("stuck_max_displacement_m", 0.05))},
             # idle_nav2_suspend: PAUSE the Nav2 lifecycle stack while parked on
             # the dock to cut idle CPU/thermal load (costmaps stop looping).
             # Default off — a deliberate per-site opt-in. RESUME is guaranteed


### PR DESCRIPTION
> ⚠️ **SAFETY-CRITICAL** — modifie le comportement physique (lame OFF + recul autonome 0,40 m). **Empilée sur #371** (re-cibler `dev` après merge de #371).

## Problème

Coincé sur des racines d'arbre, le robot **force, patine et creuse** : les racines sont sous le plan de scan du LiDAR 2D (~0,10–0,22 m) → aucune cellule costmap, aucun STOP du collision_monitor, aucune récupération. La récupération `StuckBackoff` existante (BackUp 0,40 m + ClearCostmap) était du **code mort** : son seul déclencheur `IsObstacleStuck` exige un STOP du collision_monitor, mais `PolygonStop` n'est pas dans le set actif (seul `PolygonSlow` l'est) — il ne pouvait jamais tirer.

## Changements

**Nouveau `IsWheelSlipStuck`** (condition BT) : sur une fenêtre glissante (4 s),
- `commanded = max(∫|cmd_vel_monitored.vx|dt, ∫|wheel_odom vx|dt)` — couvre **patinage** (roues tournent, pose map statique) ET **calage** (roues bloquées, PID firmware cale, l'intégrale de commande monte)
- `displacement = hypot(Δ map→base_footprint)` — vérité **frame map** (ancrée GPS/graphe), PAS `/odometry/filtered` (dead-reckoning roues : il « bouge » pendant le patinage)
- stuck ⇔ `commanded ≥ 0.15 m` ET `displacement ≤ 0.05 m`

**Fail-safe par construction** : TF absent/périmé → refus de juger ; saut de map fusion_graph → gonfle le déplacement → supprime le déclenchement ; pivots/holds FTC → `linear.x≈0` → jamais armé. Cap par session (3) + cooldown (8 s) **partagés** avec `IsObstacleStuck`. `StuckBackoff` (lame OFF → BackUp → ClearCostmap → reprise au curseur) inchangé, atteignable uniquement depuis `MowingSequence` (revue : structurellement impossible en transit/docking/undock).

**Plomberie** : subs `/cmd_vel_monitored` + `/wheel_odom` (intégrales |vx|·dt, dt clampé 0,5 s) + timer 5 Hz → `BTContext::motion_window` (deque 60 s, sous mutex). 4 clés template → launch → blackboard (clamps) → GUI Settings → Obstacles « Détection d'enlisement » (i18n en+fr) : `stuck_detection_enabled`, `stuck_window_sec`, `stuck_min_commanded_m`, `stuck_max_displacement_m`.

## Tests

- [x] `test_wheel_slip_stuck.cpp` : patinage, calage, tonte normale, sous-seuil, TF invalide/périmé, fenêtre courte/vide, toggle off, cooldown + cap partagés (CI)
- [x] Revue safety dédiée : thread-safety (ordre TF→lock OK), analyse faux-positifs (pivots, docking, undock), wiring blackboard — 0 problème
- [x] clang-format clean, drift-checker OK, `yarn build` OK
- [ ] **Terrain avant merge** : valider `stuck_max_displacement_m=0.05` > bruit RTK-Fixed + jitter graphe sur 4 s contre une session JSONL ; test sur vraie racine → statut `OBSTACLE_BACKOFF` + recul lame coupée

## Note revue

Mineur (non bloquant) : `EndSession` ne purge pas `motion_window`/accumulateurs — auto-cicatrisant (fenêtre bornée 60 s + gate fraîcheur 1 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)