### PR TITLE
chore: sync main → dev (#410 chassis-mass URDF hotfix)

### DIFF
--- a/ros2/src/mowgli_bringup/CMakeLists.txt
+++ b/ros2/src/mowgli_bringup/CMakeLists.txt
@@ -69,6 +69,9 @@ if(BUILD_TESTING)
   ament_add_pytest_test(test_robot_config_util test/test_robot_config_util.py
     TIMEOUT 30
   )
+  ament_add_pytest_test(test_urdf_xacro test/test_urdf_xacro.py
+    TIMEOUT 30
+  )
 
   # Static guard for Inv 2 (TF sole ownership) — greps sources/configs, no
   # nodes spun up.

--- a/ros2/src/mowgli_bringup/config/nav2_params_lidar.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_lidar.yaml
@@ -245,10 +245,10 @@ collision_monitor:
       enabled: false
     PolygonSlow:
       type: "polygon"
-      # Chassis + 15 cm — slow to 30% when obstacle is close
+      # Chassis + 15 cm — slow to 70% when obstacle is close
       points: "[[0.65, 0.35], [0.65, -0.35], [-0.25, -0.35], [-0.25, 0.35]]"
       action_type: "slowdown"
-      slowdown_ratio: 0.5
+      slowdown_ratio: 0.7
       # 12 points: the dock structure sits near the polygon boundary
       # when charging, causing rapid slow/normal flapping at 10 Hz.
       # Higher min_points adds hysteresis against that edge noise.

--- a/ros2/src/mowgli_bringup/launch/mowgli.launch.py
+++ b/ros2/src/mowgli_bringup/launch/mowgli.launch.py
@@ -94,6 +94,7 @@ def generate_launch_description() -> LaunchDescription:
     chassis_length   = float(robot_params.get("chassis_length", 0.54))
     chassis_width    = float(robot_params.get("chassis_width", 0.40))
     chassis_height   = float(robot_params.get("chassis_height", 0.19))
+    chassis_mass_kg  = float(robot_params.get("chassis_mass_kg", 8.76))
     chassis_center_x = float(robot_params.get("chassis_center_x", 0.18))
     wheel_radius     = float(robot_params.get("wheel_radius", 0.093))
     wheel_width      = float(robot_params.get("wheel_width", 0.04))
@@ -137,6 +138,7 @@ def generate_launch_description() -> LaunchDescription:
             " chassis_length:=", str(chassis_length),
             " chassis_width:=", str(chassis_width),
             " chassis_height:=", str(chassis_height),
+            " chassis_mass_kg:=", str(chassis_mass_kg),
             " chassis_center_x:=", str(chassis_center_x),
             " wheel_radius:=", str(wheel_radius),
             " wheel_width:=", str(wheel_width),

--- a/ros2/src/mowgli_bringup/test/test_nav2_params.py
+++ b/ros2/src/mowgli_bringup/test/test_nav2_params.py
@@ -406,9 +406,9 @@ def test_obstacle_template_defaults_match_static_yaml() -> None:
         f"template obstacle_slowdown_ratio={rp['obstacle_slowdown_ratio']} != "
         f"lidar overlay PolygonSlow.slowdown_ratio={slow}."
     )
-    assert float(rp["obstacle_margin"]) == 0.15, (
-        "template obstacle_margin must default to 0.15 m — tight pinch-point "
-        "avoidance without compromising pass-through."
+    assert float(rp["obstacle_margin"]) == 0.2, (
+        "template obstacle_margin must default to 0.2 m — the field-validated "
+        "buffer around drawn obstacles."
     )
 
 

--- a/ros2/src/mowgli_bringup/test/test_urdf_xacro.py
+++ b/ros2/src/mowgli_bringup/test/test_urdf_xacro.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Mowgli Project
+# SPDX-License-Identifier: GPL-3.0
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+_PKG_DIR = Path(__file__).resolve().parent.parent
+_XACRO_FILE = _PKG_DIR / "urdf" / "mowgli.urdf.xacro"
+
+
+def test_chassis_mass_argument_sets_base_link_inertial_mass() -> None:
+    """A configured chassis mass must reach the generated base_link inertia."""
+    configured_mass = 12.34
+    result = subprocess.run(
+        ["xacro", str(_XACRO_FILE), f"chassis_mass_kg:={configured_mass}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    robot = ET.fromstring(result.stdout)
+    base_link = robot.find("./link[@name='base_link']")
+    assert base_link is not None
+    mass = base_link.find("./inertial/mass")
+    assert mass is not None
+    assert float(mass.attrib["value"]) == configured_mass

--- a/ros2/src/mowgli_bringup/urdf/mowgli.urdf.xacro
+++ b/ros2/src/mowgli_bringup/urdf/mowgli.urdf.xacro
@@ -50,6 +50,7 @@
   <xacro:arg name="chassis_length"   default="0.60"/>
   <xacro:arg name="chassis_width"    default="0.40"/>
   <xacro:arg name="chassis_height"   default="0.19"/>
+  <xacro:arg name="chassis_mass_kg"  default="8.76"/>
   <xacro:arg name="chassis_center_x" default="0.20"/>
   <xacro:arg name="wheel_radius"     default="0.093"/>
   <xacro:arg name="wheel_width"      default="0.04"/>
@@ -80,7 +81,7 @@
   <xacro:property name="caster_x_offset"  value="${chassis_cx + base_length/2.0 - caster_radius}"/>
   <xacro:property name="caster_track"     value="$(arg caster_track)"/>
 
-  <xacro:property name="base_mass"        value="8.76"/>
+  <xacro:property name="base_mass"        value="$(arg chassis_mass_kg)"/>
 
   <xacro:property name="blade_radius"     value="$(arg blade_radius)"/>
   <xacro:property name="blade_height"     value="0.01"/>


### PR DESCRIPTION
Back-merge the main-only hotfix `38218012 fix: pipe chassis mass into URDF (#410)` into dev so dev contains all of main before the dev→main promotion. Keeps the two branches from diverging.