### PR TITLE
feat(gui): add dedicated mowing progress reset

### DIFF
--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -1373,6 +1373,17 @@
     "manualMow": "Manual Mow",
     "more": "More"
   },
+  "resetMowingProgress": {
+    "action": "Reset mowing progress",
+    "confirmTitle": "Reset saved mowing progress?",
+    "confirmBody": "This permanently clears the saved coverage progress for the current map.",
+    "confirmHint": "The mower will not start, and your mapped areas will not be deleted.",
+    "confirmAction": "Reset progress",
+    "cancel": "Cancel",
+    "success": "Mowing progress was reset",
+    "error": "Could not reset mowing progress",
+    "unknownError": "An unknown error occurred"
+  },
   "mapToolbarMobile": {
     "actionFailed": "Action failed",
     "darkMap": "Dark map",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -1369,6 +1369,17 @@
     "manualMow": "Tonte manuelle",
     "more": "Plus"
   },
+  "resetMowingProgress": {
+    "action": "Réinitialiser la progression de tonte",
+    "confirmTitle": "Réinitialiser la progression enregistrée ?",
+    "confirmBody": "Cette action efface définitivement la progression de couverture enregistrée pour la carte actuelle.",
+    "confirmHint": "La tondeuse ne démarrera pas et les zones cartographiées ne seront pas supprimées.",
+    "confirmAction": "Réinitialiser",
+    "cancel": "Annuler",
+    "success": "La progression de tonte a été réinitialisée",
+    "error": "Impossible de réinitialiser la progression de tonte",
+    "unknownError": "Une erreur inconnue est survenue"
+  },
   "mapToolbarMobile": {
     "actionFailed": "Échec de l'action",
     "darkMap": "Carte sombre",

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -25,6 +25,7 @@ import {useManualMode} from "./map/hooks/useManualMode.ts";
 import {useMapEditing} from "./map/hooks/useMapEditing.ts";
 import {useMapStreams} from "./map/hooks/useMapStreams.ts";
 import {useMapFiles, type ImportOpenMowerSummary} from "./map/hooks/useMapFiles.ts";
+import {useResetMowingProgress} from "./map/hooks/useResetMowingProgress.tsx";
 import {ImportOpenMowerModal} from "./map/components/ImportOpenMowerModal.tsx";
 import {NewAreaModal} from "./map/components/NewAreaModal.tsx";
 import {EditAreaModal} from "./map/components/EditAreaModal.tsx";
@@ -56,6 +57,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     const {colors} = useThemeMode();
     const isMobile = useIsMobile();
     const mowerAction = useMowerAction()
+    const resetMowingProgress = useResetMowingProgress()
 
     // Brand tokens for the Mapbox display-only layers (dock, mower, lidar).
     // Shared between the compact and full render branches so the two stay in
@@ -1087,7 +1089,9 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                             })()
                         }}
                         stateName={highLevelStatus.highLevelStatus.state_name}
+                        highLevelState={highLevelStatus.highLevelStatus.state}
                         emergency={highLevelStatus.highLevelStatus.emergency}
+                        onResetMowingProgress={resetMowingProgress}
                         {...mowerActions}
                     />
                 )}
@@ -1122,7 +1126,9 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                             useSatellite={useSatellite}
                             mowingAreas={mowingAreas}
                             stateName={highLevelStatus.highLevelStatus.state_name}
+                            highLevelState={highLevelStatus.highLevelStatus.state}
                             emergency={highLevelStatus.highLevelStatus.emergency}
+                            onResetMowingProgress={resetMowingProgress}
                             pitched={pitched}
                             onTogglePitch={togglePitch}
                             onEditMap={handleEditMap}

--- a/gui/web/src/pages/map/components/MapToolbar.test.tsx
+++ b/gui/web/src/pages/map/components/MapToolbar.test.tsx
@@ -21,6 +21,7 @@ describe('MapToolbar', () => {
         useSatellite: true,
         mowingAreas: [],
         stateName: 'IDLE',
+        highLevelState: 1,
         emergency: false,
         onEditMap: vi.fn(),
         onToggleSatellite: vi.fn(),
@@ -30,6 +31,7 @@ describe('MapToolbar', () => {
         onRestoreMap: vi.fn(),
         onDownloadGeoJSON: vi.fn(),
         onImportOpenMower: vi.fn(),
+        onResetMowingProgress: vi.fn(),
         onMowArea: vi.fn().mockResolvedValue(undefined),
         onStart: vi.fn().mockResolvedValue(undefined),
         onHome: vi.fn().mockResolvedValue(undefined),
@@ -91,6 +93,28 @@ describe('MapToolbar', () => {
         await user.click(screen.getByText(en.mapToolbar.more));
         expect(screen.getByText(en.mapToolbar.backupMap)).toBeInTheDocument();
         expect(screen.getByText(en.mapToolbar.restoreMap)).toBeInTheDocument();
+    });
+
+    it('offers Reset Mowing Progress whenever the mower is not active', async () => {
+        const user = userEvent.setup();
+        render(<MapToolbar {...defaultProps} highLevelState={1} />);
+        await user.click(screen.getByText(en.mapToolbar.more));
+
+        const resetItem = screen.getByText(en.resetMowingProgress.action);
+        expect(resetItem).toBeInTheDocument();
+        await user.click(resetItem);
+        expect(defaultProps.onResetMowingProgress).toHaveBeenCalledOnce();
+    });
+
+    it('disables Reset Mowing Progress while an autonomous mission is active', async () => {
+        const user = userEvent.setup();
+        render(<MapToolbar {...defaultProps} highLevelState={2} stateName="MOWING" />);
+        await user.click(screen.getByText(en.mapToolbar.more));
+
+        const resetItem = screen.getByText(en.resetMowingProgress.action);
+        expect(resetItem.closest('[role="menuitem"]')).toHaveAttribute('aria-disabled', 'true');
+        await user.click(resetItem);
+        expect(defaultProps.onResetMowingProgress).not.toHaveBeenCalled();
     });
 
     it('shows Download GeoJSON in More dropdown', async () => {

--- a/gui/web/src/pages/map/components/MapToolbar.tsx
+++ b/gui/web/src/pages/map/components/MapToolbar.tsx
@@ -20,6 +20,7 @@ import {
     CheckOutlined,
     CloseOutlined,
     ImportOutlined,
+    DeleteOutlined,
 } from "@ant-design/icons";
 import type {MenuInfo} from "rc-menu/lib/interface";
 import {useTranslation} from "react-i18next";
@@ -36,6 +37,7 @@ interface MapToolbarProps {
     useSatellite: boolean;
     mowingAreas: MowingAreaItem[];
     stateName?: string;
+    highLevelState?: number;
     emergency?: boolean;
     onEditMap: () => void;
     onToggleSatellite: () => void;
@@ -45,6 +47,7 @@ interface MapToolbarProps {
     onRestoreMap: () => void;
     onDownloadGeoJSON: () => void;
     onImportOpenMower: () => void;
+    onResetMowingProgress: () => void;
     onMowArea: (key: string) => Promise<void>;
     pitched?: boolean;
     onTogglePitch?: () => void;
@@ -63,10 +66,10 @@ interface MapToolbarProps {
 }
 
 export const MapToolbar = ({
-    manualMode, useSatellite, mowingAreas, stateName, emergency,
+    manualMode, useSatellite, mowingAreas, stateName, highLevelState, emergency,
     onEditMap, onToggleSatellite,
     onManualMode, onStopManualMode,
-    onBackupMap, onRestoreMap, onDownloadGeoJSON, onImportOpenMower,
+    onBackupMap, onRestoreMap, onDownloadGeoJSON, onImportOpenMower, onResetMowingProgress,
     onMowArea, pitched, onTogglePitch,
     onStart, onHome, onEmergencyOn, onEmergencyOff,
     onAreaRecording, onMowNextArea, onContinueOrPause,
@@ -77,6 +80,11 @@ export const MapToolbar = ({
     const {t} = useTranslation();
     const isIdle = stateName === "IDLE" || stateName === "IDLE_DOCKED";
     const isRecording = stateName === "RECORDING";
+    // Numeric state is the authoritative signal. States 2 and above are
+    // autonomous, recording, manual mowing, or a future active mode; clearing
+    // persisted progress during any of them could race an active mission.
+    // Fail closed until the first status frame arrives.
+    const resetDisabled = highLevelState === undefined || highLevelState >= 2;
 
     const safeCall = (fn?: () => Promise<void>) => {
         fn?.().catch((e: Error) => {
@@ -110,6 +118,13 @@ export const MapToolbar = ({
         {key: "backup", icon: <DatabaseOutlined />, label: t("mapToolbar.backupMap")},
         {key: "restore", icon: <DatabaseOutlined />, label: t("mapToolbar.restoreMap")},
         {key: "importOpenMower", icon: <ImportOutlined />, label: t("mapToolbar.importFromOpenMower")},
+        {
+            key: "resetMowingProgress",
+            icon: <DeleteOutlined />,
+            label: t("resetMowingProgress.action"),
+            danger: true,
+            disabled: resetDisabled,
+        },
         {type: "divider"},
         {key: "download", icon: <DownloadOutlined />, label: t("mapToolbar.downloadGeojson")},
     ];
@@ -129,6 +144,7 @@ export const MapToolbar = ({
             case "backup": onBackupMap(); break;
             case "restore": onRestoreMap(); break;
             case "importOpenMower": onImportOpenMower(); break;
+            case "resetMowingProgress": onResetMowingProgress(); break;
             case "download": onDownloadGeoJSON(); break;
         }
     };

--- a/gui/web/src/pages/map/components/MapToolbarMobile.test.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MapToolbarMobile } from "./MapToolbarMobile.tsx";
+import en from "../../../i18n/locales/en.json";
+
+vi.mock("../../../theme/ThemeContext.tsx", () => ({
+  useThemeMode: () => ({
+    colors: {
+      glassBackground: "#111",
+      glassBorder: "1px solid #222",
+      glassShadow: "none",
+      bgElevated: "#222",
+      danger: "#f00",
+      text: "#fff",
+    },
+  }),
+}));
+
+vi.mock("../../../components/AsyncButton.tsx", () => ({
+  default: ({ children, onAsyncClick, ...props }: any) => (
+    <button onClick={onAsyncClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("./ShapePickerDropdown.tsx", () => ({
+  ShapePickerDropdown: ({ children }: any) => children,
+}));
+
+describe("MapToolbarMobile", () => {
+  const defaultProps = {
+    editMap: false,
+    hasUnsavedChanges: false,
+    manualMode: false,
+    useSatellite: true,
+    historyIndex: 0,
+    editHistoryLength: 1,
+    mowingAreas: [],
+    stateName: "IDLE",
+    highLevelState: 1,
+    emergency: false,
+    onEditMap: vi.fn(),
+    onSaveMap: vi.fn().mockResolvedValue(undefined),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
+    onToggleSatellite: vi.fn(),
+    onManualMode: vi.fn().mockResolvedValue(undefined),
+    onStopManualMode: vi.fn().mockResolvedValue(undefined),
+    onBackupMap: vi.fn(),
+    onRestoreMap: vi.fn(),
+    onDownloadGeoJSON: vi.fn(),
+    onUploadGeoJSON: vi.fn(),
+    onImportOpenMower: vi.fn(),
+    onResetMowingProgress: vi.fn(),
+    onMowArea: vi.fn().mockResolvedValue(undefined),
+    onStart: vi.fn().mockResolvedValue(undefined),
+    onHome: vi.fn().mockResolvedValue(undefined),
+    onEmergencyOn: vi.fn().mockResolvedValue(undefined),
+    onEmergencyOff: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("offers the reset action in the mobile data menu while idle", async () => {
+    const user = userEvent.setup();
+    render(<MapToolbarMobile {...defaultProps} />);
+
+    await user.click(screen.getByLabelText(en.mapToolbarMobile.more));
+    await user.click(screen.getByText(en.resetMowingProgress.action));
+
+    expect(defaultProps.onResetMowingProgress).toHaveBeenCalledOnce();
+  });
+});

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -64,6 +64,7 @@ interface MapToolbarMobileProps {
     onDownloadGeoJSON: () => void;
     onUploadGeoJSON: () => void;
     onImportOpenMower: () => void;
+    onResetMowingProgress: () => void;
     onMowArea: (key: string) => Promise<void>;
     selectedFeatureCount?: number;
     onEditSelectedFeature?: () => void;
@@ -77,6 +78,7 @@ interface MapToolbarMobileProps {
     onPlaceDock?: () => void;
     dockPlacementMode?: boolean;
     stateName?: string;
+    highLevelState?: number;
     emergency?: boolean;
     onStart?: () => Promise<void>;
     onHome?: () => Promise<void>;
@@ -97,11 +99,11 @@ export const MapToolbarMobile = ({
     historyIndex, editHistoryLength, mowingAreas,
     onEditMap, onSaveMap, onUndo, onRedo, onToggleSatellite,
     onManualMode, onStopManualMode,
-    onBackupMap, onRestoreMap, onDownloadGeoJSON, onUploadGeoJSON, onImportOpenMower,
+    onBackupMap, onRestoreMap, onDownloadGeoJSON, onUploadGeoJSON, onImportOpenMower, onResetMowingProgress,
     onMowArea, selectedFeatureCount = 0, onEditSelectedFeature,
     onDrawPolygon, onDrawShape, onDrawEmoji, onTrash, onCombine, onSubtract, onSplit,
     onPlaceDock, dockPlacementMode,
-    stateName, emergency,
+    stateName, highLevelState, emergency,
     onStart, onHome, onEmergencyOn, onEmergencyOff,
     onAreaRecording, onMowNextArea, onContinueOrPause,
     onBladeForward, onBladeBackward, onBladeOff,
@@ -170,6 +172,7 @@ export const MapToolbarMobile = ({
 
     const isIdle = stateName === "IDLE" || stateName === "IDLE_DOCKED";
     const isRecording = stateName === "RECORDING";
+    const resetDisabled = highLevelState === undefined || highLevelState >= 2;
 
     const safeCall = (fn?: () => Promise<void>) => {
         fn?.().catch((e: Error) => {
@@ -195,6 +198,13 @@ export const MapToolbarMobile = ({
         {key: "backup", icon: <DatabaseOutlined />, label: t("mapToolbarMobile.backupMap")},
         {key: "restore", icon: <DatabaseOutlined />, label: t("mapToolbarMobile.restoreMap")},
         {key: "importOpenMower", icon: <ImportOutlined />, label: t("mapToolbarMobile.importFromOpenMower")},
+        {
+            key: "resetMowingProgress",
+            icon: <DeleteOutlined />,
+            label: t("resetMowingProgress.action"),
+            danger: true,
+            disabled: resetDisabled,
+        },
         {type: "divider"},
         {key: "download", icon: <DownloadOutlined />, label: t("mapToolbarMobile.downloadGeojson")},
         ...(editMap
@@ -214,6 +224,7 @@ export const MapToolbarMobile = ({
             case "backup": onBackupMap(); break;
             case "restore": onRestoreMap(); break;
             case "importOpenMower": onImportOpenMower(); break;
+            case "resetMowingProgress": onResetMowingProgress(); break;
             case "download": onDownloadGeoJSON(); break;
             case "upload": onUploadGeoJSON(); break;
         }

--- a/gui/web/src/pages/map/hooks/useResetMowingProgress.test.ts
+++ b/gui/web/src/pages/map/hooks/useResetMowingProgress.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useResetMowingProgress } from "./useResetMowingProgress.tsx";
+
+const mocks = vi.hoisted(() => ({
+  callCreate: vi.fn(),
+  confirm: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useApi.ts", () => ({
+  useApi: () => ({
+    mowglinext: { callCreate: mocks.callCreate },
+  }),
+}));
+
+vi.mock("antd", () => ({
+  App: {
+    useApp: () => ({
+      modal: { confirm: mocks.confirm },
+      notification: { success: mocks.success, error: mocks.error },
+    }),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("useResetMowingProgress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.callCreate.mockResolvedValue({ data: {}, error: undefined });
+  });
+
+  it("asks for confirmation before clearing progress", () => {
+    const { result } = renderHook(() => useResetMowingProgress());
+
+    act(() => result.current());
+
+    expect(mocks.confirm).toHaveBeenCalledOnce();
+    expect(mocks.callCreate).not.toHaveBeenCalled();
+    expect(mocks.confirm.mock.calls[0][0]).toMatchObject({
+      title: "resetMowingProgress.confirmTitle",
+      okText: "resetMowingProgress.confirmAction",
+      cancelText: "resetMowingProgress.cancel",
+      okType: "danger",
+    });
+  });
+
+  it("clears resume data without starting a mowing session", async () => {
+    const { result } = renderHook(() => useResetMowingProgress());
+    act(() => result.current());
+
+    await act(async () => {
+      await mocks.confirm.mock.calls[0][0].onOk();
+    });
+
+    expect(mocks.callCreate).toHaveBeenCalledOnce();
+    expect(mocks.callCreate).toHaveBeenCalledWith("coverage_clear_resume", {});
+    expect(mocks.callCreate).not.toHaveBeenCalledWith(
+      "high_level_control",
+      expect.anything(),
+    );
+    expect(mocks.success).toHaveBeenCalledWith({
+      message: "resetMowingProgress.success",
+    });
+  });
+
+  it("shows the backend error and keeps the confirmation retryable", async () => {
+    mocks.callCreate.mockResolvedValue({
+      data: undefined,
+      error: { error: "coverage service unavailable" },
+    });
+    const { result } = renderHook(() => useResetMowingProgress());
+    act(() => result.current());
+
+    await expect(mocks.confirm.mock.calls[0][0].onOk()).rejects.toThrow(
+      "coverage service unavailable",
+    );
+    expect(mocks.error).toHaveBeenCalledWith({
+      message: "resetMowingProgress.error",
+      description: "coverage service unavailable",
+    });
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+});

--- a/gui/web/src/pages/map/hooks/useResetMowingProgress.tsx
+++ b/gui/web/src/pages/map/hooks/useResetMowingProgress.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+import { App } from "antd";
+import { useTranslation } from "react-i18next";
+import { useApi } from "../../../hooks/useApi.ts";
+
+export const useResetMowingProgress = () => {
+  const guiApi = useApi();
+  const { modal, notification } = App.useApp();
+  const { t } = useTranslation();
+
+  return useCallback(() => {
+    modal.confirm({
+      title: t("resetMowingProgress.confirmTitle"),
+      content: (
+        <div>
+          <p>{t("resetMowingProgress.confirmBody")}</p>
+          <p style={{ marginBottom: 0 }}>
+            {t("resetMowingProgress.confirmHint")}
+          </p>
+        </div>
+      ),
+      okText: t("resetMowingProgress.confirmAction"),
+      okType: "danger",
+      cancelText: t("resetMowingProgress.cancel"),
+      onOk: async () => {
+        try {
+          const response = await guiApi.mowglinext.callCreate(
+            "coverage_clear_resume",
+            {},
+          );
+          if (response.error) {
+            throw new Error(response.error.error);
+          }
+          notification.success({
+            message: t("resetMowingProgress.success"),
+          });
+        } catch (error: unknown) {
+          const description =
+            error instanceof Error
+              ? error.message
+              : t("resetMowingProgress.unknownError");
+          notification.error({
+            message: t("resetMowingProgress.error"),
+            description,
+          });
+          // Rejecting keeps the Ant Design confirmation open so the
+          // operator can retry or cancel after reading the error.
+          throw error;
+        }
+      },
+    });
+  }, [guiApi, modal, notification, t]);
+};

--- a/gui/web/tests/e2e/reset-mowing-progress.spec.ts
+++ b/gui/web/tests/e2e/reset-mowing-progress.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { installMockBackend } from "./mock/mockBackend.ts";
+import { SCENARIOS } from "./mock/scenarios.ts";
+
+test("reset mowing progress confirms, clears only resume data, and reports success", async ({
+  page,
+}) => {
+  const idleScenario = SCENARIOS.find(
+    (scenario) => scenario.name === "idle-docked-full",
+  );
+  if (!idleScenario) throw new Error("idle-docked-full scenario is missing");
+
+  await installMockBackend(page, {
+    ...idleScenario,
+    rest: {
+      ...idleScenario.rest,
+      "/api/settings/yaml": { datum_lat: 48.1, datum_lon: 11.5 },
+    },
+  });
+
+  const mowerCommands: string[] = [];
+  await page.route(/\/api\/mowglinext\/call\//, async (route) => {
+    mowerCommands.push(new URL(route.request().url()).pathname);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/#/map");
+  await page.getByRole("button", { name: "More" }).click();
+  await page.getByText("Reset mowing progress").click();
+
+  const confirmation = page.getByRole("dialog");
+  await expect(confirmation.locator(".ant-modal-confirm-title")).toHaveText(
+    "Reset saved mowing progress?",
+  );
+  await expect(
+    confirmation.getByText(
+      "The mower will not start, and your mapped areas will not be deleted.",
+    ),
+  ).toBeVisible();
+  expect(mowerCommands).toEqual([]);
+  await page.waitForTimeout(300);
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/reset-mowing-progress-confirmation.png",
+    fullPage: true,
+  });
+
+  await confirmation.getByRole("button", { name: "Reset progress" }).click();
+
+  await expect(page.getByText("Mowing progress was reset")).toBeVisible();
+  expect(mowerCommands).toEqual(["/api/mowglinext/call/coverage_clear_resume"]);
+});
+
+test("reset mowing progress is disabled during an active mowing mission", async ({
+  page,
+}) => {
+  const mowingScenario = SCENARIOS.find(
+    (scenario) => scenario.name === "mowing-area2-rtk-fixed",
+  );
+  if (!mowingScenario)
+    throw new Error("mowing-area2-rtk-fixed scenario is missing");
+
+  await installMockBackend(page, {
+    ...mowingScenario,
+    rest: {
+      ...mowingScenario.rest,
+      "/api/settings/yaml": { datum_lat: 48.1, datum_lon: 11.5 },
+    },
+  });
+
+  await page.goto("/#/map");
+  await page.getByRole("button", { name: "More" }).click();
+
+  const resetItem = page.getByRole("menuitem", {
+    name: "Reset mowing progress",
+  });
+  await expect(resetItem).toHaveAttribute("aria-disabled", "true");
+});


### PR DESCRIPTION
## Summary

Adds the dedicated **Reset mowing progress** action requested in #420 to the map-management menus on desktop and mobile.

The action is separate from **Start fresh**: it clears saved coverage progress without starting a mowing session.

## Changes

- add the reset action to the desktop and mobile map menus
- require an explicit destructive-action confirmation
- call only the existing `coverage_clear_resume` backend action
- show success and error feedback
- disable the action while an autonomous, recording, manual, or future active high-level mode is reported
- fail closed until the first high-level status frame arrives
- add English and French copy
- add hook, desktop, mobile, and mocked browser coverage

## Safety

This change does not send a motion or blade command. The tests verify that `high_level_control` is never called by the reset flow. The action is disabled while the mower reports an active high-level state.

## Testing

- [x] Targeted Vitest/component suite: 20 passed
- [x] TypeScript + Vite production build
- [x] Full Playwright suite: 66 passed
- [x] Desktop confirmation flow visually checked from the Playwright artifact
- [x] Secret scan and `git diff --check`

## Related test maintenance

The outdated manual-mode expectations from `upstream/dev` are corrected in #440. The legacy ESLint 9 configuration-discovery issue is unchanged by this diff.

Closes #420
