### PR TITLE
fix(fusion_graph): looser kf_min_inliers so the LiDAR keyframe anchor engages during RTK-Float

### DIFF
--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -365,6 +365,17 @@ fusion_graph_node:
     # Apply gates (use the map during Float):
     kf_match_max_dist_m: 3.0        # keyframe search radius around the predicted pose
     kf_max_candidates: 5
+    # Inlier floor for the cross-viewpoint scan-to-keyframe ICP, passed as a
+    # per-call override to the shared matcher. The scan-to-scan default
+    # (scan_min_inliers: 30, near-total overlap) was ALSO applied to keyframe
+    # matches, whose overlap is partial — it rejected ~99.7% of them at the
+    # in-loop min_inliers early-abort (observed kf_matches_fail 88278 vs ok 287),
+    # so the RTK-Float keyframe anchor almost never engaged. 16 keeps a genuine
+    # geometric lock (still gated by kf_match_max_rmse_m / divergence / yaw-dev
+    # below) while letting the anchor actually fire during Float. Lower if the
+    # anchor still rarely engages on sparse/structure-poor lawn; raise toward 30
+    # if false locks appear.
+    kf_min_inliers: 16
     # ICP-realism floor on the positional σ; at apply time it is additionally
     # raised to kf_capture_sigma_max_m (a keyframe frozen up to 4 cm off must not
     # be trusted tighter than that error).

--- a/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
@@ -648,9 +648,15 @@ private:
                                             // GraphManager's kf_yaw_sigma_floor
                                             // (~0.30 rad) is the effective floor
   double kf_engage_age_s_ = 0.3;  // engage apply when Fixed older than this
+  // Looser inlier floor for cross-viewpoint scan-to-keyframe ICP, passed as a
+  // per-call override to scan_matcher_->Match. The shared scan-to-scan default
+  // (scan_min_inliers=30) assumes near-total overlap and rejected ~99.7% of
+  // keyframe matches at the in-loop min_inliers early-abort; 16 lets the
+  // RTK-Float keyframe anchor actually engage.
+  int kf_min_inliers_ = 16;
   // Relaxed ICP guard rails for keyframe matching (cross-viewpoint, not
-  // incremental). Matches the shared scan_matcher_'s internal min_inliers
-  // but overrides RMSE / divergence thresholds. The icp_max_delta_* checks
+  // incremental). Overrides min_inliers (kf_min_inliers_ above) plus the
+  // RMSE / divergence thresholds. The icp_max_delta_* checks
   // (0.30 m / 0.50 rad) are inappropriate here — res.delta is the full
   // transform between keyframe and live scan (up to kf_match_max_dist_m_).
   double kf_match_max_rmse_m_ = 0.15;

--- a/ros2/src/fusion_graph/include/fusion_graph/scan_matcher.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/scan_matcher.hpp
@@ -62,9 +62,16 @@ public:
   // Both scans are in the same body frame (no map/odom transforms
   // applied — the caller is expected to have pulled raw 2D points in
   // base_footprint with the lidar_link extrinsic).
+  //
+  // min_inliers_override: when >= 0, use this inlier threshold instead of
+  // params.min_inliers for BOTH the in-loop early-abort and the final ok
+  // gate. Lets cross-viewpoint scan-to-keyframe matching accept fewer
+  // correspondences than the (near-total-overlap) scan-to-scan path
+  // without changing the shared matcher's default. <0 keeps the default.
   ScanMatcherResult Match(const std::vector<Eigen::Vector2d>& source,
                           const std::vector<Eigen::Vector2d>& target,
-                          const gtsam::Pose2& init_guess) const;
+                          const gtsam::Pose2& init_guess,
+                          int min_inliers_override = -1) const;
 
 private:
   ScanMatcherParams p_;

--- a/ros2/src/fusion_graph/src/fusion_graph_node_setup_params.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_setup_params.cpp
@@ -49,6 +49,10 @@ void FusionGraphNode::DeclareParameters()
     // 40 source points keeps ICP rmse within a few mm of the 60-pt
     // result while halving inner-loop NN cost. ARM hot-path saving.
     sp.source_subsample = static_cast<size_t>(declare_parameter<int>("icp_source_subsample", 40));
+    // Inlier floor for the scan-to-scan between-factor (near-total overlap, so
+    // 30/40 subsampled points is easy). Keyframe matching uses its own, looser
+    // kf_min_inliers below (cross-viewpoint overlap is partial).
+    sp.min_inliers = declare_parameter<int>("scan_min_inliers", 30);
     sp.sigma_xy_base = declare_parameter<double>("icp_sigma_xy_base", 0.02);
     sp.sigma_theta_base = declare_parameter<double>("icp_sigma_theta_base", 0.005);
     scan_matcher_ = std::make_unique<ScanMatcher>(sp);
@@ -77,6 +81,13 @@ void FusionGraphNode::DeclareParameters()
     kf_capture_sigma_max_m_ = declare_parameter<double>("kf_capture_sigma_max_m", 0.01);
     kf_capture_rtk_debounce_ = declare_parameter<int>("kf_capture_rtk_debounce", 3);
     kf_capture_max_omega_ = declare_parameter<double>("kf_capture_max_omega", 0.10);
+    // Looser inlier floor for cross-viewpoint scan-to-keyframe ICP. The
+    // scan-to-scan default (scan_min_inliers=30) assumes near-total overlap;
+    // a keyframe is an older scan from a different pose, so 30/40 is rarely
+    // reachable and was rejecting ~99.7% of keyframe matches at the min_inliers
+    // early-abort. 16 keeps a genuine geometric lock while letting the RTK-Float
+    // anchor actually engage.
+    kf_min_inliers_ = declare_parameter<int>("kf_min_inliers", 16);
     kf_match_max_dist_m_ = declare_parameter<double>("kf_match_max_dist_m", 3.0);
     kf_max_candidates_ = static_cast<size_t>(declare_parameter<int>("kf_max_candidates", 5));
     kf_apply_sigma_floor_m_ = declare_parameter<double>("kf_apply_sigma_floor_m", 0.02);

--- a/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
@@ -215,7 +215,7 @@ void FusionGraphNode::OnTimer()
           // direction locked by test_factors.cpp::ScanToKeyframeComposition and
           // stays unchanged.
           const gtsam::Pose2 init = pred.between(kf->abs_pose);
-          const auto res = scan_matcher_->Match(kf->scan_body, curr_scan, init);
+          const auto res = scan_matcher_->Match(kf->scan_body, curr_scan, init, kf_min_inliers_);
           if (!res.ok)
           {
             graph_->RecordIcpRejectInliers();

--- a/ros2/src/fusion_graph/src/scan_matcher.cpp
+++ b/ros2/src/fusion_graph/src/scan_matcher.cpp
@@ -64,11 +64,16 @@ gtsam::Pose2 ScanMatcher::RigidAlign2D(const std::vector<Eigen::Vector2d>& src_c
 
 ScanMatcherResult ScanMatcher::Match(const std::vector<Eigen::Vector2d>& source,
                                      const std::vector<Eigen::Vector2d>& target,
-                                     const gtsam::Pose2& init_guess) const
+                                     const gtsam::Pose2& init_guess,
+                                     int min_inliers_override) const
 {
   ScanMatcherResult res;
   if (source.empty() || target.empty())
     return res;
+
+  // Per-call inlier threshold: keyframe matching passes a looser value than
+  // the shared scan-to-scan default (see ScanMatcherParams::min_inliers).
+  const int min_inliers = (min_inliers_override >= 0) ? min_inliers_override : p_.min_inliers;
 
   // Subsample source for speed. Stride-pick keeps angular coverage.
   std::vector<Eigen::Vector2d> src;
@@ -127,7 +132,7 @@ ScanMatcherResult ScanMatcher::Match(const std::vector<Eigen::Vector2d>& source,
       }
     }
 
-    if (static_cast<int>(src_corr.size()) < p_.min_inliers)
+    if (static_cast<int>(src_corr.size()) < min_inliers)
     {
       // Too few correspondences. Bail out with current T but flag fail.
       res.iterations = iter;
@@ -154,7 +159,7 @@ ScanMatcherResult ScanMatcher::Match(const std::vector<Eigen::Vector2d>& source,
   res.delta = T;
   res.inliers = static_cast<int>(src_corr.size());
   res.rmse = last_rmse;
-  res.ok = res.inliers >= p_.min_inliers;
+  res.ok = res.inliers >= min_inliers;
 
   // Noise model: sigma scales with rmse. Tight floors so we don't
   // outdrive the wheel between-factor when ICP looks great.

--- a/ros2/src/fusion_graph/test/test_factors.cpp
+++ b/ros2/src/fusion_graph/test/test_factors.cpp
@@ -159,6 +159,24 @@ TEST(ScanMatcher, ConvergesWithWarmStart)
   EXPECT_NEAR(res.delta.theta(), T_truth.theta(), 0.03);
 }
 
+TEST(ScanMatcher, MinInliersOverrideGatesAcceptance)
+{
+  // The per-call min_inliers override must replace params.min_inliers at BOTH
+  // the in-loop early-abort and the final ok gate — this is what lets the
+  // keyframe path (kf_min_inliers) accept partial-overlap matches the shared
+  // scan-to-scan default (30) rejects. Full-overlap scans give many inliers, so
+  // the default and a lower override both accept; an override higher than any
+  // achievable inlier count must reject the same match.
+  const gtsam::Pose2 T_truth(0.03, 0.02, 0.02);
+  auto src = SyntheticScan(200, gtsam::Pose2());
+  auto tgt = SyntheticScan(200, T_truth);
+
+  fusion_graph::ScanMatcher matcher;
+  EXPECT_TRUE(matcher.Match(src, tgt, gtsam::Pose2()).ok);            // default (30)
+  EXPECT_TRUE(matcher.Match(src, tgt, gtsam::Pose2(), 16).ok);        // looser override accepts
+  EXPECT_FALSE(matcher.Match(src, tgt, gtsam::Pose2(), 100000).ok);   // impossibly-high override rejects
+}
+
 TEST(ScanMatcher, EmptyInputsFail)
 {
   fusion_graph::ScanMatcher matcher;


### PR DESCRIPTION
## Symptom

On the live robot (10.69.4.198) the RTK-anchored **keyframe map** — the mechanism meant to hold the map-frame pose (and heading) through multi-minute **RTK-Float** windows — was almost never engaging:

```
kf_matches_ok: 287     kf_matches_fail: 88278   (~99.7% rejected)
icp_rejects_inliers: ~405k   (dominant reject reason)
scan_matches_ok: 155229      loop_closures: 739   (both healthy)
```

Between-scan matching and loop-closure were fine; only the **scan-to-keyframe** matching was collapsing. This matches the field report of **heading/pose drift when the robot is stationary / during Float**, then a visible snap when it moves (loop closures fire).

## Root cause

Scan-to-keyframe ICP reused the shared **scan-to-scan** inlier floor: `ScanMatcherParams::min_inliers = 30`, hardcoded and sized for the near-total overlap of consecutive scans. A keyframe is an older scan from a **different viewpoint**, so partial overlap rarely reaches 30/40 subsampled correspondences. Worse, `min_inliers` is an **in-loop early-abort** (`scan_matcher.cpp:130`), so those matches never even finish ICP.

The authors already relax RMSE/divergence for keyframe matching (`fusion_graph_node.hpp`) but deliberately kept `min_inliers` shared — this PR adds the missing piece.

## Change

- `ScanMatcher::Match` gains an optional `min_inliers_override` (default `-1` → use `params.min_inliers`), applied at **both** the in-loop early-abort and the final `ok` gate.
- Expose the scan-to-scan floor as **`scan_min_inliers`** (default **30**, unchanged behaviour).
- New **`kf_min_inliers`** (default **16**), passed only by the keyframe match call (`fusion_graph_node_timer.cpp:218`). Loop-closure (`367`) and scan-to-scan (`95`) paths are untouched.
- `fusion_graph.yaml` documents `kf_min_inliers` next to the other kf_ apply gates.
- Unit test `ScanMatcher.MinInliersOverrideGatesAcceptance`.

## Safety

Keyframe matches remain guarded by `kf_match_max_rmse_m` (0.15 m), the xy/theta divergence bounds, and the **absolute-yaw mirror-guard** (`kf_match_max_yaw_dev_rad`). 16 inliers only lets a genuine geometric lock **form** — it does not weaken wrong-match rejection (a mirrored/flipped ICP still fails RMSE/yaw). This only affects the optional `use_keyframe_map` path.

## Tests

- Unit test added (override gates acceptance at both the early-abort and the final gate). Backward-compatible signature (default arg) — existing `Match` call sites and tests unchanged.
- ⚠️ ROS2 not buildable locally (colcon runs in devcontainer/CI).

## Test plan (field — REQUIRED before merge)

- [ ] Rebuild + deploy to the robot, wait for / trigger an **RTK-Float** window.
- [ ] Confirm `kf_matches_ok` **climbs** (was ~0 during Float) and the map→odom heading **holds** instead of drifting/coasting.
- [ ] Confirm no false locks (blade-over-obstacle) — watch `cov_*` and the yaw mirror-guard rejects.
- [ ] If the anchor still rarely engages on sparse lawn, lower `kf_min_inliers`; if false locks appear, raise toward 30.

Relates to the stationary/Float yaw-drift investigation. Targets `dev` (not `main`).