### PR TITLE
fix(bt): detour clearance counts only TRUE lethal — stop whole-field skips

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/coverage_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/coverage_nodes.hpp
@@ -258,11 +258,21 @@ private:
   // fall back (skip the segment) instead of scanning the whole field.
   static constexpr double kDetourMaxSearchM = 8.0;
   // OccupancyGrid cost at/above which a cell is lethal for the clearance test.
-  static constexpr int8_t kDetourLethalCost = 90;
+  // MUST be 100 (TRUE lethal only): the published /global_costmap/costmap maps
+  // LETHAL(254)->100 and INSCRIBED(253)->99, and the inscribed band extends
+  // inflation_radius (0.20 m) from every keepout wall BY DESIGN. The outer
+  // headland ring rides ON the recorded line (chassis_safety_inset 0), i.e.
+  // permanently within 0.20 m of the boundary band — a 90 threshold counted
+  // those 99-cells as lethal, so EVERY outer-ring abort was "obstacle
+  // confirmed" (wedge) and NO ring pose was ever footprint-clear, which made
+  // decideDetour return no-resume and FollowStrip skip the ENTIRE sub-path
+  // (the whole field on a hole-free area). Field regression 2026-07-2x.
+  static constexpr int8_t kDetourLethalCost = 100;
   // Radius of the "stalled beside an obstacle" wedge check around the stuck pose
   // (spec Part B). Fires the detour when lethal cells hug the robot even with no
-  // dead-ahead blockage. Chassis half-width (~0.20 m) + margin; tight enough to
-  // never fire on an open-space abort.
+  // dead-ahead blockage. Chassis half-width (~0.20 m) + margin. Safe against the
+  // boundary band only because kDetourLethalCost is 100 and the TRUE lethal wall
+  // sits enforce_boundary_margin_m (0.40 m) outside the outer ring (> 0.35).
   static constexpr double kDetourWedgeRadiusM = 0.35;
 
   // Max time to hold (blade off) waiting for navigate_to_pose to become ready to

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/detour_resume.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/detour_resume.hpp
@@ -88,7 +88,13 @@ struct DetourResumeCfg
   // (-1) is below any positive threshold, so it counts as CLEAR (the global
   // planner handles unmapped space; forbidding resumes near unmapped edges would
   // be too conservative and strand the segment).
-  int8_t lethal_cost = 90;
+  // 100 = TRUE lethal only. The published costmap maps LETHAL(254)->100 and
+  // INSCRIBED(253)->99; the inscribed band hugs every keepout wall out to
+  // inflation_radius (0.20 m) BY DESIGN, and the outer headland ring rides ON
+  // the recorded boundary line — so any threshold <= 99 confirms a phantom
+  // obstacle on every outer-ring abort and rejects every ring pose as a resume
+  // candidate (whole-sub-path skips; field regression 2026-07-2x).
+  int8_t lethal_cost = 100;
   // Radius (m) of the "stalled BESIDE an obstacle" wedge check around the stuck
   // pose. FTC can abort on "failed to make progress" while boxed in next to an
   // obstacle whose lethal cells hug the robot's ACTUAL pose but do NOT lie

--- a/ros2/src/mowgli_behavior/test/test_detour_resume.cpp
+++ b/ros2/src/mowgli_behavior/test/test_detour_resume.cpp
@@ -317,3 +317,49 @@ TEST(DetourResume, MinSkipExceedsTransitGap)
   EXPECT_GT(DetourResumeCfg{}.min_skip_dist_m,
             mowgli_interfaces::coverage_geometry::kSegmentTransitGapM);
 }
+
+// ---------------------------------------------------------------------------
+// REGRESSION 2026-07: outer-ring rides ON the recorded boundary
+// (chassis_safety_inset 0). The keepout wall is LETHAL(100) 0.40 m outside the
+// line and its inflated INSCRIBED band (published value 99) reaches 0.20 m
+// outside the line — i.e. permanently within the wedge radius (0.35) and the
+// resume footprint radius (0.25) of EVERY outer-ring pose. With the old
+// lethal_cost = 90 the 99-band (a) wedge-confirmed a phantom obstacle on any
+// outer-ring abort and (b) rejected every ring pose as a resume candidate, so
+// decideDetour returned {confirmed, no-resume} and FollowStrip skipped the
+// WHOLE sub-path (the entire field on a hole-free area). The default threshold
+// must treat only TRUE lethal (100) as blocking.
+// ---------------------------------------------------------------------------
+TEST(DetourResume, InscribedBoundaryBandIsNotAnObstacleAtDefaultThreshold)
+{
+  DetourCostmap cm = makeGrid();
+  // Path rides the "recorded line" at y = 0.5. Model the by-design boundary
+  // stack above it: inscribed 99-cells at y ∈ [0.7, 0.9) (0.20 m away), the
+  // TRUE lethal wall at y ∈ [0.9, 1.0) (0.40 m away).
+  for (uint32_t row = 7; row < 9; ++row)
+  {
+    for (uint32_t col = 0; col < cm.width; ++col)
+    {
+      cm.data[static_cast<std::size_t>(row) * cm.width + col] = 99;
+    }
+  }
+  for (uint32_t col = 0; col < cm.width; ++col)
+  {
+    cm.data[static_cast<std::size_t>(9) * cm.width + col] = 100;
+  }
+  const auto poses = straightPath(40);
+
+  DetourResumeCfg c;  // library DEFAULTS — this is what the regression pins
+  c.wedge_radius_m = 0.35;
+
+  const DetourDecision d = decideDetour(cm, poses, /*stuck=*/10, c);
+
+  // No phantom obstacle: neither the wedge nor the forward scan may treat the
+  // inscribed band as lethal, and no resume/trim may be produced.
+  EXPECT_FALSE(d.obstacle_confirmed);
+  EXPECT_FALSE(d.resume_idx.has_value());
+  // And every on-the-line pose stays a valid resume candidate (footprint 0.25).
+  EXPECT_TRUE(footprintClear(cm, 2.0, 0.5, 0.25, c.lethal_cost));
+  // Sanity: the old 90 threshold is exactly what broke — it saw the 99-band.
+  EXPECT_FALSE(footprintClear(cm, 2.0, 0.5, 0.35, 90));
+}


### PR DESCRIPTION
## La régression

Depuis quelques jours (empilement 18/07 → 22/07), les robots tondent quelques mètres, partent lame coupée ailleurs, puis abandonnent. Chaîne causale :

1. **abf18261 (18/07)** — l'anneau extérieur roule **sur** la ligne enregistrée (`chassis_safety_inset` 0). Voulu, mais ça place le chemin en permanence à 0,20 m de la bande *inscribed* du keepout (inflation 0,20 m sur le mur léthal).
2. **a87ac67d + 12e6f679 (22/07)** — le détour d'obstacle et son wedge-gate jugent la clairance sur la costmap globale publiée avec un seuil **90** — or la bande inscribed est publiée à **99**.

Résultat : **tout** abort de `FollowCoveragePath` sur l'anneau extérieur (stall du progress-checker, patinage, correction GPS — obstacle ou pas) était « obstacle confirmé » par le wedge (99-cellules < 0,35 m), et **aucune** pose de l'anneau n'était jamais « clear » pour la reprise (99-cellules < 0,25 m) → recherche 8 m sans résultat → fallback = **skip du sous-chemin entier** = tout le terrain restant sur un champ sans trou (post dé-fragmentation, un sous-chemin == le chemin continu complet).

Les deux autres volets étaient déjà corrigés sur dev : transits « Start occupied » en bordure (264f7db8, slack 0,40 m mid-cost) et docking cassé par l'édition du recovery subtree (76a6862c, revert).

## Le fix

`kDetourLethalCost` / `DetourResumeCfg.lethal_cost` **90 → 100** : seul le léthal VRAI bloque (murs keepout, intérieurs d'obstacles + bande `obstacle_margin`, cellules LiDAR). Avec le mur réel à 0,40 m de l'anneau, la bordure ne confirme plus d'obstacle fantôme ; les vrais obstacles léthaux gatent/routent le détour exactement comme avant.

## Test plan

- [x] Nouveau gtest de régression `InscribedBoundaryBandIsNotAnObstacleAtDefaultThreshold` — pin des DÉFAUTS de la lib contre la pile bordure by-design (bande 99 à 0,20 m, mur 100 à 0,40 m) : pas de confirmation, pas de reprise, poses de l'anneau clear — et vérifie que l'ancien seuil 90 voyait bien la bande 99.
- [x] 15/15 gtests `test_detour_resume` passent (compilé/exécuté localement, stubs ROS-free)
- [ ] CI Build & Test
- [ ] Test terrain supervisé : abort provoqué sur l'anneau extérieur → pas de skip de sous-chemin, détour uniquement sur obstacle léthal réel

🤖 Generated with [Claude Code](https://claude.com/claude-code)