### PR TITLE
feat(gnss): rover dynamic mode — default UM980 to UAV + GUI dropdown (#395)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,12 @@
 	branch = main
 [submodule "ros2/src/external/universal-gnss"]
 	path = ros2/src/external/universal-gnss
-	# Pinned to the mowglinext fork while Pepeuch/universal-gnss#4 (GLONASS 1230
-	# optional-for-RTK correction-health fix, issue #395) is pending upstream
-	# review. Revert to https://github.com/pepeuch/universal-gnss.git once merged.
+	# Pinned to the mowglinext fork. Two fork fixes are stacked here, both for
+	# issue #395: (1) GLONASS-1230 optional-for-RTK correction health
+	# (Pepeuch/universal-gnss#4) and (2) UM980 MODE ROVER UAV default +
+	# --rover-dynamic-mode override (mowglinext/universal-gnss#1). Points at the
+	# rover-dynamic-mode branch until that fork PR merges into the 1230 branch;
+	# then re-pin the gitlink to the merge commit and restore the branch below.
+	# Revert to https://github.com/pepeuch/universal-gnss.git once upstreamed.
 	url = https://github.com/mowglinext/universal-gnss.git
-	branch = fix/glonass-1230-optional-correction-health
+	branch = fix/rover-dynamic-mode-uav

--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -335,6 +335,12 @@
           "title": "Raw Signal Group",
           "description": "Vendor-specific expert override. Accepts 'master slave', 'master,slave', or 'master/slave' and is normalized on save; advanced Unicore combinations are allowed with warnings instead of a hard allowlist."
         },
+        "gnss_rover_dynamic_mode": {
+          "type": "string",
+          "enum": ["", "uav", "survey_mow", "rover"],
+          "title": "Rover Dynamic Mode",
+          "description": "Unicore rover motion model for RTK. Empty = auto (per-model default; UM980 defaults to uav). uav is the kinematic engine (fast fix, holds lock while moving); survey_mow is the near-static survey engine; rover is the generic fallback."
+        },
         "gnss_unicore_pvt_algorithm": {
           "type": "string",
           "title": "Unicore PVT Algorithm",

--- a/gui/pkg/api/gnss.go
+++ b/gui/pkg/api/gnss.go
@@ -50,9 +50,10 @@ type gnssSavedConfig struct {
 	ExecutionBaud  string
 	Profile        string
 	SignalProfile  string
-	SignalGroup    string
-	ReceiverModel  string
-	ProfileRateHz  string
+	SignalGroup      string
+	ReceiverModel    string
+	RoverDynamicMode string
+	ProfileRateHz    string
 }
 
 type GNSSCommandExecution struct {
@@ -507,6 +508,9 @@ func buildGNSSPlanCommand(cfg gnssSavedConfig) []string {
 	if shouldPassGNSSSignalGroup(cfg) {
 		command = append(command, "--signal-group", cfg.SignalGroup)
 	}
+	if shouldPassGNSSRoverDynamicMode(cfg) {
+		command = append(command, "--rover-dynamic-mode", cfg.RoverDynamicMode)
+	}
 	command = append(command, cfg.ReceiverFamily, cfg.Profile)
 	return command
 }
@@ -549,12 +553,22 @@ func buildGNSSApplyCommand(cfg gnssSavedConfig, profile string) []string {
 	if shouldPassGNSSSignalGroup(cfg) {
 		command = append(command, "--signal-group", cfg.SignalGroup)
 	}
+	if shouldPassGNSSRoverDynamicMode(cfg) {
+		command = append(command, "--rover-dynamic-mode", cfg.RoverDynamicMode)
+	}
 
 	return command
 }
 
 func shouldPassGNSSSignalGroup(cfg gnssSavedConfig) bool {
 	return cfg.ReceiverFamily == "unicore" && strings.TrimSpace(cfg.SignalGroup) != ""
+}
+
+// shouldPassGNSSRoverDynamicMode passes an explicit rover dynamic-mode override
+// only for Unicore and only when set. Empty means "auto" — let the receiver
+// profile pick its per-model default (UM980 -> MODE ROVER UAV, issue #395).
+func shouldPassGNSSRoverDynamicMode(cfg gnssSavedConfig) bool {
+	return cfg.ReceiverFamily == "unicore" && strings.TrimSpace(cfg.RoverDynamicMode) != ""
 }
 
 func buildGNSSProbeBaudCandidates(cfg gnssSavedConfig) []string {
@@ -667,9 +681,10 @@ func loadSavedGNSSConfig(dbProvider pkgtypes.IDBProvider) (gnssSavedConfig, erro
 		ExecutionBaud:  executionBaud,
 		Profile:        profile,
 		SignalProfile:  normalizeGnssSignalProfile(doc.Flat["gnss_signal_profile"], "balanced"),
-		SignalGroup:    signalGroup,
-		ReceiverModel:  normalizeGnssReceiverModel(doc.Flat["gnss_receiver_model"]),
-		ProfileRateHz:  rateHz,
+		SignalGroup:      signalGroup,
+		ReceiverModel:    normalizeGnssReceiverModel(doc.Flat["gnss_receiver_model"]),
+		RoverDynamicMode: normalizeGnssRoverDynamicMode(doc.Flat["gnss_rover_dynamic_mode"]),
+		ProfileRateHz:    rateHz,
 	}, nil
 }
 

--- a/gui/pkg/api/settings.go
+++ b/gui/pkg/api/settings.go
@@ -579,6 +579,20 @@ func normalizeGnssReceiverModel(value any) string {
 	}
 }
 
+// normalizeGnssRoverDynamicMode canonicalizes the Unicore rover dynamic-motion
+// selector (issue #395). Empty (or an unrecognized value) means "auto" — leave
+// the receiver profile's per-model default in place (UM980 -> uav).
+func normalizeGnssRoverDynamicMode(value any) string {
+	switch mode := strings.ToLower(strings.TrimSpace(stringValue(value, ""))); mode {
+	case "uav", "survey_mow", "rover":
+		return mode
+	case "survey-mow":
+		return "survey_mow"
+	default:
+		return ""
+	}
+}
+
 func normalizeGnssProfileRate(value any, defaultValue string) string {
 	switch stringValue(value, defaultValue) {
 	case "1", "5", "7", "10":

--- a/gui/web/src/components/settings/gnssConfig.test.ts
+++ b/gui/web/src/components/settings/gnssConfig.test.ts
@@ -72,6 +72,26 @@ describe("gnssConfig", () => {
         expect(signalGroupField?.key).toBe("gnss_signal_group");
     });
 
+    it("exposes the rover dynamic-mode dropdown (Auto/UAV/Survey Mow/Rover, issue #395)", () => {
+        expect(GNSS_ACTION_SETTINGS_KEYS).toContain("gnss_rover_dynamic_mode");
+        const roverModeField = GNSS_ADVANCED_SETTINGS_BY_FAMILY.unicore?.fields.find(
+            (field) => field.key === "gnss_rover_dynamic_mode",
+        );
+        expect(roverModeField?.kind).toBe("select");
+        if (roverModeField?.kind !== "select") {
+            throw new Error("expected select field");
+        }
+        expect(roverModeField.options.map((option) => option.value)).toEqual([
+            "",
+            "uav",
+            "survey_mow",
+            "rover",
+        ]);
+        expect(i18n.t(roverModeField.options[1].label)).toBe(
+            en.gnssConfig.unicore.roverDynamicMode.option.uav.label,
+        );
+    });
+
     it("persists an optional execution-baud override separately from runtime/config baud", () => {
         expect(GNSS_ACTION_SETTINGS_KEYS).toContain("gnss_execution_baud");
         expect(GNSS_EXECUTION_BAUD_OPTIONS.map((option) => option.value)).toEqual([

--- a/gui/web/src/components/settings/gnssConfig.ts
+++ b/gui/web/src/components/settings/gnssConfig.ts
@@ -61,6 +61,13 @@ export const GNSS_SIGNAL_PROFILE_HELP_TEXT =
 export const GNSS_SIGNAL_PROFILE_CUSTOM_HELP_TEXT =
     "gnssConfig.signalProfileCustomHelpText";
 
+export const GNSS_ROVER_DYNAMIC_MODE_OPTIONS = [
+    { value: "", label: "gnssConfig.unicore.roverDynamicMode.option.auto.label" },
+    { value: "uav", label: "gnssConfig.unicore.roverDynamicMode.option.uav.label" },
+    { value: "survey_mow", label: "gnssConfig.unicore.roverDynamicMode.option.survey_mow.label" },
+    { value: "rover", label: "gnssConfig.unicore.roverDynamicMode.option.rover.label" },
+] as const;
+
 export const GNSS_PROFILE_RATE_OPTIONS = [
     { value: 1, label: "1 Hz" },
     { value: 5, label: "5 Hz" },
@@ -79,6 +86,7 @@ export const GNSS_ACTION_SETTINGS_KEYS = [
     "gnss_signal_profile",
     "gnss_profile_rate_hz",
     "gnss_signal_group",
+    "gnss_rover_dynamic_mode",
     "gnss_unicore_pvt_algorithm",
     "gnss_unicore_rtk_reliability",
     "gnss_unicore_rtk_timeout_s",
@@ -189,6 +197,14 @@ export const GNSS_ADVANCED_SETTINGS_BY_FAMILY: Record<string, GnssReceiverAdvanc
                 tooltip: "gnssConfig.unicore.signalGroup.tooltip",
                 placeholder: "gnssConfig.unicore.signalGroup.placeholder",
                 helpText: "gnssConfig.unicore.signalGroup.helpText",
+            },
+            {
+                kind: "select",
+                key: "gnss_rover_dynamic_mode",
+                label: "gnssConfig.unicore.roverDynamicMode.label",
+                tooltip: "gnssConfig.unicore.roverDynamicMode.tooltip",
+                options: GNSS_ROVER_DYNAMIC_MODE_OPTIONS,
+                helpText: "gnssConfig.unicore.roverDynamicMode.helpText",
             },
             {
                 kind: "text",

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -1884,6 +1884,17 @@
         "placeholder": "e.g. 3 6",
         "helpText": "MowgliNext normalizes this to 'master slave' on save. Universal GNSS accepts any syntactically valid 0..9 pair, then warns when the combination is advanced and not one of the recommended documented presets."
       },
+      "roverDynamicMode": {
+        "label": "Rover Dynamic Mode",
+        "tooltip": "Motion model the receiver assumes for RTK. UAV is the kinematic engine that fixes fast and holds lock while the mower moves; Survey Mow is tuned for near-static surveying (slower to fix, can drop lock under motion); Rover is the generic fallback.",
+        "helpText": "Auto uses the per-model default (UM980 defaults to UAV). Choose UAV if your receiver is slow to reach RTK-Fixed or loses fix while mowing.",
+        "option": {
+          "auto": { "label": "Auto (per-model default)" },
+          "uav": { "label": "UAV (kinematic — recommended)" },
+          "survey_mow": { "label": "Survey Mow" },
+          "rover": { "label": "Rover (generic)" }
+        }
+      },
       "pvtAlgorithm": {
         "label": "PVT Algorithm",
         "tooltip": "Optional Unicore-specific PVT algorithm override that the future backend translator can map to vendor commands.",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -1880,6 +1880,17 @@
         "placeholder": "ex. 3 6",
         "helpText": "MowgliNext normalise cette valeur en 'master slave' à l'enregistrement. Universal GNSS accepte toute paire 0..9 valide par syntaxe, puis émet un avertissement quand la combinaison est avancée et ne fait pas partie des presets documentés recommandés."
       },
+      "roverDynamicMode": {
+        "label": "Mode dynamique du rover",
+        "tooltip": "Modèle de mouvement que le récepteur suppose pour le RTK. UAV est le moteur cinématique qui fixe rapidement et conserve le verrouillage pendant que la tondeuse se déplace ; Survey Mow est optimisé pour un relevé quasi statique (plus lent à fixer, peut perdre le verrouillage en mouvement) ; Rover est le repli générique.",
+        "helpText": "Auto utilise la valeur par défaut selon le modèle (le UM980 utilise UAV par défaut). Choisissez UAV si votre récepteur est lent à atteindre le RTK-Fixe ou perd le fix pendant la tonte.",
+        "option": {
+          "auto": { "label": "Auto (défaut selon le modèle)" },
+          "uav": { "label": "UAV (cinématique — recommandé)" },
+          "survey_mow": { "label": "Survey Mow" },
+          "rover": { "label": "Rover (générique)" }
+        }
+      },
       "pvtAlgorithm": {
         "label": "Algorithme PVT",
         "tooltip": "Surcharge facultative de l'algorithme PVT spécifique à Unicore que le futur traducteur backend pourra associer aux commandes du fabricant.",

--- a/sensors/gps/start_gps.sh
+++ b/sensors/gps/start_gps.sh
@@ -359,6 +359,22 @@ resolve_signal_group() {
   printf '%s\n' "${GNSS_SIGNAL_GROUP:-}"
 }
 
+# Rover dynamic-motion model (issue #395). Empty = let the receiver profile pick
+# its per-model default (UM980 -> MODE ROVER UAV, other mower models -> SURVEY
+# MOW). Set to uav|survey_mow|rover to override. Deliberately NOT defaulted to a
+# concrete value here so the UM980-only default flip stays owned by the profile
+# builder rather than being forced onto every model.
+resolve_rover_dynamic_mode() {
+  local yaml_rover_dynamic_mode
+  yaml_rover_dynamic_mode="$(parse_yaml_any gnss_rover_dynamic_mode)"
+  if [ -n "$yaml_rover_dynamic_mode" ]; then
+    printf '%s\n' "$yaml_rover_dynamic_mode"
+    return 0
+  fi
+
+  printf '%s\n' "${GNSS_ROVER_DYNAMIC_MODE:-}"
+}
+
 print_command() {
   local label="$1"
   shift
@@ -438,6 +454,7 @@ config_profile="$(resolve_config_profile)"
 signal_profile="$(resolve_signal_profile)"
 receiver_model="$(resolve_receiver_model)"
 signal_group="$(resolve_signal_group)"
+rover_dynamic_mode="$(resolve_rover_dynamic_mode)"
 
 if [ "$transport" = "serial" ] && [ ! -e "$serial_device" ]; then
   echo "[start_gps.sh] ERROR: selected GNSS serial device does not exist: ${serial_device}"
@@ -468,6 +485,9 @@ if [ -n "$receiver_model" ]; then
 fi
 if [ -n "$signal_group" ]; then
   config_apply_cmd+=(--signal-group "$signal_group")
+fi
+if [ -n "$rover_dynamic_mode" ]; then
+  config_apply_cmd+=(--rover-dynamic-mode "$rover_dynamic_mode")
 fi
 
 # Apply the receiver profile synchronously (serial transport only). A failure is


### PR DESCRIPTION
## Problem
Issue #395: a UM980 takes **hours** to reach RTK-Fixed and drops it under motion, while uPrecise / OpenMower fix in **seconds** on the same receiver + antenna + corrections. Diagnostics show corrections are healthy (RTCM forwarding active, 0 write errors, GGA injection on). Root cause is the rover config we push: since #408 auto-applies `rover_high_precision`, which sets **MODE ROVER SURVEY MOW** — a near-static survey engine that is slow to commit a fix and fragile under motion. OpenMower's proven config uses **MODE ROVER UAV** (kinematic): fast fix, holds lock while moving.

## Change
- **Fork (mowglinext/universal-gnss#1, re-pinned here):** UM980 `rover_high_precision` defaults to `MODE ROVER UAV`; adds a portable `--rover-dynamic-mode <uav|survey_mow|rover>` override. Other models keep SURVEY MOW.
- **start_gps.sh:** reads `gnss_rover_dynamic_mode` (empty = auto → per-model default, so only UM980 flips to UAV) and passes `--rover-dynamic-mode` to the boot-time apply.
- **GUI:** new **Rover Dynamic Mode** dropdown (Auto / UAV / Survey Mow / Rover) in the Unicore advanced section; threaded through the Go apply + plan commands; en/fr strings; schema enum; unit tests.

## Test plan
- [x] `go build ./pkg/api` + `go test` (GNSS/Settings) green
- [x] en/fr/schema JSON valid; TS test added (mirrors existing `.toContain` patterns)
- [ ] Fork CI (mowglinext/universal-gnss#1) — validates the C++ (not buildable in this env)
- [ ] **Field test (owed):** UM980 on `dev` build reaches RTK-Fixed in seconds and holds it while mowing; dropdown override switches modes

Depends on mowglinext/universal-gnss#1 (merge that, then re-pin the gitlink to the merge commit and restore the .gitmodules branch). Closes #395 once field-confirmed.