### PR TITLE
perf(gui): precompress and cache web assets

### DIFF
--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -7,7 +7,9 @@ RUN CGO_ENABLED=0 go build -o mowglinext
 FROM node:22 AS build-web
 COPY ./web /web
 WORKDIR /web
-RUN yarn && yarn build
+RUN yarn && yarn build \
+ && find dist/assets -type f \( -name '*.js' -o -name '*.css' -o -name '*.json' -o -name '*.svg' -o -name '*.wasm' \) \
+      -size +1024c -exec gzip -9 -k {} +
 
 FROM ubuntu:22.04 AS deps
 RUN apt-get update && apt-get install -y ca-certificates curl python3 python3-pip python3-venv libjim-dev\

--- a/gui/pkg/api/api.go
+++ b/gui/pkg/api/api.go
@@ -1,15 +1,15 @@
 package api
 
 import (
+	"log"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
 	"github.com/mowglinext/mowglinext/docs"
 	"github.com/mowglinext/mowglinext/pkg/providers"
 	"github.com/mowglinext/mowglinext/pkg/types"
-	"github.com/gin-contrib/cors"
-	"github.com/gin-contrib/static"
-	"github.com/gin-gonic/gin"
 	swaggerfiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
-	"log"
 )
 
 // gin-swagger middleware
@@ -33,18 +33,7 @@ func NewAPI(dbProvider types.IDBProvider, dockerProvider types.IDockerProvider, 
 		log.Fatal(err)
 	}
 	webDir := string(webDirectory)
-	r.Use(func(c *gin.Context) {
-		p := c.Request.URL.Path
-		if p == "/" || p == "/index.html" {
-			c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
-		}
-		c.Next()
-	})
-	r.Use(static.Serve("/", static.LocalFile(webDir, false)))
-	r.NoRoute(func(c *gin.Context) {
-		c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
-		c.File(webDir + "/index.html")
-	})
+	registerWebUI(r, webDir)
 	apiGroup := r.Group("/api")
 	ConfigRoute(apiGroup, dbProvider)
 	SettingsRoutes(apiGroup, dbProvider)

--- a/gui/pkg/api/web_static.go
+++ b/gui/pkg/api/web_static.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gin-contrib/static"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	noCacheHTMLControl         = "no-cache, no-store, must-revalidate"
+	immutableAssetCacheControl = "public, max-age=31536000, immutable"
+)
+
+func registerWebUI(router *gin.Engine, webDir string) {
+	router.Use(webAssetDelivery(webDir))
+	router.Use(static.Serve("/", static.LocalFile(webDir, false)))
+	router.NoRoute(func(c *gin.Context) {
+		c.Header("Cache-Control", noCacheHTMLControl)
+		c.File(filepath.Join(webDir, "index.html"))
+	})
+}
+
+func webAssetDelivery(webDir string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestPath := c.Request.URL.Path
+		if requestPath == "/" || requestPath == "/index.html" {
+			c.Header("Cache-Control", noCacheHTMLControl)
+		}
+
+		if !strings.HasPrefix(requestPath, "/assets/") {
+			c.Next()
+			return
+		}
+
+		c.Header("Cache-Control", immutableAssetCacheControl)
+		appendVary(c.Writer.Header(), "Accept-Encoding")
+
+		if (c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead) ||
+			!acceptsGzip(c.GetHeader("Accept-Encoding")) ||
+			!isCompressibleAsset(requestPath) ||
+			!hasGzipSidecar(webDir, requestPath) {
+			c.Next()
+			return
+		}
+
+		originalPath := c.Request.URL.Path
+		c.Request.URL.Path += ".gz"
+		c.Header("Content-Encoding", "gzip")
+		if contentType := mime.TypeByExtension(filepath.Ext(originalPath)); contentType != "" {
+			c.Header("Content-Type", contentType)
+		}
+		c.Next()
+		c.Request.URL.Path = originalPath
+	}
+}
+
+func hasGzipSidecar(webDir, requestPath string) bool {
+	relativePath := filepath.Clean(strings.TrimPrefix(requestPath, "/"))
+	assetsPrefix := "assets" + string(filepath.Separator)
+	if !strings.HasPrefix(relativePath, assetsPrefix) {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(webDir, relativePath) + ".gz")
+	return err == nil && !info.IsDir()
+}
+
+func isCompressibleAsset(requestPath string) bool {
+	switch strings.ToLower(filepath.Ext(requestPath)) {
+	case ".css", ".js", ".json", ".svg", ".wasm":
+		return true
+	default:
+		return false
+	}
+}
+
+func acceptsGzip(header string) bool {
+	var wildcardQuality *float64
+	for _, value := range strings.Split(header, ",") {
+		parts := strings.Split(value, ";")
+		encoding := strings.ToLower(strings.TrimSpace(parts[0]))
+		quality := 1.0
+		for _, parameter := range parts[1:] {
+			name, rawValue, found := strings.Cut(strings.TrimSpace(parameter), "=")
+			if !found || !strings.EqualFold(strings.TrimSpace(name), "q") {
+				continue
+			}
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(rawValue), 64)
+			if err != nil {
+				quality = 0
+			} else {
+				quality = parsed
+			}
+		}
+
+		switch encoding {
+		case "gzip":
+			return quality > 0
+		case "*":
+			qualityCopy := quality
+			wildcardQuality = &qualityCopy
+		}
+	}
+
+	return wildcardQuality != nil && *wildcardQuality > 0
+}
+
+func appendVary(header http.Header, value string) {
+	for _, existing := range header.Values("Vary") {
+		for _, field := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), value) {
+				return
+			}
+		}
+	}
+	header.Add("Vary", value)
+}

--- a/gui/pkg/api/web_static_test.go
+++ b/gui/pkg/api/web_static_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-contrib/static"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const testAssetPath = "/assets/index-ABC123.js"
+
+func writeWebFixture(tb testing.TB) (string, []byte) {
+	tb.Helper()
+	webDir := tb.TempDir()
+	require.NoError(tb, os.MkdirAll(filepath.Join(webDir, "assets"), 0o755))
+	require.NoError(tb, os.WriteFile(filepath.Join(webDir, "index.html"), []byte("<html>shell</html>"), 0o644))
+
+	// Mix repeated JavaScript-like content with deterministic high-entropy text.
+	// This keeps the fixture large while avoiding an unrealistically tiny gzip.
+	raw := bytes.Repeat([]byte("const mowerStatus = updateTelemetry(frame);\n"), 7_000)
+	noise := make([]byte, 132_000)
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()[]{}"
+	seed := uint32(0x9e3779b9)
+	for i := range noise {
+		seed ^= seed << 13
+		seed ^= seed >> 17
+		seed ^= seed << 5
+		noise[i] = alphabet[int(seed)%len(alphabet)]
+	}
+	raw = append(raw, noise...)
+	require.NoError(tb, os.WriteFile(filepath.Join(webDir, testAssetPath), raw, 0o644))
+
+	compressedFile, err := os.Create(filepath.Join(webDir, testAssetPath+".gz"))
+	require.NoError(tb, err)
+	gzipWriter, err := gzip.NewWriterLevel(compressedFile, gzip.BestCompression)
+	require.NoError(tb, err)
+	_, err = gzipWriter.Write(raw)
+	require.NoError(tb, err)
+	require.NoError(tb, gzipWriter.Close())
+	require.NoError(tb, compressedFile.Close())
+	return webDir, raw
+}
+
+func newBaselineStaticRouter(webDir string) *gin.Engine {
+	router := gin.New()
+	router.Use(static.Serve("/", static.LocalFile(webDir, false)))
+	router.NoRoute(func(c *gin.Context) {
+		c.File(filepath.Join(webDir, "index.html"))
+	})
+	return router
+}
+
+func performRequest(router http.Handler, path, acceptEncoding string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	if acceptEncoding != "" {
+		request.Header.Set("Accept-Encoding", acceptEncoding)
+	}
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func TestRegisterWebUIUsesPrecompressedHashedAssets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir, raw := writeWebFixture(t)
+	router := gin.New()
+	registerWebUI(router, webDir)
+
+	response := performRequest(router, testAssetPath, "br, gzip")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "gzip", response.Header().Get("Content-Encoding"))
+	require.Equal(t, "Accept-Encoding", response.Header().Get("Vary"))
+	require.Equal(t, immutableAssetCacheControl, response.Header().Get("Cache-Control"))
+	require.Contains(t, response.Header().Get("Content-Type"), "javascript")
+
+	reader, err := gzip.NewReader(response.Body)
+	require.NoError(t, err)
+	decoded, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	require.Equal(t, raw, decoded)
+}
+
+func TestRegisterWebUIFallsBackWhenGzipIsRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir, raw := writeWebFixture(t)
+	router := gin.New()
+	registerWebUI(router, webDir)
+
+	response := performRequest(router, testAssetPath, "gzip;q=0, identity")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Empty(t, response.Header().Get("Content-Encoding"))
+	require.Equal(t, immutableAssetCacheControl, response.Header().Get("Cache-Control"))
+	require.Equal(t, raw, response.Body.Bytes())
+}
+
+func TestRegisterWebUIFallsBackWhenSidecarIsMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir, raw := writeWebFixture(t)
+	require.NoError(t, os.Remove(filepath.Join(webDir, testAssetPath+".gz")))
+	router := gin.New()
+	registerWebUI(router, webDir)
+
+	response := performRequest(router, testAssetPath, "gzip")
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Empty(t, response.Header().Get("Content-Encoding"))
+	require.Equal(t, immutableAssetCacheControl, response.Header().Get("Cache-Control"))
+	require.Equal(t, raw, response.Body.Bytes())
+}
+
+func TestRegisterWebUIDoesNotCacheHTMLShell(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	webDir, _ := writeWebFixture(t)
+	router := gin.New()
+	registerWebUI(router, webDir)
+
+	for _, test := range []struct {
+		path       string
+		statusCode int
+		body       string
+	}{
+		{path: "/", statusCode: http.StatusOK, body: "<html>shell</html>"},
+		{path: "/index.html", statusCode: http.StatusMovedPermanently},
+		{path: "/settings", statusCode: http.StatusOK, body: "<html>shell</html>"},
+	} {
+		response := performRequest(router, test.path, "gzip")
+		require.Equal(t, test.statusCode, response.Code, test.path)
+		require.Equal(t, noCacheHTMLControl, response.Header().Get("Cache-Control"), test.path)
+		require.Empty(t, response.Header().Get("Content-Encoding"), test.path)
+		require.Equal(t, test.body, response.Body.String(), test.path)
+	}
+}
+
+func BenchmarkStaticAssetDelivery(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	webDir, _ := writeWebFixture(b)
+
+	benchmarks := []struct {
+		name           string
+		router         http.Handler
+		acceptEncoding string
+	}{
+		{name: "baseline_raw", router: newBaselineStaticRouter(webDir)},
+		{name: "precompressed_gzip", router: func() http.Handler {
+			router := gin.New()
+			registerWebUI(router, webDir)
+			return router
+		}(), acceptEncoding: "gzip"},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			request := httptest.NewRequest(http.MethodGet, testAssetPath, nil)
+			request.Header.Set("Accept-Encoding", benchmark.acceptEncoding)
+			var wireBytes int
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				response := httptest.NewRecorder()
+				benchmark.router.ServeHTTP(response, request)
+				require.Equal(b, http.StatusOK, response.Code)
+				wireBytes = response.Body.Len()
+			}
+			b.ReportMetric(float64(wireBytes), "wire-B/op")
+		})
+	}
+}
+
+func TestAcceptsGzip(t *testing.T) {
+	for _, test := range []struct {
+		header string
+		want   bool
+	}{
+		{header: "gzip", want: true},
+		{header: "br, gzip", want: true},
+		{header: "gzip;q=0.5", want: true},
+		{header: "gzip;q=0", want: false},
+		{header: "*;q=0.5", want: true},
+		{header: "*;q=1, gzip;q=0", want: false},
+		{header: "gzip;q=bogus", want: false},
+		{header: "br", want: false},
+		{header: "", want: false},
+	} {
+		t.Run(strings.ReplaceAll(test.header, ";", "_"), func(t *testing.T) {
+			require.Equal(t, test.want, acceptsGzip(test.header))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- generate gzip sidecars for compressible Vite assets larger than 1 KiB
- serve a sidecar when the client accepts gzip, without runtime compression
- cache Vite's content-hashed `/assets/` files as immutable for one year
- preserve the no-cache policy for the HTML application shell and SPA fallback
- preserve raw-file delivery when gzip is rejected or a sidecar is absent

## Performance

Production bundle measurement:

| Metric | Raw | Gzip | Difference |
| --- | ---: | ---: | ---: |
| 56 compressible assets | 4,701,705 B | 1,374,403 B | -70.77% transferred bytes |

Static delivery benchmark median, 10 runs of 200 requests on Linux arm64 with Go 1.24:

| Metric | Existing raw delivery | Precompressed delivery | Difference |
| --- | ---: | ---: | ---: |
| Time | 124,992 ns/op | 44,366 ns/op | -64.51% |
| Allocated memory | 1,051,244 B/op | 265,330 B/op | -74.76% |
| Response bytes | 440,000 B/op | 105,925 B/op | -75.93% |
| Allocations | 36 allocs/op | 42 allocs/op | +6 allocs/op |

The benchmark covers static response delivery. It does not measure browser rendering or macOS energy impact.

## Testing

- [x] gzip negotiation, fallback, cache, content type, SPA, and HTML-shell unit tests
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Docker `build-web` target
- [x] decompressed all 56 generated sidecars and compared them byte-for-byte with their source assets
- [x] `git diff --check` and secret scan

The schema/template default mismatches encountered during the original validation are corrected by #441.

Related to #430
