### PR TITLE
fix(gui): surface dock-calibration start rejection reason (#412)

### DIFF
--- a/gui/web/src/components/settings/DockCalibrationCard.test.tsx
+++ b/gui/web/src/components/settings/DockCalibrationCard.test.tsx
@@ -1,0 +1,85 @@
+import { App } from "antd";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DockCalibrationCard } from "./DockCalibrationCard.tsx";
+import type { DockCalibrationStatus } from "../../hooks/useDockCalibration.ts";
+
+// Return value of useDockCalibration, overridden per test.
+interface UseDockCalibrationValue {
+    status: DockCalibrationStatus | null;
+    start: () => void;
+    starting: boolean;
+    startError: string | null;
+    running: boolean;
+    done: boolean;
+}
+
+const hookValue: UseDockCalibrationValue = {
+    status: null,
+    start: vi.fn(),
+    starting: false,
+    startError: null,
+    running: false,
+    done: false,
+};
+
+vi.mock("../../hooks/useDockCalibration.ts", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../hooks/useDockCalibration.ts")>();
+    return {
+        ...actual,
+        useDockCalibration: () => hookValue,
+    };
+});
+
+vi.mock("../../theme/ThemeContext.tsx", () => ({
+    useThemeMode: () => ({ colors: { text: "#000", primary: "#1677ff" } }),
+}));
+
+const renderCard = () =>
+    render(
+        <App>
+            <DockCalibrationCard />
+        </App>,
+    );
+
+describe("DockCalibrationCard", () => {
+    beforeEach(() => {
+        hookValue.status = null;
+        hookValue.starting = false;
+        hookValue.startError = null;
+        hookValue.running = false;
+        hookValue.done = false;
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            })),
+        });
+    });
+
+    it("surfaces the start-rejection reason returned by the ROS service", () => {
+        // Regression for issue #412: a rejected start (e.g. robot not on the
+        // dock) publishes no status message, so startError is the only signal —
+        // the card must render it instead of silently doing nothing.
+        hookValue.startError = "Robot is not on the dock (not charging). Dock it, then retry.";
+        renderCard();
+
+        expect(screen.getByText("Could not start dock calibration")).toBeInTheDocument();
+        expect(
+            screen.getByText("Robot is not on the dock (not charging). Dock it, then retry."),
+        ).toBeInTheDocument();
+    });
+
+    it("shows no error alert when the start was accepted", () => {
+        renderCard();
+
+        expect(screen.queryByText("Could not start dock calibration")).not.toBeInTheDocument();
+    });
+});

--- a/gui/web/src/components/settings/DockCalibrationCard.tsx
+++ b/gui/web/src/components/settings/DockCalibrationCard.tsx
@@ -19,7 +19,7 @@ const { Text, Paragraph } = Typography;
  */
 export const DockCalibrationCard: React.FC = () => {
     const { colors } = useThemeMode();
-    const { status, start, starting, running, done } = useDockCalibration();
+    const { status, start, starting, startError, running, done } = useDockCalibration();
 
     const phase = status?.phase ?? 6;
     const progressPct = Math.round((status?.progress ?? 0) * 100);
@@ -51,6 +51,15 @@ export const DockCalibrationCard: React.FC = () => {
                 >
                     {running ? "Calibrating…" : "Start dock calibration"}
                 </Button>
+
+                {startError && !running && (
+                    <Alert
+                        type="error"
+                        showIcon
+                        message="Could not start dock calibration"
+                        description={startError}
+                    />
+                )}
 
                 {(running || (status && status.phase !== 6)) && !showResult && (
                     <div>


### PR DESCRIPTION
## Problem

Fixes #412. Clicking **Settings → Docking → Start dock calibration** appears to do nothing — the button spins briefly and no feedback is shown.

## Root cause

`POST /api/calibration/dock/start` calls the ROS `~/dock_calibration/start` service. That service (`dock_start_cb`, `calibrate_imu_yaw_node.cpp`) guards on preconditions — emergency / mowing (AUTONOMOUS) / **not-charging** / already-running — and on those paths returns `success:false` with a message **and publishes no `~/dock_calibration/status` message**.

The reporter's robot misses the dock and parks beside it, so it isn't charging → the service returns *"Robot is not on the dock (not charging). Dock it, then retry."* with HTTP 200 (consistent with the issue's ~923 µs, 200 log line — an instant rejection, not a real run).

The `useDockCalibration` hook captured this in `startError`, but `DockCalibrationCard` never destructured or rendered it. With no status-stream update either, the card showed nothing → "nothing happens."

## Fix

- `DockCalibrationCard.tsx`: destructure `startError` and render it as an error `Alert` ("Could not start dock calibration" + the service message) when set and not running. The operator now sees why it didn't start and what to do.
- Add `DockCalibrationCard.test.tsx` regression test.

## Scope

This resolves the filed GUI bug (calibration does nothing / no feedback). The **underlying** complaint — the mower parking next to the dock instead of on it — is a separate docking-accuracy problem (fusion lever-arm / `gps_y`) and is not addressed here.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run DockCalibrationCard.test.tsx` — 2/2 pass
- [ ] Field: on a non-docked robot, click Start dock calibration → error alert with the rejection reason appears
- [ ] Field: on a docked+charging RTK-Fixed robot, calibration runs and progresses as before

Note: ESLint can't run in this checkout (ESLint 9 vs. the repo's legacy `.eslintrc` format — pre-existing tooling mismatch, unrelated to this change).