### PR TITLE
fix(gps): silence false GLONASS-1230 NTRIP correction alarms (#395)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,8 @@
 	branch = main
 [submodule "ros2/src/external/universal-gnss"]
 	path = ros2/src/external/universal-gnss
-	url = https://github.com/pepeuch/universal-gnss.git
+	# Pinned to the mowglinext fork while Pepeuch/universal-gnss#4 (GLONASS 1230
+	# optional-for-RTK correction-health fix, issue #395) is pending upstream
+	# review. Revert to https://github.com/pepeuch/universal-gnss.git once merged.
+	url = https://github.com/mowglinext/universal-gnss.git
+	branch = fix/glonass-1230-optional-correction-health


### PR DESCRIPTION
Fixes the false RTCM correction-health alarms reported in #395 (UM980 + Centipede NTRIP):
- `rtcm.required_messages_missing` (ERROR)
- `rtcm.1230_not_valid` (WARN)
- `rtcm_semantic/glonass_code_phase_bias` "decoded but not valid" (WARN)

**Root cause:** the `universal-gnss` correction monitor required a *valid* RTCM 1230 (GLONASS code-phase bias) for correction availability. RTCM 1230 is optional for RTK and the default Centipede/crtk.net caster commonly omits it or clears its validity flag. These diagnostics are purely informational — RTCM forwarding to the receiver is never gated by correction health — so this is spam removal, not an RTK behaviour change.

**Change:** re-pins the `ros2/src/external/universal-gnss` submodule to the `mowglinext/universal-gnss` fork branch carrying the fix (`require_glonass_bias=false`, 1230-not-valid WARN→INFO, decoded-but-not-valid semantic → OK, + tests). Upstream PR: Pepeuch/universal-gnss#4. Revert the submodule URL to `pepeuch/universal-gnss` once that merges.

Note: the separate "2h to first fix" symptom from #395 is **not** addressed here — that's being triaged via live diagnostics (RTCM write-back path + NEAR/GGA mountpoint), see the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)