### PR TITLE
fix(coverage): clamp continuous-path poses inside the outermost-ring clearance ring (#388)

### DIFF
--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -1162,6 +1162,76 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
 
 // ── Continuous cusp-free path (forward turn-around connectors) ───────────────
 
+namespace
+{
+
+// How far INSIDE the clearance ring a clamped (previously out-of-bounds) pose is
+// placed. The clearance ring is the outermost headland ring's centerline (== the
+// recorded line eroded by chassis_safety_inset). A pose that pokes PAST it — the
+// only source being the F2C offset mismatch between generateHeadlandSwaths (the
+// ring) and generateHeadlands (the clearance boundary), which round convex
+// corners differently — is projected back to `kClearanceClampMarginM` inside the
+// nearest ring edge. Small enough that the local deformation stays trackable, and
+// far below the server's kBoundarySlackM (0.05 m) verify slack so the clamped
+// path passes the in-bounds check. See issue #388.
+constexpr double kClearanceClampMarginM = 0.02;
+
+// Project a pose that lies OUTSIDE `ring` back to `margin` inside the nearest ring
+// edge. Poses already inside are returned unchanged, so applying this to a whole
+// path only nudges the out-of-bounds convex-corner pokes and is a no-op for every
+// ring/swath/connector pose the planner already kept in-bounds.
+std::pair<double, double> clampInsideRing(double x,
+                                          double y,
+                                          const std::vector<std::pair<double, double>>& ring,
+                                          double margin)
+{
+  if (ring.size() < 3 || pointInRing(x, y, ring))
+  {
+    return {x, y};
+  }
+  // Nearest point on the ring boundary.
+  const std::size_t n = ring.size();
+  double best_d2 = std::numeric_limits<double>::max();
+  double px = x, py = y;
+  for (std::size_t i = 0, j = n - 1; i < n; j = i++)
+  {
+    const double ax = ring[j].first, ay = ring[j].second;
+    const double bx = ring[i].first, by = ring[i].second;
+    const double dx = bx - ax, dy = by - ay;
+    const double len2 = dx * dx + dy * dy;
+    double t = (len2 > 0.0) ? ((x - ax) * dx + (y - ay) * dy) / len2 : 0.0;
+    t = std::max(0.0, std::min(1.0, t));
+    const double qx = ax + t * dx, qy = ay + t * dy;
+    const double d2 = (x - qx) * (x - qx) + (y - qy) * (y - qy);
+    if (d2 < best_d2)
+    {
+      best_d2 = d2;
+      px = qx;
+      py = qy;
+    }
+  }
+  // The direction from the exterior pose toward its nearest boundary projection
+  // points INTO the polygon; stepping `margin` past the projection lands inside
+  // (unless the ring is thinner than the margin there, in which case snap to the
+  // boundary rather than risk crossing to the far side).
+  double inx = px - x, iny = py - y;
+  const double inl = std::hypot(inx, iny);
+  if (inl < 1e-9)
+  {
+    return {px, py};
+  }
+  inx /= inl;
+  iny /= inl;
+  const double cx = px + margin * inx, cy = py + margin * iny;
+  if (pointInRing(cx, cy, ring))
+  {
+    return {cx, cy};
+  }
+  return {px, py};
+}
+
+}  // namespace
+
 std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
     const BoustrophedonPlan& plan,
     const std::vector<std::pair<double, double>>& boundary,
@@ -1493,6 +1563,23 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
     }
     auto rounded = roundSharpCorners(
         sp, boundary, plan.safe_holes, kCornerThreshold, fillet_r, min_radius, step);
+    // SAFETY (#388): the ring/swath poses are appended verbatim from F2C, and the
+    // OUTERMOST ring's convex-corner vertices can poke a few cm PAST the clearance
+    // ring — generateHeadlandSwaths (the ring) and generateHeadlands (this
+    // `boundary`) round corners differently, so the two nominally-coincident
+    // offsets disagree at corners. Left uncorrected, the first such pose is the
+    // seg-1 start TransitToStrip drives to; sitting outside the recorded line (in
+    // the keepout mask's lethal band) it made the blade-off transit un-drivable
+    // and the whole sub-path was skipped. Project every out-of-bounds pose back
+    // just inside the clearance ring so the path — and its start — stay drivable.
+    // A no-op for the in-bounds majority.
+    if (boundary.size() >= 3)
+    {
+      for (auto& pt : rounded)
+      {
+        pt = clampInsideRing(pt.first, pt.second, boundary, kClearanceClampMarginM);
+      }
+    }
     // Emit each rounded sub-path WHOLE — sub-paths split ONLY at Split A (a real
     // obstacle-gap / relocation), never at an interior cusp. FTC (restored
     // 2026-06-19, reverting MPPI) tracks the continuous full_path through the

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -1001,6 +1001,69 @@ TEST(CoveragePlanning, TurnArcFootprintStaysInsideRecordedBoundary)
       << " poses) — edge turns forced below min_turning_radius into straight-fallback splits";
 }
 
+// SAFETY REGRESSION (#388): outermost-ring connector start outside the clearance
+// ring. With the DEFAULT chassis_safety_inset = 0 the outermost headland ring
+// rides ON the recorded line, and F2C rounds the ring (generateHeadlandSwaths)
+// and the clearance boundary (generateHeadlands) differently at convex corners —
+// so a few outermost-ring vertices poke a few cm PAST the clearance ring. The
+// first such pose is the seg-1 start TransitToStrip drives to; sitting outside
+// the recorded line (in the keepout mask's lethal band) it made the blade-off
+// transit un-drivable and the whole sub-path was skipped, collapsing coverage to
+// the outer rings. buildContinuousSubPaths now projects every out-of-bounds pose
+// back just inside the clearance ring. This asserts the continuous path — every
+// pose, on the operator's REAL boundary-hugging recorded garden — stays inside
+// the clearance ring the connectors are bounded to.
+TEST(CoverageContinuousPath, OutermostRingStaysInsideClearanceRingOnTheLine)
+{
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kMinSwath = 0.15;
+  constexpr double kInset = 0.0;  // DEFAULT: outermost ring rides ON the recorded line
+  constexpr double kTurnRadius = 0.18;
+  constexpr double kMinTurnRadius = 0.15;
+  constexpr double kStep = 0.03;
+  // Matches the server's kBoundarySlackM verify slack (coverage_server.cpp): a
+  // pose within this of the ring from outside is on-the-line densification noise,
+  // not a real excursion. The clamp places poses strictly INSIDE, so the check
+  // below (pointInRing OR within slack) is met with room to spare.
+  constexpr double kBoundarySlack = 0.05;
+
+  const auto cell = makeRecordedArea1();
+  const auto plan =
+      planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath, 0, kMinTurnRadius);
+  ASSERT_FALSE(plan.rings.empty()) << "no rings planned";
+  ASSERT_GE(plan.connector_clearance_boundary.size(), 3u)
+      << "connector_clearance_boundary not populated";
+  const std::vector<std::pair<double, double>>& clearance = plan.connector_clearance_boundary;
+
+  // The server bounds/verifies against connector_clearance_boundary — mirror that.
+  const auto subs =
+      buildContinuousSubPaths(plan, clearance, kTurnRadius, kMinTurnRadius, kStep);
+  ASSERT_FALSE(subs.empty()) << "no continuous sub-paths built";
+
+  std::size_t out_of_bounds = 0;
+  double worst = 0.0;
+  for (const auto& sub : subs)
+  {
+    for (const auto& p : sub)
+    {
+      if (!pointInRing(p.first, p.second, clearance))
+      {
+        const double d = distanceToRing(p.first, p.second, clearance);
+        worst = std::max(worst, d);
+        if (d > kBoundarySlack)
+        {
+          ++out_of_bounds;
+        }
+      }
+    }
+  }
+  EXPECT_EQ(out_of_bounds, 0u)
+      << out_of_bounds
+      << " continuous-path pose(s) outside the outermost-ring clearance ring (worst " << worst
+      << " m past it) — the connector/ring geometry escaped the safety inset (#388)";
+}
+
 // Headland-on-the-line: with chassis_safety_inset = 0 (the new default) the
 // OUTERMOST ring rides ON the recorded boundary — the perimeter the operator
 // drove — so its centerline comes within a densify step of the line instead of


### PR DESCRIPTION
Fixes #388.

## Root cause
The outermost headland ring (F2C `generateHeadlandSwaths`) and the clearance boundary the connectors are bounded to (F2C `generateHeadlands`) are nominally coincident, but the two offset routines round convex corners differently — so a few of the outermost ring's vertices poke a few cm PAST the clearance ring. With the default `chassis_safety_inset=0` that ring rides ON the recorded line, so the poke lands OUTSIDE the operator boundary, in the keepout mask's lethal band.

The first such pose is the seg-1 start `TransitToStrip` drives to (`drivable_subpaths.front().poses.front()`, `coverage_nodes.cpp:1865`); sitting in the lethal band with `local_costmap.inflation_radius=0.58`, RPP's forward-collision check refuses to move, the blade-off transit fails, and the whole sub-path is skipped — collapsing area coverage to the outer rings only.

## Fix
`buildContinuousSubPaths` now projects every pose lying outside the clearance ring back to 2 cm inside the nearest ring edge (a no-op for the in-bounds majority). This keeps the continuous path — and its start — inside the safety inset, removes the "poses outside the outermost-ring clearance ring" ERROR, and makes the seg-1 transit reachable. `buildContinuousPath` (full_path) is fixed too since it calls `buildContinuousSubPaths`.

Connectors are unaffected: an escaping connector fallback already triggers a sub-path split, so the only source clamped is the raw ring/swath vertices.

## Test
Adds `test_coverage_planning` `OutermostRingStaysInsideClearanceRingOnTheLine`: on the operator's real recorded garden with `inset=0`, asserts every continuous-path pose stays inside the clearance ring.

## Acceptance criteria
- [x] No `poses outside the outermost-ring clearance ring` ERROR (server verify checks the same clamped `connector_clearance_boundary`).
- [x] Seg-1 transit target sits inside the recorded line → reachable.
- [x] Test asserts in-bounds continuous path for a boundary-hugging outer ring.

## Test plan
- [ ] CI: `colcon test mowgli_coverage` green (no local ROS2 toolchain).
- [ ] Field: `recorded_area_1` mows past the outer rings; no seg-1 transit skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)