### PR TITLE
feat: flag padded template defaults in the committed sparse config (#381)

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'ros2/**'
       - 'tools/motor/**'
+      - 'install/config/mowgli/**'
       - '.github/workflows/ros2-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'ros2/**'
       - 'tools/motor/**'
+      - 'install/config/mowgli/**'
       - '.github/workflows/ros2-ci.yml'
 
 concurrency:
@@ -28,7 +30,10 @@ jobs:
   # field (chassis geometry, wheel kinematics, sensor mounts) is defined in both
   # files with divergent values, or added to the installed file with no template
   # default — either of which silently gives Nav2/URDF/coverage the wrong
-  # chassis. No ROS2 setup needed; runs in seconds as a hard gate.
+  # chassis. It also fails (issue #381) if the committed sparse file pads a key
+  # with a value EQUAL to its template default — a no-op at merge time that
+  # silently pins robots to a stale value when the template default is later
+  # changed. No ROS2 setup needed; runs in seconds as a hard gate.
   config-drift:
     name: Config Drift (mowgli_robot.yaml)
     runs-on: ubuntu-24.04
@@ -36,10 +41,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Check mowgli_robot.yaml structural drift
+      - name: Check mowgli_robot.yaml drift + padded defaults
         run: |
           python3 -m pip install --quiet pyyaml
           python3 ros2/scripts/check_config_drift.py
+
+      - name: Unit-test check_config_drift.py
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest -q ros2/scripts/test_check_config_drift.py
 
   # ─── Build & Test ────────────────────────────────────────────────────────────
   build-and-test:

--- a/ros2/scripts/check_config_drift.py
+++ b/ros2/scripts/check_config_drift.py
@@ -37,7 +37,14 @@ What this script does
   propagate-a-new-default property (Invariant 15).
 - For each USER_OVERRIDE / calibration-output field, expects them to
   differ (or only exist in the installed file) and is silent.
-- Prints a diff and exits non-zero if any structural field has drifted.
+- Flags ANY field present in the installed file whose value EQUALS the
+  template default (issue #381). Such a key is a no-op at merge time, but
+  it masks future template-default changes (Invariant 15's propagate-a-
+  new-default property) — the fix is to delete the line, not to keep it in
+  sync. Calibration outputs and install-time seed keys (INSTALL_SEED) are
+  exempt: the committed sparse file deliberately carries those as
+  placeholders for the installer / GUI / calibration to fill in.
+- Prints a diff and exits non-zero on any of the above.
 
 User-tunable fields (datum, dock pose, IMU mounting calibration, GNSS
 transport, NTRIP creds…) and calibration outputs (ticks_per_meter, wheel
@@ -110,13 +117,29 @@ USER_OVERRIDE = {
 }
 
 # Per-robot calibration outputs written back into the sparse installed file
-# (Invariant 15). These legitimately live only in the installed file and are
-# expected to differ from any template seed — never treated as drift or orphans.
+# (Invariant 15, Bucket B). These legitimately live only in the installed file
+# and are expected to differ from any template seed — never treated as drift or
+# orphans. A template-equal value is also benign: it just means a
+# freshly-uncalibrated robot (e.g. dock_pose 0/0/0, imu_yaw 0.0).
 CALIBRATION_OUTPUT = {
     "ticks_per_meter",
     "wheel_pid_kp", "wheel_pid_ki", "wheel_pid_kd",
     "wheel_pid_integral_limit", "wheel_pid_pwm_per_mps",
     "imu_yaw", "declination_deg", "enable_mag_cal", "mag_calibration_path",
+    "dock_pose_x", "dock_pose_y", "dock_pose_yaw",
+}
+
+# Install-time choices (Invariant 15, Bucket A) the committed sparse file
+# deliberately carries as PLACEHOLDERS equal to the template defaults (datum
+# 0/0, empty NTRIP, default GNSS serial). The installer / onboarding GUI fills
+# them in via line-splice, so the lines must exist even while still holding the
+# default value — exempt from the padded-default check below.
+INSTALL_SEED = {
+    "mower_model", "lidar_enabled", "use_lidar",
+    "gnss_receiver_family", "gnss_serial_device", "gnss_serial_baud",
+    "datum_lat", "datum_lon", "datum_alt",
+    "ntrip_enabled", "ntrip_host", "ntrip_port",
+    "ntrip_user", "ntrip_password", "ntrip_mountpoint",
 }
 
 
@@ -124,6 +147,42 @@ def load(p: Path) -> dict:
     with p.open() as f:
         data = yaml.safe_load(f) or {}
     return data.get("mowgli", {}).get("ros__parameters", {})
+
+
+def find_structural_issues(tpl: dict, rt: dict) -> tuple[list, list]:
+    """Return (drift, no_default) for STRUCTURAL fields.
+
+    drift      — field present in BOTH files with differing values.
+    no_default — field present ONLY in the installed file (no template
+                 default → breaks reset-to-default).
+    """
+    drift = []
+    no_default = []
+    for k in sorted(STRUCTURAL):
+        if k in CALIBRATION_OUTPUT:
+            continue
+        in_tpl, in_rt = k in tpl, k in rt
+        if in_tpl and in_rt and tpl[k] != rt[k]:
+            drift.append((k, tpl[k], rt[k]))
+        elif in_rt and not in_tpl:
+            no_default.append((k, rt[k]))
+    return drift, no_default
+
+
+def find_padded_defaults(tpl: dict, rt: dict) -> list:
+    """Return keys in the installed file that duplicate the template default
+    (Invariant 15 violation: a no-op line that masks future template-default
+    changes). Applies to EVERY key — USER_OVERRIDE, STRUCTURAL, and
+    uncategorized alike — so newly-added template tunables are covered without
+    maintaining a list. Calibration outputs and install-time seed placeholders
+    are exempt.
+    """
+    exempt = CALIBRATION_OUTPUT | INSTALL_SEED
+    return [
+        (k, rt[k])
+        for k in sorted(rt)
+        if k not in exempt and k in tpl and tpl[k] == rt[k]
+    ]
 
 
 def main() -> int:
@@ -140,22 +199,17 @@ def main() -> int:
     # Structural drift under the sparse-config model (Invariant 15). The
     # installed file inherits every absent key from the template via
     # load_robot_params' deep-merge, so a structural field that lives ONLY in
-    # the template is the healthy, expected state — NOT drift. We flag:
-    #   * drift        — field present in BOTH files with differing values.
-    #   * no_default   — structural field present ONLY in the installed file
-    #                    (no template default → breaks reset-to-default).
+    # the template is the healthy, expected state — NOT drift.
     # Calibration outputs (ticks_per_meter, wheel PID…) are excluded: they are
     # per-robot and legitimately diverge from any template seed.
-    drift = []
-    no_default = []
-    for k in sorted(STRUCTURAL):
-        if k in CALIBRATION_OUTPUT:
-            continue
-        in_tpl, in_rt = k in tpl, k in rt
-        if in_tpl and in_rt and tpl[k] != rt[k]:
-            drift.append((k, tpl[k], rt[k]))
-        elif in_rt and not in_tpl:
-            no_default.append((k, rt[k]))
+    drift, no_default = find_structural_issues(tpl, rt)
+
+    # Keys in the sparse file that duplicate the template default (issue
+    # #381). Such a key is a no-op (deep-merge produces the same result with
+    # or without it) but breaks the propagate-a-new-template-default property
+    # (Invariant 15): when a maintainer later corrects the template default,
+    # the committed copy silently pins every robot to the stale value.
+    padded = find_padded_defaults(tpl, rt)
 
     # Surface orphan keys in the installed file — not on any known list and
     # absent from the template. Likely a typo or a stray default. Keys that
@@ -184,13 +238,25 @@ def main() -> int:
         print("Structural fields: in sync.")
         print()
 
+    if padded:
+        print(f"KEYS THAT DUPLICATE THE TEMPLATE DEFAULT ({len(padded)}):")
+        print("  Delete these lines from the installed file; the template "
+              "default is inherited automatically (Invariant 15). Keeping "
+              "the copy would mask future template-default changes.")
+        for k, v in padded:
+            print(f"  {k}: {v}")
+        print()
+    else:
+        print("Padded template defaults: none.")
+        print()
+
     if unexpected_in_runtime:
         print("Keys in installed file not categorized (treat as orphans?):")
         for k in unexpected_in_runtime:
             print(f"  {k} = {rt[k]}")
         print()
 
-    return 1 if (drift or no_default) else 0
+    return 1 if (drift or no_default or padded) else 0
 
 
 if __name__ == "__main__":

--- a/ros2/scripts/test_check_config_drift.py
+++ b/ros2/scripts/test_check_config_drift.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2026 Mowgli Project
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for check_config_drift.py (run with pytest).
+
+Covers the three checks the script enforces over the sparse-config model
+(Architecture Invariant 15):
+  * structural drift (both files, differing values)
+  * structural key without a template default
+  * USER_OVERRIDE key padded with the template default (issue #381)
+plus a regression test that the actual committed yaml pair passes.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_config_drift as ccd  # noqa: E402
+
+
+# ── find_padded_defaults (issue #381) ────────────────────────────────
+
+
+def test_flags_key_equal_to_template_default():
+    # Arrange — swath_overlap is the issue's example of a padded default.
+    tpl = {"swath_overlap": 0.02, "mowing_speed": 0.2}
+    rt = {"swath_overlap": 0.02}
+
+    # Act
+    padded = ccd.find_padded_defaults(tpl, rt)
+
+    # Assert
+    assert padded == [("swath_overlap", 0.02)]
+
+
+def test_flags_structural_key_equal_to_template_default():
+    # tool_width padded into the sparse file is the issue's motivating
+    # example — the historical 54%-coverage bug class.
+    tpl = {"tool_width": 0.18}
+    rt = {"tool_width": 0.18}
+
+    assert ccd.find_padded_defaults(tpl, rt) == [("tool_width", 0.18)]
+
+
+def test_ignores_genuinely_overridden_value():
+    tpl = {"mowing_speed": 0.2}
+    rt = {"mowing_speed": 0.35}
+
+    assert ccd.find_padded_defaults(tpl, rt) == []
+
+
+def test_ignores_key_absent_from_installed_file():
+    tpl = {"mowing_speed": 0.2, "swath_overlap": 0.02}
+    rt = {}
+
+    assert ccd.find_padded_defaults(tpl, rt) == []
+
+
+def test_ignores_key_absent_from_template():
+    # lidar_enabled-style keys exist only in the installed file — there is
+    # no template default to duplicate.
+    tpl = {}
+    rt = {"lidar_enabled": True}
+
+    assert ccd.find_padded_defaults(tpl, rt) == []
+
+
+def test_ignores_calibration_output_matching_template_seed():
+    # A freshly-uncalibrated robot legitimately carries template-equal
+    # calibration seeds (dock pose 0/0/0, imu_yaw 0.0).
+    tpl = {"dock_pose_x": 0.0, "imu_yaw": 0.0, "ticks_per_meter": 399.0}
+    rt = {"dock_pose_x": 0.0, "imu_yaw": 0.0, "ticks_per_meter": 399.0}
+
+    assert ccd.find_padded_defaults(tpl, rt) == []
+
+
+def test_ignores_install_seed_placeholders():
+    # Bucket A placeholders are deliberately committed equal to the template
+    # defaults so the installer / GUI can line-splice real values in.
+    tpl = {"datum_lat": 0.0, "ntrip_enabled": False, "ntrip_port": 2101}
+    rt = {"datum_lat": 0.0, "ntrip_enabled": False, "ntrip_port": 2101}
+
+    assert ccd.find_padded_defaults(tpl, rt) == []
+
+
+def test_flags_uncategorized_keys_too():
+    # A tunable added to the template AFTER this script was last touched
+    # must still be covered — no maintained key list to fall out of date.
+    tpl = {"some_future_key": 1}
+    rt = {"some_future_key": 1}
+
+    assert ccd.find_padded_defaults(tpl, rt) == [("some_future_key", 1)]
+
+
+def test_reports_multiple_padded_keys_sorted():
+    tpl = {"transit_speed": 0.2, "mowing_speed": 0.2, "rain_mode": 2}
+    rt = {"transit_speed": 0.2, "mowing_speed": 0.2, "rain_mode": 2}
+
+    padded = ccd.find_padded_defaults(tpl, rt)
+
+    assert padded == [
+        ("mowing_speed", 0.2),
+        ("rain_mode", 2),
+        ("transit_speed", 0.2),
+    ]
+
+
+def test_install_seed_keys_are_categorized():
+    # Guard against typos: an INSTALL_SEED entry outside the categorized sets
+    # exempts nothing (find_padded_defaults only iterates USER_OVERRIDE).
+    assert ccd.INSTALL_SEED <= ccd.STRUCTURAL | ccd.USER_OVERRIDE
+
+
+# ── find_structural_issues (pre-existing checks, now extracted) ──────
+
+
+def test_structural_drift_on_differing_values():
+    tpl = {"chassis_width": 0.40}
+    rt = {"chassis_width": 0.54}
+
+    drift, no_default = ccd.find_structural_issues(tpl, rt)
+
+    assert drift == [("chassis_width", 0.40, 0.54)]
+    assert no_default == []
+
+
+def test_structural_key_only_in_template_is_healthy():
+    tpl = {"chassis_width": 0.40}
+    rt = {}
+
+    drift, no_default = ccd.find_structural_issues(tpl, rt)
+
+    assert drift == []
+    assert no_default == []
+
+
+def test_structural_key_without_template_default_is_flagged():
+    tpl = {}
+    rt = {"chassis_width": 0.40}
+
+    drift, no_default = ccd.find_structural_issues(tpl, rt)
+
+    assert drift == []
+    assert no_default == [("chassis_width", 0.40)]
+
+
+def test_structural_calibration_output_is_exempt():
+    # ticks_per_meter is STRUCTURAL and a calibration output — per-robot
+    # divergence from the template seed is expected, never drift.
+    tpl = {"ticks_per_meter": 399.0}
+    rt = {"ticks_per_meter": 412.3}
+
+    drift, no_default = ccd.find_structural_issues(tpl, rt)
+
+    assert drift == []
+    assert no_default == []
+
+
+# ── regression: the committed yaml pair must pass every check ────────
+
+
+def test_committed_repo_configs_are_clean():
+    tpl = ccd.load(ccd.TEMPLATE)
+    rt = ccd.load(ccd.RUNTIME)
+
+    drift, no_default = ccd.find_structural_issues(tpl, rt)
+    padded = ccd.find_padded_defaults(tpl, rt)
+
+    assert drift == []
+    assert no_default == []
+    assert padded == []


### PR DESCRIPTION
Closes #381.

## What

`check_config_drift.py` gains a third check: any key in the committed sparse `install/config/mowgli/mowgli_robot.yaml` whose value **equals** its template default now fails CI. Such a key is a no-op at merge time (deep-merge yields the same result with or without it) but breaks Invariant 15's propagate-a-new-template-default property — when a maintainer later corrects the template default, the committed copy silently pins every robot seeded from it to the stale value (the 54%-coverage bug class).

## Deviations from the issue sketch (both deliberate)

1. **Scope widened from `USER_OVERRIDE`-only to every key.** The issue's own examples — `swath_overlap` and `tool_width` — are not in the `USER_OVERRIDE` set (it has drifted ~40 tunables behind the template: `mow_angle_deg`, `chassis_safety_inset`, the obstacle knobs, …), and `tool_width` is `STRUCTURAL`. The proposed loop would have missed both. Checking all keys removes the maintained-list blind spot entirely; exemptions are explicit instead.
2. **Two exemption sets so the deliberately-committed placeholders stay legal** (without them the naive check fails on the current repo state, on 14 keys):
   - `dock_pose_x/y/yaw` moved into `CALIBRATION_OUTPUT` — they are Bucket B calibration outputs per Invariant 15; a template-equal value just means a freshly-uncalibrated robot (the exclusion the issue itself calls for).
   - New `INSTALL_SEED` set for Bucket A install-time placeholders (datum 0/0, empty NTRIP, GNSS serial, `mower_model`, `lidar_enabled`) — the installer/GUI fills these in via line-splice, so the lines must exist while still holding the default.

## Also in this PR

- Extracted `find_structural_issues()` / `find_padded_defaults()` as pure functions; behavior of the two pre-existing checks is unchanged.
- New 15-case pytest suite (`ros2/scripts/test_check_config_drift.py`): padded-default detection, both exemption sets, the structural checks, and a regression test asserting the committed yaml pair passes everything.
- CI `config-drift` job now also runs the pytest suite, and the workflow `paths` filters gained `install/config/mowgli/**` — previously a PR that **only** padded the installed yaml never triggered the gate at all, defeating the check's purpose.

## Test plan

- [x] `python3 -m pytest ros2/scripts/test_check_config_drift.py` — 15 passed
- [x] `python3 ros2/scripts/check_config_drift.py` on the committed pair — exit 0 (repo state stays green)
- [x] Injected `swath_overlap: 0.02` + `tool_width: 0.18` into the installed file (the issue's example) — both flagged, exit 1
- [ ] `config-drift` CI job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)