### PR TITLE
fix(gui): populate coverage, strips and distance in mowing stats (#405)

### DIFF
--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -336,6 +336,13 @@ func (r *RosProvider) fanOut(logicalKey string, msg []byte) {
 		msgCopy := append([]byte(nil), msg...)
 		r.sessionTracker.Enqueue(msgCopy)
 	}
+	// Feed wheel odometry to the session odometer (total distance / blade-wear
+	// proxy). Kept alive by the MQTT persistent "wheelOdom" subscription, same as
+	// highLevelStatus above.
+	if logicalKey == "wheelOdom" && r.sessionTracker != nil {
+		msgCopy := append([]byte(nil), msg...)
+		r.sessionTracker.EnqueueOdometry(msgCopy)
+	}
 }
 
 // initDockPoseSubscription subscribes to the map_server_node's docking_pose

--- a/gui/pkg/providers/session_tracker.go
+++ b/gui/pkg/providers/session_tracker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"sync"
 	"time"
 
@@ -40,13 +41,41 @@ type SessionTracker struct {
 	// "aborted" record. pauseCount tallies the recharge cycles for the record.
 	paused     bool
 	pauseCount int
+	// Live coverage/strip counters captured from the status stream while mowing.
+	// The BT publishes these per AUTONOMOUS tick (coverage_percent is the smooth
+	// 0..100 progress; completed/skipped_swaths are the coarse swath tallies).
+	// They are snapshotted into the finalized record so the stats page shows real
+	// coverage instead of a hardcoded 0. Peak (max) is kept rather than the last
+	// value so a per-area reset near the end of a mow does not clobber the result.
+	coveragePeak    float32
+	stripsCompleted uint32
+	stripsSkipped   uint32
+	// Odometer: total ground distance travelled during the session, integrated
+	// from consecutive /wheel_odom positions. Surfaced as the fleet-wide "km
+	// driven" figure (blade-wear proxy) on the stats page. lastOdom* holds the
+	// previous sample; hasOdom guards the very first sample after a start.
+	distanceMeters float64
+	lastOdomX      float64
+	lastOdomY      float64
+	hasOdom        bool
 	// queue serializes status messages through a single consumer goroutine so
 	// the start/pause/resume/end state machine is applied in arrival order.
 	// Previously fanOut spawned a goroutine per message (go OnHighLevelStatus),
 	// which the scheduler could run out of order — corrupting inSession/paused/
 	// pauseCount on rapid MOWING->CHARGING->IDLE bursts.
 	queue chan []byte
+	// odomQueue carries /wheel_odom samples to a dedicated consumer so the JSON
+	// parse happens off the fanOut goroutine (which holds the ROS provider lock).
+	// Distance is lossy-tolerant, so a full buffer drops samples rather than
+	// blocking; the jump guard absorbs the resulting larger steps.
+	odomQueue chan []byte
 }
+
+// maxOdomStepM caps the per-sample position delta folded into session distance.
+// At ~12 Hz and mowing speed a real step is a few cm; a larger jump means an
+// odometry frame reset (node restart) or a dropped burst of samples, not real
+// travel, so it is discarded instead of inflating the odometer.
+const maxOdomStepM = 1.0
 
 const sessionsDBKey = "mowing.sessions"
 
@@ -62,8 +91,10 @@ func NewSessionTracker(dbProvider types.IDBProvider) *SessionTracker {
 	s := &SessionTracker{
 		dbProvider: dbProvider,
 		queue:      make(chan []byte, 256),
+		odomQueue:  make(chan []byte, 16),
 	}
 	go s.run()
+	go s.runOdom()
 	return s
 }
 
@@ -85,15 +116,71 @@ func (s *SessionTracker) run() {
 	}
 }
 
+// EnqueueOdometry hands a raw /wheel_odom message to the odometer consumer.
+// Non-blocking: a full buffer drops the sample (distance is lossy-tolerant).
+func (s *SessionTracker) EnqueueOdometry(msg []byte) {
+	select {
+	case s.odomQueue <- msg:
+	default:
+	}
+}
+
+// runOdom drains odometry samples on a dedicated goroutine.
+func (s *SessionTracker) runOdom() {
+	for msg := range s.odomQueue {
+		s.OnOdometry(msg)
+	}
+}
+
+// OnOdometry folds one /wheel_odom position into the running session distance.
+// It only accumulates while a session is open; a jump beyond maxOdomStepM (frame
+// reset or dropped burst) re-baselines without counting the gap.
+func (s *SessionTracker) OnOdometry(msg []byte) {
+	var odom struct {
+		Pose struct {
+			Pose struct {
+				Position struct {
+					X float64 `json:"x"`
+					Y float64 `json:"y"`
+				} `json:"position"`
+			} `json:"pose"`
+		} `json:"pose"`
+	}
+	if err := json.Unmarshal(msg, &odom); err != nil {
+		return
+	}
+	x := odom.Pose.Pose.Position.X
+	y := odom.Pose.Pose.Position.Y
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.inSession {
+		s.hasOdom = false
+		return
+	}
+	if s.hasOdom {
+		if d := math.Hypot(x-s.lastOdomX, y-s.lastOdomY); d <= maxOdomStepM {
+			s.distanceMeters += d
+		}
+	}
+	s.lastOdomX = x
+	s.lastOdomY = y
+	s.hasOdom = true
+}
+
 // OnHighLevelStatus processes a raw JSON high-level status message.
 // Call this from the fanOut pipeline for the "highLevelStatus" topic.
 func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 	var status struct {
-		State     int     `json:"state"`
-		StateName string  `json:"state_name"`
-		Emergency bool    `json:"emergency"`
-		Battery   float32 `json:"battery_percent"`
-		Area      int     `json:"current_area"`
+		State           int     `json:"state"`
+		StateName       string  `json:"state_name"`
+		Emergency       bool    `json:"emergency"`
+		Battery         float32 `json:"battery_percent"`
+		Area            int     `json:"current_area"`
+		CoveragePercent float32 `json:"coverage_percent"`
+		CompletedSwaths int     `json:"completed_swaths"`
+		SkippedSwaths   int     `json:"skipped_swaths"`
 	}
 	if err := json.Unmarshal(msg, &status); err != nil {
 		return
@@ -113,9 +200,20 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 		s.inSession = true
 		s.paused = false
 		s.pauseCount = 0
+		s.coveragePeak = 0
+		s.stripsCompleted = 0
+		s.stripsSkipped = 0
+		s.distanceMeters = 0
+		s.hasOdom = false
+		s.captureProgress(status.CoveragePercent, status.CompletedSwaths, status.SkippedSwaths)
 		s.sessionStart = time.Now().UTC()
 		log.Printf("SessionTracker: mowing session started (state=%s)", status.StateName)
 		return
+	}
+
+	// Accumulate live coverage/strip progress on every mowing tick.
+	if isMowing && s.inSession {
+		s.captureProgress(status.CoveragePercent, status.CompletedSwaths, status.SkippedSwaths)
 	}
 
 	// Resume after a recharge pause: mowing came back on the SAME session.
@@ -169,14 +267,18 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 		}
 
 		session := MowingSessionRecord{
-			ID:             fmt.Sprintf("%d", s.sessionStart.UnixMilli()),
-			StartTime:      s.sessionStart.Format(time.RFC3339),
-			EndTime:        endTime.Format(time.RFC3339),
-			DurationSec:    duration,
-			AreaIndex:      status.Area,
-			Status:         sessionStatus,
-			RechargePauses: s.pauseCount,
-			Errors:         []string{},
+			ID:              fmt.Sprintf("%d", s.sessionStart.UnixMilli()),
+			StartTime:       s.sessionStart.Format(time.RFC3339),
+			EndTime:         endTime.Format(time.RFC3339),
+			DurationSec:     duration,
+			AreaIndex:       status.Area,
+			CoveragePercent: s.coveragePeak,
+			StripsCompleted: s.stripsCompleted,
+			StripsSkipped:   s.stripsSkipped,
+			DistanceMeters:  math.Round(s.distanceMeters*10) / 10,
+			Status:          sessionStatus,
+			RechargePauses:  s.pauseCount,
+			Errors:          []string{},
 		}
 
 		if status.Emergency {
@@ -185,6 +287,23 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 
 		s.saveSession(session)
 		log.Printf("SessionTracker: session ended (status=%s, duration=%.0fs)", sessionStatus, duration)
+	}
+}
+
+// captureProgress folds a live status tick into the session's running coverage
+// and swath tallies. Coverage keeps its peak (it is monotonic within an area but
+// resets to 0 when a new area starts, so the peak is the meaningful figure).
+// Swath counts also keep their peak, guarding against the transient -1/0 the BT
+// emits between areas. Caller must hold s.mu.
+func (s *SessionTracker) captureProgress(coverage float32, completed, skipped int) {
+	if coverage > s.coveragePeak {
+		s.coveragePeak = coverage
+	}
+	if completed > 0 && uint32(completed) > s.stripsCompleted {
+		s.stripsCompleted = uint32(completed)
+	}
+	if skipped > 0 && uint32(skipped) > s.stripsSkipped {
+		s.stripsSkipped = uint32(skipped)
 	}
 }
 

--- a/gui/pkg/providers/session_tracker_test.go
+++ b/gui/pkg/providers/session_tracker_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -64,6 +65,81 @@ func TestSessionTracker_RecordsRealSession(t *testing.T) {
 	}
 	if got[0].Status != "completed" {
 		t.Fatalf("expected completed, got %q", got[0].Status)
+	}
+}
+
+// progressStatus builds a mowing status carrying live coverage/swath telemetry.
+func progressStatus(coverage float32, completed, skipped int) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"state": 2, "state_name": "MOWING", "emergency": false,
+		"coverage_percent": coverage, "completed_swaths": completed, "skipped_swaths": skipped,
+	})
+	return b
+}
+
+func TestSessionTracker_CapturesCoverageAndStrips(t *testing.T) {
+	db := types.NewMockDBProvider()
+	s := newTrackerNoGoroutine(db)
+
+	s.OnHighLevelStatus(progressStatus(10, 1, 0)) // start
+	s.sessionStart = time.Now().UTC().Add(-60 * time.Second)
+	s.OnHighLevelStatus(progressStatus(55, 4, 1))
+	s.OnHighLevelStatus(progressStatus(92, 8, 2)) // peak
+	// A new-area reset tick must not clobber the captured peak.
+	s.OnHighLevelStatus(progressStatus(3, 0, 0))
+	s.OnHighLevelStatus(status(1, "IDLE_DOCKED", false))
+	s.OnHighLevelStatus(status(1, "IDLE_DOCKED", false))
+
+	got := loadStoredSessions(t, db)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 recorded session, got %d", len(got))
+	}
+	if got[0].CoveragePercent != 92 {
+		t.Fatalf("expected coverage peak 92, got %v", got[0].CoveragePercent)
+	}
+	if got[0].StripsCompleted != 8 {
+		t.Fatalf("expected 8 completed strips, got %d", got[0].StripsCompleted)
+	}
+	if got[0].StripsSkipped != 2 {
+		t.Fatalf("expected 2 skipped strips, got %d", got[0].StripsSkipped)
+	}
+}
+
+// odomAt builds a nav_msgs/Odometry payload at position (x, y).
+func odomAt(x, y float64) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"pose": map[string]any{"pose": map[string]any{
+			"position": map[string]any{"x": x, "y": y},
+		}},
+	})
+	return b
+}
+
+func TestSessionTracker_AccumulatesDistance(t *testing.T) {
+	db := types.NewMockDBProvider()
+	s := newTrackerNoGoroutine(db)
+
+	// Samples before a session starts must not count.
+	s.OnOdometry(odomAt(10, 10))
+
+	s.OnHighLevelStatus(status(2, "MOWING", false)) // start; resets odometer
+	s.sessionStart = time.Now().UTC().Add(-60 * time.Second)
+	s.OnOdometry(odomAt(0, 0))   // baseline
+	s.OnOdometry(odomAt(0.3, 0)) // +0.3
+	s.OnOdometry(odomAt(0.6, 0)) // +0.3
+	s.OnOdometry(odomAt(0.9, 0)) // +0.3 => 0.9
+	s.OnOdometry(odomAt(50, 50)) // jump > maxOdomStepM: discarded, re-baseline
+	s.OnOdometry(odomAt(50.3, 50)) // +0.3 => 1.2
+
+	s.OnHighLevelStatus(status(1, "IDLE_DOCKED", false))
+	s.OnHighLevelStatus(status(1, "IDLE_DOCKED", false))
+
+	got := loadStoredSessions(t, db)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 recorded session, got %d", len(got))
+	}
+	if math.Abs(got[0].DistanceMeters-1.2) > 1e-6 {
+		t.Fatalf("expected distance 1.2 m, got %v", got[0].DistanceMeters)
 	}
 }
 


### PR DESCRIPTION
## Problem

Closes #405. The Statistics page showed empty coverage/distance figures. Root cause: `SessionTracker` recorded mowing sessions but only decoded `state`/`emergency`/`battery`/`current_area` from the high-level status stream, so `coverage_percent`, `strips_completed/skipped` and `distance_meters` were **always persisted as 0**. The Coverage column, avg-coverage hero, total-distance hero, weekly chart and "Year of Lawn" heatmap all read those zeros.

## Fix (all in `gui/pkg/providers/`)

- **Coverage + strips** (`session_tracker.go`): decode `coverage_percent` + `completed/skipped_swaths` and fold each mowing tick via `captureProgress()`, keeping the **peak** (robust to the per-area reset to 0 and the transient `-1`/`0` the BT emits between areas). Written into the finalized record.
- **Odometer / distance** (`session_tracker.go` + `ros.go`): integrate `/wheel_odom` position deltas during a session into total distance — a "km driven" / blade-wear proxy. An anti-jump guard (`maxOdomStepM = 1.0 m`) re-baselines on a frame reset instead of inflating the total. Fed from `fanOut` via the MQTT-persistent `wheelOdom` subscription, the same path as `highLevelStatus`.

No frontend changes: `StatisticsPage` already displayed these fields — they were just always 0.

## Tests

New unit tests in `session_tracker_test.go`:
- coverage/strip peak capture with a per-area reset tick
- distance accumulation with an ignored jump + pre-session sample excluded

Full `pkg/providers` suite + `go vet` pass.

## Out of scope

The Diagnostics "Zone Coverage" snapshot panel remains empty server-side (`diagnostics.go:213`, cell-grid removed) — separate concern.