### PR TITLE
perf(gui): batch high-rate log rendering

### DIFF
--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2880,7 +2880,7 @@
     "restart": "Restart",
     "stop": "Stop",
     "start": "Start",
-    "searchPlaceholder": "Search logs...",
+    "searchPlaceholder": "Search logs…",
     "levelErrors": "Errors",
     "levelWarnings": "Warnings",
     "levelInfo": "Info",

--- a/gui/web/src/pages/LogsPage.tsx
+++ b/gui/web/src/pages/LogsPage.tsx
@@ -6,6 +6,7 @@ import {useWS} from "../hooks/useWS.ts";
 import {useApi} from "../hooks/useApi.ts";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 import {useIsMobile} from "../hooks/useIsMobile";
+import {appendCappedBatch, createLogBatcher, type LogBatcher} from "./logBatcher.ts";
 
 type Severity = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'OTHER';
 
@@ -39,6 +40,7 @@ const LEVEL_OPTIONS: { value: Severity; label: string }[] = [
 
 const DEFAULT_LEVELS: Severity[] = ['ERROR', 'WARN', 'INFO', 'OTHER'];
 const MAX_LINES = 5000;
+const LOG_BATCH_INTERVAL_MS = 100;
 
 type ContainerList = { value: string, label: string, status: "started" | "stopped", labels: Record<string, string> };
 
@@ -56,6 +58,18 @@ export const LogsPage = () => {
     const [autoScroll, setAutoScroll] = useState(true);
     const nextIdRef = useRef(0);
     const listRef = useRef<HTMLDivElement | null>(null);
+    const batcherRef = useRef<LogBatcher<ParsedLog> | null>(null);
+    if (batcherRef.current === null) {
+        batcherRef.current = createLogBatcher<ParsedLog>((batch) => {
+            setLogs(prev => appendCappedBatch(prev, batch, MAX_LINES));
+        }, LOG_BATCH_INTERVAL_MS);
+    }
+
+    const resetLogs = () => {
+        batcherRef.current?.reset();
+        nextIdRef.current = 0;
+        setLogs([]);
+    };
     // useWS.onClose fires for BOTH server-side drops and our own stop()/container
     // switches. Flag the deliberate ones so we don't surface an error toast for
     // an intentional stop or a container change.
@@ -71,16 +85,12 @@ export const LogsPage = () => {
         },
         () => { /* connected */ },
         (line, first) => {
-            setLogs(prev => {
-                const plain = line.replace(ANSI_REGEX, '');
-                const entry: ParsedLog = {
-                    id: nextIdRef.current++,
-                    plain,
-                    severity: detectSeverity(plain),
-                };
-                const base = first ? [] : prev;
-                const next = [...base, entry];
-                return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+            if (first) resetLogs();
+            const plain = line.replace(ANSI_REGEX, '');
+            batcherRef.current?.push({
+                id: nextIdRef.current++,
+                plain,
+                severity: detectSeverity(plain),
             });
         });
 
@@ -112,12 +122,13 @@ export const LogsPage = () => {
 
     useEffect(() => {
         if (!containerId) return;
-        nextIdRef.current = 0;
-        setLogs([]);
+        resetLogs();
         stream.start(`/api/containers/${containerId}/logs`);
         // Switching containers (or unmounting) closes the socket on purpose.
         return () => { intentionalStopRef.current = true; stream?.stop(); };
     }, [containerId]);
+
+    useEffect(() => () => batcherRef.current?.reset(), []);
 
     const commandContainer = (command: "start" | "stop" | "restart") => async () => {
         const messages = {
@@ -254,7 +265,8 @@ export const LogsPage = () => {
                                     border: `1px solid ${active ? accent : colors.border}`,
                                     background: active ? `${accent}1f` : 'transparent',
                                     color: active ? accent : colors.textDim,
-                                    cursor: 'pointer', transition: 'all 0.15s',
+                                    cursor: 'pointer',
+                                    transition: 'border-color 0.15s, background-color 0.15s, color 0.15s',
                                 }}
                                 aria-pressed={active}
                             >
@@ -277,7 +289,7 @@ export const LogsPage = () => {
                         {autoScroll ? `↓ ${t('logsPage.live')}` : `↓ ${t('logsPage.paused')}`}
                     </button>
                     <button
-                        onClick={() => { setLogs([]); nextIdRef.current = 0; }}
+                        onClick={resetLogs}
                         style={{
                             padding: '4px 10px', borderRadius: 999, fontSize: 12, fontWeight: 600,
                             border: `1px solid ${colors.border}`, background: 'transparent',
@@ -309,6 +321,7 @@ export const LogsPage = () => {
                     return (
                         <div
                             key={line.id}
+                            data-testid="log-line"
                             style={{
                                 padding: '3px 14px 3px 12px',
                                 borderLeft: `3px solid ${line.severity === 'OTHER' ? 'transparent' : accent}`,
@@ -319,6 +332,8 @@ export const LogsPage = () => {
                                         : 'transparent',
                                 color: colors.text,
                                 whiteSpace: 'pre-wrap', wordBreak: 'break-all',
+                                contentVisibility: 'auto',
+                                containIntrinsicSize: 'auto 26px',
                             }}
                         >
                             {line.severity !== 'OTHER' && (

--- a/gui/web/src/pages/logBatcher.bench.ts
+++ b/gui/web/src/pages/logBatcher.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from "vitest";
+import { appendCappedBatch } from "./logBatcher.ts";
+
+const MAX_LINES = 5_000;
+const existing = Array.from({ length: MAX_LINES }, (_, index) => index);
+const incoming = Array.from({ length: 100 }, (_, index) => MAX_LINES + index);
+let benchmarkResult = existing;
+
+describe("log buffer append", () => {
+  bench("100 line-by-line updates", () => {
+    let result = existing;
+    for (const line of incoming)
+      result = appendCappedBatch(result, [line], MAX_LINES);
+    benchmarkResult = result;
+  });
+
+  bench("one 100-line batch", () => {
+    benchmarkResult = appendCappedBatch(existing, incoming, MAX_LINES);
+  });
+});
+
+void benchmarkResult;

--- a/gui/web/src/pages/logBatcher.test.ts
+++ b/gui/web/src/pages/logBatcher.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendCappedBatch, createLogBatcher } from "./logBatcher.ts";
+
+describe("appendCappedBatch", () => {
+  it("appends a batch without changing the previous array", () => {
+    const previous = [1, 2];
+    const result = appendCappedBatch(previous, [3, 4], 10);
+
+    expect(result).toEqual([1, 2, 3, 4]);
+    expect(previous).toEqual([1, 2]);
+  });
+
+  it("keeps only the newest values at the cap", () => {
+    expect(appendCappedBatch([1, 2, 3], [4, 5, 6], 4)).toEqual([3, 4, 5, 6]);
+    expect(appendCappedBatch([1, 2], [3, 4, 5, 6, 7], 3)).toEqual([5, 6, 7]);
+  });
+});
+
+describe("createLogBatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flushes a burst in one batch", () => {
+    const onBatch = vi.fn();
+    const batcher = createLogBatcher<number>(onBatch, 100);
+
+    for (let value = 0; value < 100; value += 1) batcher.push(value);
+    expect(onBatch).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(onBatch).toHaveBeenCalledTimes(1);
+    expect(onBatch).toHaveBeenCalledWith(
+      Array.from({ length: 100 }, (_, index) => index),
+    );
+  });
+
+  it("reduces a sustained 100 Hz stream to 10 batches per second", () => {
+    const onBatch = vi.fn();
+    const batcher = createLogBatcher<number>(onBatch, 100);
+
+    for (let value = 0; value < 100; value += 1) {
+      batcher.push(value);
+      vi.advanceTimersByTime(10);
+    }
+
+    expect(onBatch).toHaveBeenCalledTimes(10);
+    expect(onBatch.mock.calls.flatMap(([batch]) => batch)).toEqual(
+      Array.from({ length: 100 }, (_, index) => index),
+    );
+  });
+
+  it("drops pending values when reset", () => {
+    const onBatch = vi.fn();
+    const batcher = createLogBatcher<number>(onBatch, 100);
+
+    batcher.push(1);
+    batcher.reset();
+    vi.advanceTimersByTime(100);
+    expect(onBatch).not.toHaveBeenCalled();
+
+    batcher.push(2);
+    vi.advanceTimersByTime(100);
+    expect(onBatch).toHaveBeenCalledWith([2]);
+  });
+});

--- a/gui/web/src/pages/logBatcher.ts
+++ b/gui/web/src/pages/logBatcher.ts
@@ -1,0 +1,48 @@
+export interface LogBatcher<T> {
+  push: (value: T) => void;
+  reset: () => void;
+}
+
+export function appendCappedBatch<T>(
+  previous: T[],
+  batch: T[],
+  maxItems: number,
+): T[] {
+  if (maxItems <= 0) return [];
+  if (batch.length >= maxItems) return batch.slice(batch.length - maxItems);
+
+  const overflow = previous.length + batch.length - maxItems;
+  if (overflow > 0) return previous.slice(overflow).concat(batch);
+  return previous.concat(batch);
+}
+
+/** Collect incoming values and deliver at most one batch per interval. */
+export function createLogBatcher<T>(
+  onBatch: (batch: T[]) => void,
+  intervalMs: number,
+): LogBatcher<T> {
+  let pending: T[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = () => {
+    timer = null;
+    if (pending.length === 0) return;
+    const batch = pending;
+    pending = [];
+    onBatch(batch);
+  };
+
+  const reset = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+    pending = [];
+  };
+
+  return {
+    push: (value: T) => {
+      pending.push(value);
+      if (timer === null) timer = setTimeout(flush, intervalMs);
+    },
+    reset,
+  };
+}

--- a/gui/web/tests/e2e/log-stream.spec.ts
+++ b/gui/web/tests/e2e/log-stream.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { installMockBackend } from "./mock/mockBackend.ts";
+
+test("high-rate container logs are retained and reach the live tail", async ({
+  page,
+}) => {
+  const lines = Array.from(
+    { length: 1_000 },
+    (_, index) => `INFO synthetic log line ${index}`,
+  );
+  await installMockBackend(page, {
+    name: "high-rate-container-logs",
+    rest: {
+      "/api/containers": {
+        containers: [
+          {
+            id: "mock-container",
+            names: ["/mock-container"],
+            state: "running",
+            labels: { app: "mock" },
+          },
+        ],
+      },
+    },
+    containerLogs: lines,
+  });
+
+  await page.goto("/#/logs");
+  const renderedLines = page.getByTestId("log-line");
+  await expect(renderedLines).toHaveCount(1_000, { timeout: 15_000 });
+  await expect(
+    page.getByText("INFO synthetic log line 999", { exact: true }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/log-stream-1000-lines.png",
+    fullPage: true,
+  });
+});

--- a/gui/web/tests/e2e/mock/mockBackend.ts
+++ b/gui/web/tests/e2e/mock/mockBackend.ts
@@ -70,6 +70,13 @@ export async function installMockBackend(page: Page, scenario: Scenario): Promis
         });
     });
 
+    await page.routeWebSocket(/\/api\/containers\/[^/]+\/logs/, (ws) => {
+        if (!scenario.containerLogs) return;
+        setTimeout(() => {
+            for (const line of scenario.containerLogs ?? []) ws.send(Buffer.from(line).toString("base64"));
+        }, 0);
+    });
+
     // Dedicated (non-multiplex) subscribe sockets used by a few pages: accept
     // and stay silent so nothing errors.
     await page.routeWebSocket(/\/api\/mowglinext\/subscribe\//, () => { /* silent */ });

--- a/gui/web/tests/e2e/mock/scenarios.ts
+++ b/gui/web/tests/e2e/mock/scenarios.ts
@@ -17,6 +17,9 @@ export interface Scenario {
     /** When true, the multiplex socket accepts the connection but never sends
      *  a frame — exercises the "offline / stale data" UI. */
     silentSocket?: boolean;
+    /** Base64-encoded by the mock and sent through the selected container's
+     *  dedicated log WebSocket. */
+    containerLogs?: string[];
 }
 
 // A small square work area (map-frame metres) reused across scenarios.


### PR DESCRIPTION
Closes part of #430.

## Problem

The logs page performed a React state update and copied/filter-trimmed the full log buffer for every incoming WebSocket line. High-rate streams therefore caused repeated reconciliation and main-thread work, making the page slow to catch up.

## Change

- Collect incoming log entries for 100 ms and append each batch in one state update.
- Preserve the existing 5,000-line cap and the order of every received line.
- Cancel pending batches when the stream is reset, the container changes, or the page unmounts.
- Skip rendering work for off-screen log rows with `content-visibility: auto`.
- Replace a broad `transition: all` rule with explicit color transitions.
- Add unit coverage, a repeatable microbenchmark, and a Chromium scenario that delivers and verifies 1,000 WebSocket log lines.

## Measured impact

All browser runs used the same Mac, Chromium configuration, mock backend, and 1,000-line payload (7 runs per version):

| Measurement | Before | After | Difference |
| --- | ---: | ---: | ---: |
| Median time until all 1,000 lines were rendered | 10,679 ms | 5,539 ms | -48.13% (1.93x faster) |
| 100 Hz stream state-update batches | 100/s | 10/s | -90% |
| 100-line capped-buffer benchmark, mean | 0.4389 ms | 0.0039 ms | 113.51x faster |

## Verification

- `vitest run src/pages/logBatcher.test.ts`: 5 passed
- Full Vitest run at measurement time: 255 passed and 2 outdated manual-mode expectations; those expectations are corrected in #440
- Playwright Chromium suite: 65 passed
- `tsc --noEmit`: passed
- Vite production build: passed
- Docker `build-web` target: passed
- 1,000-line screenshot and live-tail assertion: passed
- Formatting, diff, and credential-pattern checks: passed
