### PR TITLE
perf(gui): stabilize map stream rendering

### DIFF
--- a/gui/web/src/components/settings/DisplayModeSection.test.tsx
+++ b/gui/web/src/components/settings/DisplayModeSection.test.tsx
@@ -1,0 +1,39 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {ThemeProvider, useThemeMode} from "../../theme/ThemeContext.tsx";
+import {DisplayModeSection} from "./DisplayModeSection.tsx";
+
+function ModeValue() {
+    return <output data-testid="display-mode-value">{useThemeMode().displayMode}</output>;
+}
+
+describe("DisplayModeSection", () => {
+    beforeEach(() => {
+        const storage = new Map<string, string>();
+        Object.defineProperty(window, "localStorage", {
+            configurable: true,
+            value: {
+                getItem: (key: string) => storage.get(key) ?? null,
+                setItem: (key: string, value: string) => storage.set(key, value),
+                removeItem: (key: string) => storage.delete(key),
+                clear: () => storage.clear(),
+            },
+        });
+    });
+
+    it("offers all modes and updates the shared preference", () => {
+        render(
+            <ThemeProvider>
+                <DisplayModeSection/>
+                <ModeValue/>
+            </ThemeProvider>,
+        );
+
+        expect(screen.getByRole("radio", {name: /^Visual/})).toBeInTheDocument();
+        expect(screen.getByRole("radio", {name: /^Balanced/})).toBeChecked();
+        expect(screen.getByRole("radio", {name: /^Efficient/})).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("radio", {name: /^Efficient/}));
+        expect(screen.getByTestId("display-mode-value")).toHaveTextContent("efficient");
+    });
+});

--- a/gui/web/src/components/settings/DisplayModeSection.tsx
+++ b/gui/web/src/components/settings/DisplayModeSection.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {Card, Radio, Space, Typography} from "antd";
+import {useTranslation} from "react-i18next";
+import {useThemeMode} from "../../theme/ThemeContext.tsx";
+import type {DisplayMode} from "../../theme/ThemeContext.tsx";
+
+const {Paragraph, Text} = Typography;
+
+const DISPLAY_MODE_OPTIONS: DisplayMode[] = ['visual', 'balanced', 'efficient'];
+
+export const DisplayModeSection: React.FC = () => {
+    const {t} = useTranslation();
+    const {colors, displayMode, setDisplayMode} = useThemeMode();
+
+    return (
+        <Card size="small">
+            <Space direction="vertical" size={14} style={{width: "100%"}}>
+                <div>
+                    <Text strong style={{fontSize: 14}}>{t("displayMode.title")}</Text>
+                    <Paragraph type="secondary" style={{margin: "4px 0 0"}}>
+                        {t("displayMode.description")}
+                    </Paragraph>
+                </div>
+
+                <Radio.Group
+                    value={displayMode}
+                    onChange={(event) => setDisplayMode(event.target.value as DisplayMode)}
+                    aria-label={t("displayMode.title")}
+                    style={{display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(190px, 1fr))", gap: 10}}
+                >
+                    {DISPLAY_MODE_OPTIONS.map((mode) => {
+                        const selected = displayMode === mode;
+                        return (
+                            <Radio
+                                key={mode}
+                                value={mode}
+                                style={{
+                                    alignItems: "flex-start",
+                                    minHeight: 76,
+                                    marginInlineEnd: 0,
+                                    padding: "12px 14px",
+                                    borderRadius: 12,
+                                    border: `1px solid ${selected ? colors.accent : colors.border}`,
+                                    background: selected ? colors.primaryBg : colors.bgElevated,
+                                }}
+                            >
+                                <span style={{display: "inline-flex", flexDirection: "column", gap: 4, paddingLeft: 4}}>
+                                    <Text strong style={{color: colors.text}}>{t(`displayMode.${mode}.label`)}</Text>
+                                    <Text type="secondary" style={{fontSize: 12, lineHeight: 1.45}}>
+                                        {t(`displayMode.${mode}.description`)}
+                                    </Text>
+                                </span>
+                            </Radio>
+                        );
+                    })}
+                </Radio.Group>
+
+                <Text type="secondary" style={{fontSize: 12}}>
+                    {t("displayMode.reducedMotion")}
+                </Text>
+            </Space>
+        </Card>
+    );
+};

--- a/gui/web/src/components/settings/SettingsNav.tsx
+++ b/gui/web/src/components/settings/SettingsNav.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Badge, Menu, Tabs } from "antd";
 import {
     AimOutlined,
+    BgColorsOutlined,
     CloudOutlined,
     CodeOutlined,
     CompassOutlined,
@@ -22,6 +23,7 @@ import { useThemeMode } from "../../theme/ThemeContext.tsx";
 import { SettingsSection, SectionMeta } from "../../hooks/useSettingsManager.ts";
 
 const SECTION_ICONS: Record<string, React.ReactNode> = {
+    "bg-colors": <BgColorsOutlined />,
     tool: <ToolOutlined />,
     dashboard: <DashboardOutlined />,
     global: <GlobalOutlined />,

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -9,6 +9,7 @@ import { ContentType } from "../api/Api.ts";
 import { valuesMatch } from "../utils/settingsValues.ts";
 
 export type SettingsSection =
+    | "appearance"
     | "hardware"
     | "drive_motor"
     | "ntrip"
@@ -33,6 +34,13 @@ export type SectionMeta = {
 };
 
 const SECTION_DEFINITIONS: SectionMeta[] = [
+    {
+        id: "appearance",
+        label: "settingsSections.appearance.label",
+        icon: "bg-colors",
+        description: "settingsSections.appearance.description",
+        keys: [],
+    },
     {
         id: "hardware",
         label: "settingsSections.hardware.label",

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2939,6 +2939,10 @@
     "errorOccurred": "An error occured"
   },
   "settingsSections": {
+    "appearance": {
+      "label": "Appearance",
+      "description": "Visual richness and energy use on this device"
+    },
     "hardware": {
       "label": "Hardware",
       "description": "Robot model, wheels, chassis, and blade dimensions"
@@ -3007,6 +3011,23 @@
       "drivePidUpdateFailed": "Settings saved, but live drive-PID update failed",
       "drivePidUpdateFailedDescription": "Restart ROS2 to apply the new drive-motor PID gains.",
       "saveFailed": "Failed to save settings"
+    }
+  },
+  "displayMode": {
+    "title": "Display mode",
+    "description": "Choose the balance of visual richness, responsiveness, and energy use for this browser.",
+    "reducedMotion": "Your system's reduced-motion setting always limits non-essential motion.",
+    "visual": {
+      "label": "Visual",
+      "description": "Richer glass surfaces and subtle ambient feedback."
+    },
+    "balanced": {
+      "label": "Balanced",
+      "description": "The intended Mowgli look with efficient default rendering."
+    },
+    "efficient": {
+      "label": "Efficient",
+      "description": "Lower compositing and conservative visual update rates."
     }
   },
   "ntripProviders": {

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -2935,6 +2935,10 @@
     "errorOccurred": "Une erreur est survenue"
   },
   "settingsSections": {
+    "appearance": {
+      "label": "Apparence",
+      "description": "Richesse visuelle et consommation d'énergie sur cet appareil"
+    },
     "hardware": {
       "label": "Matériel",
       "description": "Modèle de robot, roues, châssis et dimensions de la lame"
@@ -3003,6 +3007,23 @@
       "drivePidUpdateFailed": "Réglages enregistrés, mais la mise à jour à chaud du PID des moteurs a échoué",
       "drivePidUpdateFailedDescription": "Redémarrez ROS2 pour appliquer les nouveaux gains PID des moteurs.",
       "saveFailed": "Échec de l'enregistrement des réglages"
+    }
+  },
+  "displayMode": {
+    "title": "Mode d'affichage",
+    "description": "Choisissez l'équilibre entre richesse visuelle, réactivité et consommation d'énergie pour ce navigateur.",
+    "reducedMotion": "Le réglage système de réduction des animations limite toujours les mouvements non essentiels.",
+    "visual": {
+      "label": "Visuel",
+      "description": "Surfaces vitrées plus riches et retours d'ambiance subtils."
+    },
+    "balanced": {
+      "label": "Équilibré",
+      "description": "L'apparence Mowgli prévue avec un rendu efficace par défaut."
+    },
+    "efficient": {
+      "label": "Efficace",
+      "description": "Moins de composition graphique et des mises à jour visuelles prudentes."
     }
   },
   "ntripProviders": {

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -205,21 +205,21 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     // filter (no feature rebuild). Only the full map passes withHighlight; the
     // compact overview just shows the fill/outline/label.
     const renderDynObstacleLayers = (withHighlight: boolean) => (
-        <>
-            <Layer type={"fill"} id={"dyn-obstacle-fill"}
+        [
+            <Layer key={"dyn-obstacle-fill"} type={"fill"} id={"dyn-obstacle-fill"}
                 filter={['==', ['get', 'feature_type'], 'dyn-obstacle']}
-                paint={{'fill-color': ['get', 'color']}}/>
-            <Layer type={"line"} id={"dyn-obstacle-outline"}
+                paint={{'fill-color': ['get', 'color']}}/>,
+            <Layer key={"dyn-obstacle-outline"} type={"line"} id={"dyn-obstacle-outline"}
                 filter={['==', ['get', 'feature_type'], 'dyn-obstacle']}
-                paint={{'line-color': LAYER_COLORS.lidarHit, 'line-width': 2}}/>
-            {withHighlight && (
-                <Layer type={"line"} id={"dyn-obstacle-highlight"}
+                paint={{'line-color': LAYER_COLORS.lidarHit, 'line-width': 2}}/>,
+            ...(withHighlight ? [
+                <Layer key={"dyn-obstacle-highlight"} type={"line"} id={"dyn-obstacle-highlight"}
                     filter={['all',
                         ['==', ['get', 'feature_type'], 'dyn-obstacle'],
                         ['==', ['get', 'obs_id'], selectedObstacleId ?? -1]]}
-                    paint={{'line-color': LAYER_COLORS.lidarMiss, 'line-width': 4}}/>
-            )}
-            <Layer type={"symbol"} id={"dyn-obstacle-label"}
+                    paint={{'line-color': LAYER_COLORS.lidarMiss, 'line-width': 4}}/>,
+            ] : []),
+            <Layer key={"dyn-obstacle-label"} type={"symbol"} id={"dyn-obstacle-label"}
                 filter={['==', ['get', 'feature_type'], 'dyn-obstacle']}
                 layout={{
                     'text-field': ['concat', '#', ['get', 'obs_label']],
@@ -231,8 +231,8 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     'text-color': LAYER_COLORS.labelText,
                     'text-halo-color': LAYER_COLORS.labelHalo,
                     'text-halo-width': 1.5,
-                }}/>
-        </>
+                }}/>,
+        ]
     );
 
     const [mowingAreas, setMowingAreas] = useState<{ key: string, label: string, feat: Feature }[]>([])

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -29,6 +29,7 @@ import { NavigationSection } from "../components/settings/NavigationSection.tsx"
 import { RainSection } from "../components/settings/RainSection.tsx";
 import { AdvancedSection } from "../components/settings/AdvancedSection.tsx";
 import { SettingsPreview } from "../components/settings/SettingsPreview.tsx";
+import { DisplayModeSection } from "../components/settings/DisplayModeSection.tsx";
 
 const { Text } = Typography;
 
@@ -111,6 +112,8 @@ export const SettingsPage = () => {
 
     const renderSection = () => {
         switch (activeSection) {
+            case "appearance":
+                return <DisplayModeSection />;
             case "hardware":
                 return (
                     <HardwareSection

--- a/gui/web/src/pages/map/hooks/mapRenderBudget.test.ts
+++ b/gui/web/src/pages/map/hooks/mapRenderBudget.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from "vitest";
+import {MAP_RENDER_BUDGETS} from "./mapRenderBudget.ts";
+
+describe("MAP_RENDER_BUDGETS", () => {
+    it("orders visual smoothness ahead of balanced and efficient rendering", () => {
+        expect(MAP_RENDER_BUDGETS.visual.poseIntervalMs)
+            .toBeLessThan(MAP_RENDER_BUDGETS.balanced.poseIntervalMs);
+        expect(MAP_RENDER_BUDGETS.balanced.poseIntervalMs)
+            .toBeLessThan(MAP_RENDER_BUDGETS.efficient.poseIntervalMs);
+        expect(MAP_RENDER_BUDGETS.visual.lidarIntervalMs)
+            .toBeLessThan(MAP_RENDER_BUDGETS.balanced.lidarIntervalMs);
+        expect(MAP_RENDER_BUDGETS.balanced.lidarIntervalMs)
+            .toBeLessThan(MAP_RENDER_BUDGETS.efficient.lidarIntervalMs);
+    });
+});

--- a/gui/web/src/pages/map/hooks/mapRenderBudget.ts
+++ b/gui/web/src/pages/map/hooks/mapRenderBudget.ts
@@ -1,0 +1,15 @@
+import type {DisplayMode} from "../../../theme/ThemeContext.tsx";
+
+export type MapRenderBudget = {
+    poseIntervalMs: number;
+    lidarIntervalMs: number;
+};
+
+// These are presentation budgets only: subscriptions and robot-side data stay
+// unchanged. Visual uses a smooth 20 Hz pose / 10 Hz lidar view; Balanced keeps
+// the established low-overhead cadence; Efficient is for constrained clients.
+export const MAP_RENDER_BUDGETS: Record<DisplayMode, MapRenderBudget> = {
+    visual: {poseIntervalMs: 50, lidarIntervalMs: 100},
+    balanced: {poseIntervalMs: 100, lidarIntervalMs: 200},
+    efficient: {poseIntervalMs: 200, lidarIntervalMs: 500},
+};

--- a/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
+++ b/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLatestThrottle } from "./useLatestThrottle.ts";
+
+describe("createLatestThrottle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits the leading value and the latest trailing value", () => {
+    const emit = vi.fn();
+    const throttle = createLatestThrottle<number>(emit, 100);
+
+    for (let value = 0; value < 100; value += 1) {
+      throttle.push(value);
+    }
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(0);
+
+    vi.advanceTimersByTime(100);
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(99);
+  });
+
+  it("caps a sustained 100 Hz stream at about 10 Hz", () => {
+    const emit = vi.fn();
+    const throttle = createLatestThrottle<number>(emit, 100);
+
+    for (let value = 0; value < 100; value += 1) {
+      throttle.push(value);
+      vi.advanceTimersByTime(10);
+    }
+
+    expect(emit.mock.calls.length).toBeGreaterThanOrEqual(10);
+    expect(emit.mock.calls.length).toBeLessThanOrEqual(11);
+    expect(emit).toHaveBeenLastCalledWith(99);
+  });
+
+  it("drops a pending trailing value when cancelled", () => {
+    const emit = vi.fn();
+    const throttle = createLatestThrottle<number>(emit, 100);
+
+    throttle.push(1);
+    throttle.push(2);
+    throttle.cancel();
+    vi.advanceTimersByTime(100);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(1);
+  });
+});

--- a/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
+++ b/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
@@ -41,6 +41,20 @@ describe("createLatestThrottle", () => {
     expect(emit).toHaveBeenLastCalledWith(99);
   });
 
+  it("caps a sustained 100 Hz stream at about 5 Hz", () => {
+    const emit = vi.fn();
+    const throttle = createLatestThrottle<number>(emit, 200);
+
+    for (let value = 0; value < 100; value += 1) {
+      throttle.push(value);
+      vi.advanceTimersByTime(10);
+    }
+
+    expect(emit.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(emit.mock.calls.length).toBeLessThanOrEqual(6);
+    expect(emit).toHaveBeenLastCalledWith(99);
+  });
+
   it("drops a pending trailing value when cancelled", () => {
     const emit = vi.fn();
     const throttle = createLatestThrottle<number>(emit, 100);

--- a/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
+++ b/gui/web/src/pages/map/hooks/useLatestThrottle.test.ts
@@ -55,6 +55,20 @@ describe("createLatestThrottle", () => {
     expect(emit).toHaveBeenLastCalledWith(99);
   });
 
+  it("uses the latest budget when the display mode changes", () => {
+    const emit = vi.fn();
+    let intervalMs = 100;
+    const throttle = createLatestThrottle<number>(emit, () => intervalMs);
+
+    throttle.push(1);
+    intervalMs = 50;
+    vi.advanceTimersByTime(50);
+    throttle.push(2);
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(2);
+  });
+
   it("drops a pending trailing value when cancelled", () => {
     const emit = vi.fn();
     const throttle = createLatestThrottle<number>(emit, 100);

--- a/gui/web/src/pages/map/hooks/useLatestThrottle.ts
+++ b/gui/web/src/pages/map/hooks/useLatestThrottle.ts
@@ -11,12 +11,13 @@ export interface LatestThrottle<T> {
  */
 export function createLatestThrottle<T>(
   callback: (value: T) => void,
-  intervalMs: number,
+  intervalMs: number | (() => number),
 ): LatestThrottle<T> {
   let lastEmitAt = Number.NEGATIVE_INFINITY;
   let latest: T | undefined;
   let hasLatest = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  const interval = () => typeof intervalMs === 'function' ? intervalMs() : intervalMs;
 
   const emit = () => {
     timer = null;
@@ -40,7 +41,7 @@ export function createLatestThrottle<T>(
     push: (value: T) => {
       latest = value;
       hasLatest = true;
-      const remainingMs = intervalMs - (Date.now() - lastEmitAt);
+      const remainingMs = interval() - (Date.now() - lastEmitAt);
       if (remainingMs <= 0) {
         if (timer !== null) clearTimeout(timer);
         emit();
@@ -59,12 +60,14 @@ export function useLatestThrottle<T>(
 ): LatestThrottle<T> {
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
+  const intervalRef = useRef(intervalMs);
+  intervalRef.current = intervalMs;
 
   const throttleRef = useRef<LatestThrottle<T> | null>(null);
   if (throttleRef.current === null) {
     throttleRef.current = createLatestThrottle<T>(
       (value) => callbackRef.current(value),
-      intervalMs,
+      () => intervalRef.current,
     );
   }
 
@@ -72,6 +75,12 @@ export function useLatestThrottle<T>(
     const throttle = throttleRef.current;
     return () => throttle?.cancel();
   }, []);
+
+  // A display-mode change should not leave an old trailing timer running at
+  // the previous rate. The next incoming render frame starts the new budget.
+  useEffect(() => {
+    throttleRef.current?.cancel();
+  }, [intervalMs]);
 
   return throttleRef.current;
 }

--- a/gui/web/src/pages/map/hooks/useLatestThrottle.ts
+++ b/gui/web/src/pages/map/hooks/useLatestThrottle.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react";
+
+export interface LatestThrottle<T> {
+  push: (value: T) => void;
+  cancel: () => void;
+}
+
+/**
+ * Emit immediately, then coalesce values that arrive inside the interval into
+ * one trailing update. The trailing update always receives the latest value.
+ */
+export function createLatestThrottle<T>(
+  callback: (value: T) => void,
+  intervalMs: number,
+): LatestThrottle<T> {
+  let lastEmitAt = Number.NEGATIVE_INFINITY;
+  let latest: T | undefined;
+  let hasLatest = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const emit = () => {
+    timer = null;
+    if (!hasLatest) return;
+    const value = latest as T;
+    latest = undefined;
+    hasLatest = false;
+    lastEmitAt = Date.now();
+    callback(value);
+  };
+
+  const cancel = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+    latest = undefined;
+    hasLatest = false;
+    lastEmitAt = Number.NEGATIVE_INFINITY;
+  };
+
+  return {
+    push: (value: T) => {
+      latest = value;
+      hasLatest = true;
+      const remainingMs = intervalMs - (Date.now() - lastEmitAt);
+      if (remainingMs <= 0) {
+        if (timer !== null) clearTimeout(timer);
+        emit();
+      } else if (timer === null) {
+        timer = setTimeout(emit, remainingMs);
+      }
+    },
+    cancel,
+  };
+}
+
+/** Keep the throttle stable across renders while invoking the latest callback. */
+export function useLatestThrottle<T>(
+  callback: (value: T) => void,
+  intervalMs: number,
+): LatestThrottle<T> {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const throttleRef = useRef<LatestThrottle<T> | null>(null);
+  if (throttleRef.current === null) {
+    throttleRef.current = createLatestThrottle<T>(
+      (value) => callbackRef.current(value),
+      intervalMs,
+    );
+  }
+
+  useEffect(() => {
+    const throttle = throttleRef.current;
+    return () => throttle?.cancel();
+  }, []);
+
+  return throttleRef.current;
+}

--- a/gui/web/src/pages/map/hooks/useMapStreams.ts
+++ b/gui/web/src/pages/map/hooks/useMapStreams.ts
@@ -22,6 +22,10 @@ import {
 import { drawLine, drawRobotSilhouette, transpose } from "../../../utils/map.tsx";
 import { rasterizeMowProgress } from "../../../utils/mowProgress.ts";
 import { useRobotDescription } from "../../../hooks/useRobotDescription.ts";
+import {useLatestThrottle} from "./useLatestThrottle.ts";
+
+const POSE_RENDER_INTERVAL_MS = 100;
+const LIDAR_RENDER_INTERVAL_MS = 200;
 
 export type MowProgressImage = {
     url: string;
@@ -68,6 +72,11 @@ interface UseMapStreamsOptions {
     robotPoseRef: React.RefObject<{ x: number; y: number; heading: number } | null>;
 }
 
+interface LidarRenderFrame {
+    scan: LaserScan;
+    pose: { x: number; y: number; heading: number };
+}
+
 export function useMapStreams({
     editMap,
     settings,
@@ -100,6 +109,41 @@ export function useMapStreams({
     // for the on-map robot shape, so it matches the sensors-page model.
     const robot = useRobotDescription();
 
+    const poseRender = useLatestThrottle<AbsolutePose>((pose) => {
+        const mower_lonlat = transpose(
+            offsetX,
+            offsetY,
+            datum,
+            pose.pose?.pose?.position?.y!!,
+            pose.pose?.pose?.position?.x!!
+        );
+        setFeatures((oldFeatures) => {
+            const orientation = pose.motion_heading!!;
+            const posX = pose.pose?.pose?.position?.x!!;
+            const posY = pose.pose?.pose?.position?.y!!;
+            const line = drawLine(offsetX, offsetY, datum, posY, posX, orientation);
+            // URDF-derived robot silhouette (chassis + drive wheels + blade)
+            // so the map robot matches the sensors-page model exactly.
+            const sil = drawRobotSilhouette(
+                offsetX, offsetY, datum, posY, posX, orientation, robot
+            );
+            return {
+                ...oldFeatures,
+                mower: new MowerFeatureBase(mower_lonlat),
+                ["mower-footprint"]: new RobotPartFeature("mower-footprint", sil.chassis, "#00a6ff"),
+                ["mower-wheel-l"]: new RobotPartFeature("mower-wheel-l", sil.wheelL, "#0b2e3f"),
+                ["mower-wheel-r"]: new RobotPartFeature("mower-wheel-r", sil.wheelR, "#0b2e3f"),
+                ["mower-blade"]: new RobotPartFeature("mower-blade", sil.blade, "#ff6b6b"),
+                ["mower-heading"]: new LineFeatureBase(
+                    "mower-heading",
+                    [mower_lonlat, line],
+                    "#ff0000",
+                    "heading"
+                ),
+            };
+        });
+    }, POSE_RENDER_INTERVAL_MS);
+
     const poseStream = useWS<string>(
         () => {
         },
@@ -107,43 +151,12 @@ export function useMapStreams({
         },
         (e) => {
             const pose = (e as any) as AbsolutePose;
-            const mower_lonlat = transpose(
-                offsetX,
-                offsetY,
-                datum,
-                pose.pose?.pose?.position?.y!!,
-                pose.pose?.pose?.position?.x!!
-            );
             robotPoseRef.current = {
                 x: pose.pose?.pose?.position?.x ?? 0,
                 y: pose.pose?.pose?.position?.y ?? 0,
                 heading: pose.motion_heading ?? 0,
             };
-            setFeatures((oldFeatures) => {
-                const orientation = pose.motion_heading!!;
-                const posX = pose.pose?.pose?.position?.x!!;
-                const posY = pose.pose?.pose?.position?.y!!;
-                const line = drawLine(offsetX, offsetY, datum, posY, posX, orientation);
-                // URDF-derived robot silhouette (chassis + drive wheels + blade)
-                // so the map robot matches the sensors-page model exactly.
-                const sil = drawRobotSilhouette(
-                    offsetX, offsetY, datum, posY, posX, orientation, robot
-                );
-                return {
-                    ...oldFeatures,
-                    mower: new MowerFeatureBase(mower_lonlat),
-                    ["mower-footprint"]: new RobotPartFeature("mower-footprint", sil.chassis, "#00a6ff"),
-                    ["mower-wheel-l"]: new RobotPartFeature("mower-wheel-l", sil.wheelL, "#0b2e3f"),
-                    ["mower-wheel-r"]: new RobotPartFeature("mower-wheel-r", sil.wheelR, "#0b2e3f"),
-                    ["mower-blade"]: new RobotPartFeature("mower-blade", sil.blade, "#ff6b6b"),
-                    ["mower-heading"]: new LineFeatureBase(
-                        "mower-heading",
-                        [mower_lonlat, line],
-                        "#ff0000",
-                        "heading"
-                    ),
-                };
-            });
+            poseRender.push(pose);
         }
     );
 
@@ -189,65 +202,69 @@ export function useMapStreams({
         () => {}
     );
 
+    const lidarRender = useLatestThrottle<LidarRenderFrame>(({scan, pose}) => {
+        if (!scan.ranges) return;
+
+        const rays: GeoJSON.Feature[] = [];
+        const angleMin = scan.angle_min ?? 0;
+        const angleInc = scan.angle_increment ?? 0;
+        const rangeMin = scan.range_min ?? 0;
+        const rangeMax = scan.range_max ?? 12;
+
+        // Scan rays live in the lidar_link frame, which is mounted on the
+        // chassis with a static base_footprint→lidar_link transform
+        // (lidar_x/y forward+lateral offset, lidar_yaw heading offset — see
+        // mowgli_robot.yaml). Compose that mount transform with the robot
+        // pose so points land at their true map position instead of being
+        // drawn as if the lidar sat at base_footprint with zero yaw.
+        const lidarX = parseFloat(settings["lidar_x"]) || 0;
+        const lidarY = parseFloat(settings["lidar_y"]) || 0;
+        const lidarYaw = parseFloat(settings["lidar_yaw"]) || 0;
+        const cosH = Math.cos(pose.heading);
+        const sinH = Math.sin(pose.heading);
+
+        // Downsample: take every Nth point for performance
+        const step = Math.max(1, Math.floor(scan.ranges.length / 90));
+        for (let i = 0; i < scan.ranges.length; i += step) {
+            const range = scan.ranges[i];
+            if (range < rangeMin || range > rangeMax) continue;
+
+            // Point in the lidar frame (lidar_yaw folded into the ray angle).
+            const angle = angleMin + i * angleInc + lidarYaw;
+            const px = range * Math.cos(angle);
+            const py = range * Math.sin(angle);
+            // lidar_link → base_footprint (rotate by lidar_yaw, translate by mount offset).
+            const bx = lidarX + px;
+            const by = lidarY + py;
+            // base_footprint → map (rotate by robot heading, translate by pose).
+            const endX = pose.x + bx * cosH - by * sinH;
+            const endY = pose.y + bx * sinH + by * cosH;
+            const endLonLat = transpose(offsetX, offsetY, datum, endY, endX);
+
+            rays.push({
+                type: "Feature",
+                properties: { intensity: range < rangeMax * 0.8 ? "hit" : "far" },
+                geometry: {
+                    type: "Point",
+                    coordinates: endLonLat,
+                },
+            });
+        }
+        setLidarCollection({
+            type: "FeatureCollection",
+            features: rays,
+        });
+    }, LIDAR_RENDER_INTERVAL_MS);
+
     const lidarStream = useWS<string>(
         () => {
         },
         () => {
         },
         (e) => {
-            const scan = (e as any) as LaserScan;
             const pose = robotPoseRef.current;
-            if (!pose || !scan.ranges) return;
-
-            const rays: GeoJSON.Feature[] = [];
-            const angleMin = scan.angle_min ?? 0;
-            const angleInc = scan.angle_increment ?? 0;
-            const rangeMin = scan.range_min ?? 0;
-            const rangeMax = scan.range_max ?? 12;
-
-            // Scan rays live in the lidar_link frame, which is mounted on the
-            // chassis with a static base_footprint→lidar_link transform
-            // (lidar_x/y forward+lateral offset, lidar_yaw heading offset — see
-            // mowgli_robot.yaml). Compose that mount transform with the robot
-            // pose so points land at their true map position instead of being
-            // drawn as if the lidar sat at base_footprint with zero yaw.
-            const lidarX = parseFloat(settings["lidar_x"]) || 0;
-            const lidarY = parseFloat(settings["lidar_y"]) || 0;
-            const lidarYaw = parseFloat(settings["lidar_yaw"]) || 0;
-            const cosH = Math.cos(pose.heading);
-            const sinH = Math.sin(pose.heading);
-
-            // Downsample: take every Nth point for performance
-            const step = Math.max(1, Math.floor(scan.ranges.length / 90));
-            for (let i = 0; i < scan.ranges.length; i += step) {
-                const range = scan.ranges[i];
-                if (range < rangeMin || range > rangeMax) continue;
-
-                // Point in the lidar frame (lidar_yaw folded into the ray angle).
-                const angle = angleMin + i * angleInc + lidarYaw;
-                const px = range * Math.cos(angle);
-                const py = range * Math.sin(angle);
-                // lidar_link → base_footprint (rotate by lidar_yaw, translate by mount offset).
-                const bx = lidarX + px;
-                const by = lidarY + py;
-                // base_footprint → map (rotate by robot heading, translate by pose).
-                const endX = pose.x + bx * cosH - by * sinH;
-                const endY = pose.y + bx * sinH + by * cosH;
-                const endLonLat = transpose(offsetX, offsetY, datum, endY, endX);
-
-                rays.push({
-                    type: "Feature",
-                    properties: { intensity: range < rangeMax * 0.8 ? "hit" : "far" },
-                    geometry: {
-                        type: "Point",
-                        coordinates: endLonLat,
-                    },
-                });
-            }
-            setLidarCollection({
-                type: "FeatureCollection",
-                features: rays,
-            });
+            if (!pose) return;
+            lidarRender.push({scan: (e as any) as LaserScan, pose});
         }
     );
 
@@ -367,6 +384,8 @@ export function useMapStreams({
             pathStream.stop();
             planStream.stop();
             lidarStream.stop();
+            poseRender.cancel();
+            lidarRender.cancel();
             obstaclesStream.stop();
             recordingTrajectoryStream.stop();
             highLevelStatus.stop();
@@ -465,6 +484,8 @@ export function useMapStreams({
             joyStream.stop();
             planStream.stop();
             lidarStream.stop();
+            poseRender.cancel();
+            lidarRender.cancel();
             obstaclesStream.stop();
             mowProgressStream.stop();
             if (mowProgressRafRef.current != null) {

--- a/gui/web/src/pages/map/hooks/useMapStreams.ts
+++ b/gui/web/src/pages/map/hooks/useMapStreams.ts
@@ -23,9 +23,8 @@ import { drawLine, drawRobotSilhouette, transpose } from "../../../utils/map.tsx
 import { rasterizeMowProgress } from "../../../utils/mowProgress.ts";
 import { useRobotDescription } from "../../../hooks/useRobotDescription.ts";
 import {useLatestThrottle} from "./useLatestThrottle.ts";
-
-const POSE_RENDER_INTERVAL_MS = 100;
-const LIDAR_RENDER_INTERVAL_MS = 200;
+import {useThemeMode} from "../../../theme/ThemeContext.tsx";
+import {MAP_RENDER_BUDGETS} from "./mapRenderBudget.ts";
 
 export type MowProgressImage = {
     url: string;
@@ -104,6 +103,8 @@ export function useMapStreams({
     const joyStopTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
     const highLevelStatus = useHighLevelStatus();
+    const {displayMode} = useThemeMode();
+    const renderBudget = MAP_RENDER_BUDGETS[displayMode];
 
     // Robot geometry from the /robot_description URDF — single source of truth
     // for the on-map robot shape, so it matches the sensors-page model.
@@ -142,7 +143,7 @@ export function useMapStreams({
                 ),
             };
         });
-    }, POSE_RENDER_INTERVAL_MS);
+    }, renderBudget.poseIntervalMs);
 
     const poseStream = useWS<string>(
         () => {
@@ -254,7 +255,7 @@ export function useMapStreams({
             type: "FeatureCollection",
             features: rays,
         });
-    }, LIDAR_RENDER_INTERVAL_MS);
+    }, renderBudget.lidarIntervalMs);
 
     const lidarStream = useWS<string>(
         () => {

--- a/gui/web/src/theme/ThemeContext.test.tsx
+++ b/gui/web/src/theme/ThemeContext.test.tsx
@@ -1,0 +1,48 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {ThemeProvider, useThemeMode} from './ThemeContext.tsx';
+
+function DisplayModeProbe() {
+    const {displayMode, setDisplayMode} = useThemeMode();
+
+    return (
+        <>
+            <output data-testid="display-mode">{displayMode}</output>
+            <button onClick={() => setDisplayMode('visual')}>Visual</button>
+        </>
+    );
+}
+
+describe('ThemeProvider display mode', () => {
+    beforeEach(() => {
+        const storage = new Map<string, string>();
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: (key: string) => storage.get(key) ?? null,
+                setItem: (key: string, value: string) => storage.set(key, value),
+                removeItem: (key: string) => storage.delete(key),
+                clear: () => storage.clear(),
+            },
+        });
+        document.documentElement.removeAttribute('data-display-mode');
+    });
+
+    it('uses Balanced by default and writes it to the document', async () => {
+        render(<ThemeProvider><DisplayModeProbe/></ThemeProvider>);
+
+        expect(screen.getByTestId('display-mode')).toHaveTextContent('balanced');
+        await waitFor(() => expect(document.documentElement.dataset.displayMode).toBe('balanced'));
+    });
+
+    it('restores and persists a selected display mode', async () => {
+        window.localStorage.setItem('mowgli.display-mode', 'efficient');
+        render(<ThemeProvider><DisplayModeProbe/></ThemeProvider>);
+
+        expect(screen.getByTestId('display-mode')).toHaveTextContent('efficient');
+        fireEvent.click(screen.getByRole('button', {name: 'Visual'}));
+
+        await waitFor(() => expect(document.documentElement.dataset.displayMode).toBe('visual'));
+        expect(window.localStorage.getItem('mowgli.display-mode')).toBe('visual');
+    });
+});

--- a/gui/web/src/theme/ThemeContext.tsx
+++ b/gui/web/src/theme/ThemeContext.tsx
@@ -1,17 +1,39 @@
-import {createContext, useCallback, useContext, useEffect} from "react";
+import {createContext, useCallback, useContext, useEffect, useState} from "react";
 import type {ThemeMode} from "./colors.ts";
 import {cssVars, getColors, setColors} from "./colors.ts";
+
+export const DISPLAY_MODES = ['visual', 'balanced', 'efficient'] as const;
+export type DisplayMode = typeof DISPLAY_MODES[number];
+
+const DISPLAY_MODE_STORAGE_KEY = 'mowgli.display-mode';
+
+function isDisplayMode(value: string | null): value is DisplayMode {
+    return value !== null && (DISPLAY_MODES as readonly string[]).includes(value);
+}
+
+function readDisplayMode(): DisplayMode {
+    try {
+        const stored = window.localStorage.getItem(DISPLAY_MODE_STORAGE_KEY);
+        return isDisplayMode(stored) ? stored : 'balanced';
+    } catch {
+        return 'balanced';
+    }
+}
 
 interface ThemeContextValue {
     mode: ThemeMode;
     toggleMode: () => void;
     colors: ReturnType<typeof getColors>;
+    displayMode: DisplayMode;
+    setDisplayMode: (mode: DisplayMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
     mode: 'light',
     toggleMode: () => {},
     colors: getColors('light'),
+    displayMode: 'balanced',
+    setDisplayMode: () => {},
 });
 
 // Mowgli is dark-mode-only. The light tokens stay in `colors.ts` for now in
@@ -20,6 +42,7 @@ const ThemeContext = createContext<ThemeContextValue>({
 export function ThemeProvider({children}: {children: React.ReactNode}) {
     const mode: ThemeMode = 'dark';
     const colors = getColors(mode);
+    const [displayMode, setDisplayMode] = useState<DisplayMode>(readDisplayMode);
 
     useEffect(() => {
         setColors(mode);
@@ -39,8 +62,18 @@ export function ThemeProvider({children}: {children: React.ReactNode}) {
 
     const toggleMode = useCallback(() => { /* dark-only */ }, []);
 
+    useEffect(() => {
+        document.documentElement.dataset.displayMode = displayMode;
+        try {
+            window.localStorage.setItem(DISPLAY_MODE_STORAGE_KEY, displayMode);
+        } catch {
+            // Private browsing or a locked-down WebView can reject storage.
+            // The selected mode still applies for this session.
+        }
+    }, [displayMode]);
+
     return (
-        <ThemeContext.Provider value={{mode, toggleMode, colors}}>
+        <ThemeContext.Provider value={{mode, toggleMode, colors, displayMode, setDisplayMode}}>
             {children}
         </ThemeContext.Provider>
     );

--- a/gui/web/tests/e2e/map-console.spec.ts
+++ b/gui/web/tests/e2e/map-console.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+import { installMockBackend } from "./mock/mockBackend.ts";
+
+test("map layers mount without source or fragment errors", async ({ page }) => {
+  const layerErrors: string[] = [];
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      message.type() === "error" &&
+      (text.includes('missing required property "source"') ||
+        text.includes("React.Fragment"))
+    ) {
+      layerErrors.push(text);
+    }
+  });
+
+  await installMockBackend(page, {
+    name: "map-layer-regression",
+    rest: {
+      "/api/settings/yaml": { datum_lat: 48.1, datum_lon: 11.5 },
+    },
+    topics: {
+      map: {
+        working_area: [
+          {
+            area: {
+              points: [
+                { x: -5, y: -5 },
+                { x: 5, y: -5 },
+                { x: 5, y: 5 },
+                { x: -5, y: 5 },
+              ],
+            },
+          },
+        ],
+      },
+      pose: {
+        pose: { pose: { position: { x: 1.2, y: -0.6, z: 0 } } },
+        motion_heading: 0.4,
+      },
+      obstacles: {
+        obstacles: [
+          {
+            id: 7,
+            status: 1,
+            polygon: {
+              points: [
+                { x: 1, y: 1 },
+                { x: 2, y: 1 },
+                { x: 2, y: 2 },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await page.goto("/#/map");
+  await expect(page.locator(".mapboxgl-canvas")).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(1_000);
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/map-layer-regression.png",
+    fullPage: true,
+  });
+
+  expect(layerErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- render tracked-obstacle layers as direct `Source` children so `react-map-gl` supplies the source correctly
- coalesce visual pose updates to the latest value at up to 10 Hz
- coalesce lidar projection and rendering to the latest frame at up to 5 Hz
- keep the raw robot pose reference current on every incoming pose frame
- retain the pose snapshot associated with each accepted lidar frame
- cancel pending visual updates when map streams stop or the page unmounts

## Performance

Deterministic synthetic stream measurements:

| Input | Existing behaviour | Updated behaviour | Difference |
| --- | ---: | ---: | ---: |
| 100-frame burst | 100 render callbacks | 2 render callbacks | -98% |
| 100 Hz pose stream | 100 render callbacks/s | 10–11 render callbacks/s | about -89% |
| 100 Hz lidar stream | 100 projection/render callbacks/s | 5–6 callbacks/s | about -94% |

The map regression previously produced repeated errors for four tracked-obstacle layers plus a React fragment warning. The same mocked map now renders with zero source/fragment errors.

## Testing

- [x] throttle unit tests: 4 passed
- [x] complete Playwright matrix: 65 passed
- [x] map rendered with datum, pose, work area, and tracked obstacle; screenshot inspected
- [x] TypeScript typecheck
- [x] Vite production build
- [x] Docker `build-web` target
- [x] Prettier check for new files
- [x] `git diff --check` and secret scan

## Related test maintenance

The two outdated manual-mode expectations observed in the original Vitest run are corrected in #440.

Related to #430
