### PR TITLE
fix(gui): recover from corrupted Bitcask database

### DIFF
--- a/gui/pkg/providers/db.go
+++ b/gui/pkg/providers/db.go
@@ -2,9 +2,16 @@ package providers
 
 import (
 	"errors"
+	"fmt"
 	"git.mills.io/prologic/bitcask"
 	"golang.org/x/xerrors"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
 )
 
 type DBProvider struct {
@@ -12,41 +19,41 @@ type DBProvider struct {
 }
 
 var EnvFallbacks = map[string]string{
-	"system.api.addr":         "API_ADDR",
-	"system.api.webDirectory": "WEB_DIR",
-	"system.map.enabled":      "MAP_TILE_ENABLED",
-	"system.map.tileServer":   "MAP_TILE_SERVER",
-	"system.map.tileUri":      "MAP_TILE_URI",
-	"system.homekit.enabled":  "HOMEKIT_ENABLED",
-	"system.mqtt.enabled":     "MQTT_ENABLED",
-	"system.mqtt.prefix":      "MQTT_PREFIX",
-	"system.mqtt.host":        "MQTT_HOST",
+	"system.api.addr":             "API_ADDR",
+	"system.api.webDirectory":     "WEB_DIR",
+	"system.map.enabled":          "MAP_TILE_ENABLED",
+	"system.map.tileServer":       "MAP_TILE_SERVER",
+	"system.map.tileUri":          "MAP_TILE_URI",
+	"system.homekit.enabled":      "HOMEKIT_ENABLED",
+	"system.mqtt.enabled":         "MQTT_ENABLED",
+	"system.mqtt.prefix":          "MQTT_PREFIX",
+	"system.mqtt.host":            "MQTT_HOST",
 	"system.mower.configFile":     "MOWER_CONFIG_FILE",
 	"system.mower.yamlConfigFile": "MOWER_YAML_CONFIG_FILE",
 	"system.mower.runtimeEnvFile": "MOWER_RUNTIME_ENV_FILE",
-	"system.ros.masterUri":     "ROS_MASTER_URI",
-	"system.ros.nodeName":      "ROS_NODE_NAME",
-	"system.ros.nodeHost":      "ROS_NODE_HOST",
-	"system.ros.foxgloveUrl":   "FOXGLOVE_URL",
-	"system.homekit.pincode":  "HOMEKIT_PINCODE",
+	"system.ros.masterUri":        "ROS_MASTER_URI",
+	"system.ros.nodeName":         "ROS_NODE_NAME",
+	"system.ros.nodeHost":         "ROS_NODE_HOST",
+	"system.ros.foxgloveUrl":      "FOXGLOVE_URL",
+	"system.homekit.pincode":      "HOMEKIT_PINCODE",
 }
 var Defaults = map[string]string{
-	"system.api.addr":         ":4006",
-	"system.api.webDirectory": "/app/web",
-	"system.map.enabled":      "false",
-	"system.map.tileServer":   "http://localhost:5000",
-	"system.map.tileUri":      "/tiles/vt/lyrs=s,h&x={x}&y={y}&z={z}",
-	"system.homekit.enabled":  "false",
-	"system.homekit.pincode":  "00102003",
-	"system.mqtt.enabled":     "false",
-	"system.mqtt.host":        ":1883",
-	"system.mqtt.prefix":      "/gui",
+	"system.api.addr":             ":4006",
+	"system.api.webDirectory":     "/app/web",
+	"system.map.enabled":          "false",
+	"system.map.tileServer":       "http://localhost:5000",
+	"system.map.tileUri":          "/tiles/vt/lyrs=s,h&x={x}&y={y}&z={z}",
+	"system.homekit.enabled":      "false",
+	"system.homekit.pincode":      "00102003",
+	"system.mqtt.enabled":         "false",
+	"system.mqtt.host":            ":1883",
+	"system.mqtt.prefix":          "/gui",
 	"system.mower.configFile":     "/config/mower_config.sh",
 	"system.mower.yamlConfigFile": "/config/mowgli_robot.yaml",
 	"system.mower.runtimeEnvFile": "/runtime_config/.env",
-	"system.ros.masterUri":    "http://localhost:11311",
-	"system.ros.nodeName":     "mowglinext",
-	"system.ros.nodeHost":     "localhost",
+	"system.ros.masterUri":        "http://localhost:11311",
+	"system.ros.nodeName":         "mowglinext",
+	"system.ros.nodeHost":         "localhost",
 }
 
 func (d *DBProvider) Set(key string, value []byte) error {
@@ -99,11 +106,98 @@ func (d *DBProvider) GetWithEnvFallback(key string, env string, def string) stri
 }
 
 func NewDBProvider() *DBProvider {
-	var err error
-	d := &DBProvider{}
-	d.db, err = bitcask.Open(os.Getenv("DB_PATH"))
-	if err != nil {
+	dbPath := os.Getenv("DB_PATH")
+	db, err := bitcask.Open(dbPath)
+	if err == nil {
+		return &DBProvider{db: db}
+	}
+	if !isRecoverableBitcaskCorruption(err) {
 		panic(err)
 	}
-	return d
+
+	log.Printf("bitcask database open failed; attempting recovery: %v", err)
+	backupPath, backupErr := backupDatabase(dbPath)
+	if backupErr != nil {
+		panic(fmt.Errorf("backing up corrupted bitcask database: %w", backupErr))
+	}
+	log.Printf("bitcask database backup created at %s", backupPath)
+
+	// bitcask v1.0.2 retains its lock when opening a corrupted data file fails.
+	// Release the discarded instance's file handles, then replace only that lock.
+	runtime.GC()
+	if removeErr := os.Remove(filepath.Join(dbPath, "lock")); removeErr != nil && !os.IsNotExist(removeErr) {
+		panic(fmt.Errorf("removing failed bitcask lock before recovery: %w", removeErr))
+	}
+
+	db, err = bitcask.Open(dbPath, bitcask.WithAutoRecovery(true))
+	if err != nil {
+		panic(fmt.Errorf("recovering bitcask database backed up at %s: %w", backupPath, err))
+	}
+	log.Printf("bitcask database recovery completed using backup %s", backupPath)
+	return &DBProvider{db: db}
+}
+
+func isRecoverableBitcaskCorruption(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "key/value size is invalid") ||
+		strings.Contains(message, "data is truncated")
+}
+
+func backupDatabase(dbPath string) (string, error) {
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("database path is not a directory: %s", dbPath)
+	}
+
+	backupPath, err := os.MkdirTemp(filepath.Dir(dbPath), fmt.Sprintf("%s.corrupt-%s-", filepath.Base(dbPath), time.Now().UTC().Format("20060102T150405.000000000Z")))
+	if err != nil {
+		return "", err
+	}
+
+	err = filepath.Walk(dbPath, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relPath, err := filepath.Rel(dbPath, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." || relPath == "lock" {
+			return nil
+		}
+		destination := filepath.Join(backupPath, relPath)
+		if info.IsDir() {
+			return os.MkdirAll(destination, info.Mode())
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported database file type: %s", path)
+		}
+		return copyFile(path, destination, info.Mode())
+	})
+	if err != nil {
+		return "", err
+	}
+	return backupPath, nil
+}
+
+func copyFile(source string, destination string, mode os.FileMode) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(output, input)
+	closeErr := output.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }

--- a/gui/pkg/providers/db_test.go
+++ b/gui/pkg/providers/db_test.go
@@ -2,11 +2,110 @@ package providers
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func closeDB(t *testing.T, db *DBProvider) {
+	t.Helper()
+	require.NoError(t, db.db.Close())
+}
+
+func corruptLastDatafile(t *testing.T, dir string) {
+	t.Helper()
+	datafiles, err := filepath.Glob(filepath.Join(dir, "*.data"))
+	require.NoError(t, err)
+	require.NotEmpty(t, datafiles)
+
+	f, err := os.OpenFile(datafiles[len(datafiles)-1], os.O_RDWR, 0)
+	require.NoError(t, err)
+	info, err := f.Stat()
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(1))
+	require.NoError(t, f.Truncate(info.Size()-1))
+	require.NoError(t, f.Close())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{"index_up_to_date":false,"reclaimable_space":0}`), 0600))
+}
+
+func backupPaths(t *testing.T, dbPath string) []string {
+	t.Helper()
+	paths, err := filepath.Glob(dbPath + ".corrupt-*")
+	require.NoError(t, err)
+	return paths
+}
+
+func TestDBProvider_HealthyDatabaseDoesNotCreateBackup(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DB_PATH", dir)
+
+	db := NewDBProvider()
+	require.NoError(t, db.Set("test.key", []byte("hello")))
+	closeDB(t, db)
+
+	db = NewDBProvider()
+	t.Cleanup(func() { closeDB(t, db) })
+	value, err := db.Get("test.key")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(value))
+	assert.Empty(t, backupPaths(t, dir))
+}
+
+func TestDBProvider_RecoversCorruptedDatabaseAfterBackup(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DB_PATH", dir)
+
+	db := NewDBProvider()
+	require.NoError(t, db.Set("preserved", []byte("value")))
+	require.NoError(t, db.Set("truncated", []byte("value")))
+	closeDB(t, db)
+	corruptLastDatafile(t, dir)
+
+	db = NewDBProvider()
+	require.NoError(t, db.Set("after-recovery", []byte("works")))
+	value, err := db.Get("after-recovery")
+	require.NoError(t, err)
+	assert.Equal(t, "works", string(value))
+	closeDB(t, db)
+
+	backups := backupPaths(t, dir)
+	require.Len(t, backups, 1)
+	backupDatafiles, err := filepath.Glob(filepath.Join(backups[0], "*.data"))
+	require.NoError(t, err)
+	require.NotEmpty(t, backupDatafiles)
+	backupInfo, err := os.Stat(backupDatafiles[len(backupDatafiles)-1])
+	require.NoError(t, err)
+	assert.Greater(t, backupInfo.Size(), int64(0))
+
+	db = NewDBProvider()
+	closeDB(t, db)
+	assert.Len(t, backupPaths(t, dir), 1)
+}
+
+func TestDBProvider_DoesNotRecoverNonCorruptionFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "db-file")
+	require.NoError(t, os.WriteFile(path, []byte("not a database directory"), 0600))
+	t.Setenv("DB_PATH", path)
+
+	require.Panics(t, func() { NewDBProvider() })
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.False(t, info.IsDir())
+	assert.Empty(t, backupPaths(t, path))
+}
+
+func TestDBProvider_BackupNamesDoNotCollide(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "000000000.data"), []byte("data"), 0600))
+
+	first, err := backupDatabase(dir)
+	require.NoError(t, err)
+	second, err := backupDatabase(dir)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second)
+}
 
 func TestDBProvider_SetAndGet(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

An interrupted Bitcask write can leave the GUI unable to rebuild its index, causing `NewDBProvider()` to panic and the container to restart indefinitely. This adds a narrow backup-first recovery path for Bitcask's documented truncated/corrupt-entry failures while retaining the current behavior for healthy databases and unrelated operational errors.

## Root cause

`NewDBProvider()` previously panicked on every `bitcask.Open()` error. With Bitcask v1.0.2, an interrupted final write can make index reconstruction return `data is truncated` or `key/value size is invalid`, so each GUI restart failed at the same point.

## Changes

- Retry only Bitcask's known corrupt-entry error messages.
- Copy the complete database directory before recovery, excluding the transient lock file.
- Retry with Bitcask v1.0.2's `WithAutoRecovery(true)` and log the normal-open failure, backup path, and successful recovery.
- Add regression coverage for healthy startup, truncated-data recovery, non-corruption failures, repeat startup, and backup-name collisions.

## Recovery behavior

1. Open normally.
2. If the error is `data is truncated` or `key/value size is invalid`, create a sibling backup named `<db-path>.corrupt-<UTC timestamp>-<random>`.
3. Reopen with Bitcask auto-recovery, which retains the valid prefix of the final data file and rebuilds the index.
4. If backup or recovery fails, preserve the error and panic as before; no empty database is created.
5. Permission, path, lock, disk, configuration, metadata, and other operational errors are not treated as recoverable corruption.

## Data safety

The original database directory, including all `.data` files and metadata, is copied before recovery can truncate the final corrupt record. The transient `lock` file is deliberately excluded. Existing backups are never removed or overwritten; collision-resistant names are created atomically beside the database.

## Tests

All commands below passed:

```text
cd gui
go test ./pkg/providers -run 'TestDBProvider' -count=1
go test ./pkg/providers -run 'TestDBProvider' -count=10
go test -race ./pkg/providers -count=1
go test ./... -count=1
go vet ./...
go build ./...
git diff --check
```

## Manual reproduction

Outside the repository, I created a valid temporary Bitcask store, wrote a value, closed it, marked its index stale, and truncated the final `.data` file by one byte. Provider startup logged the normal open failure, created a sibling backup, completed auto-recovery, and accepted a subsequent write. A later clean startup did not create another backup.

## Risks

This relies on the pinned Bitcask v1.0.2 recovery implementation, which only repairs the last data file and may discard its corrupt tail. The complete pre-recovery store remains in the backup for manual inspection.

## Not tested

- Real Raspberry Pi power loss.
- Disk-full and permission-denied failures during backup or recovery.
- Every historical Bitcask corruption pattern.

## Rollback

Reverting this PR restores the previous startup behavior. Existing recovery backups are not automatically deleted.

Fixes #288
