### PR TITLE
fix(fusion_graph): honor GNSS measurement timestamps

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -212,6 +212,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_keyframe_map fusion_graph_core)
 
+  ament_add_gtest(test_gnss_timestamp
+    test/test_gnss_timestamp.cpp
+  )
+  target_link_libraries(test_gnss_timestamp fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_manager.hpp
@@ -105,8 +105,15 @@ public:
   // at next tick. sigma is per-axis; pass < 0 to use floor. When
   // `robust` is true, the noise model is wrapped in a Huber kernel —
   // appropriate for RTK-Float / single-fix samples where multipath
-  // outliers can lie outside the reported covariance.
-  void QueueGnss(double x, double y, double sigma_xy, bool robust = false);
+  // outliers can lie outside the reported covariance. When `target_node`
+  // is set, the factor is attached to that existing pose instead of the
+  // node created by the next Tick(). Returns false if the requested node
+  // is no longer present in the live graph.
+  bool QueueGnss(double x,
+                 double y,
+                 double sigma_xy,
+                 bool robust = false,
+                 std::optional<uint64_t> target_node = std::nullopt);
 
   // Yaw observation (COG or mag). sigma_yaw is rad. `robust` should be
   // true for magnetometer yaw (uncalibrated / heading-dependent bias),
@@ -158,6 +165,13 @@ public:
   // Read-only accessors (snapshot of current state).
   std::optional<TickOutput> LatestSnapshot() const;
   GraphStats Stats() const;
+
+  // Newest live pose node whose graph timestamp is at or before
+  // `timestamp_s`. Sensor callbacks use this to associate delayed stamped
+  // observations with the state they measured instead of the state at
+  // callback-delivery time. Returns nullopt before the oldest indexed live
+  // node, for non-finite timestamps, or while uninitialized.
+  std::optional<uint64_t> FindNodeAtOrBefore(double timestamp_s) const;
 
   // Count of pose ('x') variables currently live in the iSAM2 graph.
   // Distinct from GraphStats::total_nodes, which is the monotonic
@@ -388,6 +402,7 @@ private:
       gtsam::Vector2 xy;
       double sigma;
       bool robust;
+      std::optional<uint64_t> target_node;
     };
     struct Yaw
     {
@@ -446,6 +461,10 @@ private:
 
   uint64_t next_index_ = 0;  // index of the next node to create
   double last_node_time_s_ = 0.0;  // wall time of last created node
+  // Creation times for recent live pose nodes, in chronological order.
+  // The deque is capped alongside the graph window; FindNodeAtOrBefore also
+  // skips entries already removed by an asynchronous rebase.
+  std::deque<std::pair<double, uint64_t>> node_time_index_;
 
   Accumulator accum_;
   UnaryQueue queue_;

--- a/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
@@ -328,7 +328,45 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
     TrySeedInitialPose();
     return;
   }
-  graph_->QueueGnss(mx, my, sigma, /*robust=*/true);
+  // GNSS bridges preserve the receiver measurement epoch in header.stamp,
+  // which may precede callback delivery by hundreds of milliseconds or more.
+  // Resolve that epoch only after the quality/docking gates above so the
+  // factor constrains the state that was actually observed instead of the
+  // state at callback-delivery time.
+  const rclcpp::Time measurement_stamp(msg->header.stamp, get_clock()->get_clock_type());
+  std::optional<uint64_t> measurement_node;
+  if (graph_->IsInitialized() && measurement_stamp.nanoseconds() != 0)
+  {
+    constexpr double kFutureStampToleranceS = 0.5;
+    const double future_offset_s = (measurement_stamp - this->now()).seconds();
+    if (future_offset_s > kFutureStampToleranceS)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "fusion_graph: GNSS stamp is %.3f s in the future; sample dropped",
+                           future_offset_s);
+      return;
+    }
+    measurement_node = graph_->FindNodeAtOrBefore(measurement_stamp.seconds());
+    if (!measurement_node)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "fusion_graph: no live graph node at/before GNSS epoch; sample dropped");
+      return;
+    }
+  }
+
+  if (!graph_->QueueGnss(mx, my, sigma, /*robust=*/true, measurement_node))
+  {
+    RCLCPP_WARN_THROTTLE(get_logger(),
+                         *get_clock(),
+                         5000,
+                         "fusion_graph: GNSS epoch node left the live graph; sample dropped");
+    return;
+  }
   seed_xy_ = gtsam::Vector2(mx, my);
   // Latch whether the most recent seed came from RTK-Fixed so the next
   // graph initialization can use a tight prior matching that quality.

--- a/ros2/src/fusion_graph/src/graph_manager.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager.cpp
@@ -158,12 +158,16 @@ void GraphManager::AddGyroDelta(double wz, double dt)
   }
 }
 
-void GraphManager::QueueGnss(double x, double y, double sigma_xy, bool robust)
+bool GraphManager::QueueGnss(
+    double x, double y, double sigma_xy, bool robust, std::optional<uint64_t> target_node)
 {
   std::lock_guard<std::mutex> lock(mu_);
+  if (target_node && !HasPoseAt(*target_node))
+    return false;
   if (sigma_xy < params_.gps_sigma_floor)
     sigma_xy = params_.gps_sigma_floor;
-  queue_.gnss = UnaryQueue::Gnss{gtsam::Vector2(x, y), sigma_xy, robust};
+  queue_.gnss = UnaryQueue::Gnss{gtsam::Vector2(x, y), sigma_xy, robust, target_node};
+  return true;
 }
 
 void GraphManager::QueueYaw(double yaw, double sigma_yaw, bool robust)
@@ -236,6 +240,8 @@ void GraphManager::Initialize(const gtsam::Pose2& X0,
 
   next_index_ = 1;
   last_node_time_s_ = timestamp;
+  node_time_index_.clear();
+  node_time_index_.emplace_back(timestamp, 0);
   initialized_ = true;
 
   TickOutput out;
@@ -245,6 +251,20 @@ void GraphManager::Initialize(const gtsam::Pose2& X0,
   out.node_index = 0;
   out.timestamp = timestamp;
   latest_ = out;
+}
+
+std::optional<uint64_t> GraphManager::FindNodeAtOrBefore(double timestamp_s) const
+{
+  std::lock_guard<std::mutex> lock(mu_);
+  if (!initialized_ || !std::isfinite(timestamp_s))
+    return std::nullopt;
+
+  for (auto it = node_time_index_.rbegin(); it != node_time_index_.rend(); ++it)
+  {
+    if (it->first <= timestamp_s && HasPoseAt(it->second))
+      return it->second;
+  }
+  return std::nullopt;
 }
 
 std::optional<TickOutput> GraphManager::LatestSnapshot() const

--- a/ros2/src/fusion_graph/src/graph_manager_node.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager_node.cpp
@@ -40,9 +40,17 @@ std::optional<TickOutput> GraphManager::Tick(double now_s)
   // but Tick() is driven by the node clock — under use_sim_time those differ
   // by ~1.79e9 s, so the gate below would never fire and node creation would
   // freeze for the whole sim. Snapping down to now_s resumes the cadence and
-  // is clock-source-agnostic (no-op on real hardware where they agree).
+  // is clock-source-agnostic (no-op on real hardware where they agree). The
+  // timestamp index belongs to the old clock epoch, so rebuild it from the
+  // latest live node rather than allowing new sensor stamps to match stale
+  // entries after a bag loop / simulation reset.
   if (last_node_time_s_ > now_s)
+  {
     last_node_time_s_ = now_s;
+    node_time_index_.clear();
+    if (latest_ && HasPoseAt(latest_->node_index))
+      node_time_index_.emplace_back(now_s, latest_->node_index);
+  }
   if (now_s - last_node_time_s_ < params_.node_period_s)
     return std::nullopt;
 
@@ -335,8 +343,17 @@ std::optional<TickOutput> GraphManager::CreateNodeLocked(double now_s)
                                                     params_.huber_k_gps),
                                                 noise);
     }
-    new_factors_.add(GnssLeverArmFactor(
-        k_curr, queue_.gnss->xy, gtsam::Vector2(params_.lever_arm_x, params_.lever_arm_y), noise));
+    const auto factor_key = queue_.gnss->target_node ? PoseKey(*queue_.gnss->target_node) : k_curr;
+    // A windowed asynchronous rebase may remove a historical target after
+    // QueueGnss validated it. Drop that stale observation rather than silently
+    // applying it to the current state at the wrong epoch.
+    if (!queue_.gnss->target_node || HasPoseAt(*queue_.gnss->target_node))
+    {
+      new_factors_.add(GnssLeverArmFactor(factor_key,
+                                          queue_.gnss->xy,
+                                          gtsam::Vector2(params_.lever_arm_x, params_.lever_arm_y),
+                                          noise));
+    }
   }
   if (queue_.yaw)
   {
@@ -458,6 +475,11 @@ std::optional<TickOutput> GraphManager::CreateNodeLocked(double now_s)
   // 6. Reset for next tick.
   ++next_index_;
   last_node_time_s_ = now_s;
+  node_time_index_.emplace_back(now_s, out.node_index);
+  const size_t time_index_cap =
+      params_.max_graph_nodes > 0 ? static_cast<size_t>(params_.max_graph_nodes) : 10000U;
+  while (node_time_index_.size() > std::max<size_t>(1U, time_index_cap))
+    node_time_index_.pop_front();
   accum_.Reset();
   queue_.gnss.reset();
   queue_.yaw.reset();

--- a/ros2/src/fusion_graph/src/graph_manager_persistence.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager_persistence.cpp
@@ -106,6 +106,7 @@ void GraphManager::ResetLocked()
 
   next_index_ = 0;
   last_node_time_s_ = 0.0;
+  node_time_index_.clear();
   initialized_ = false;
 
   accum_.Reset();
@@ -425,6 +426,11 @@ bool GraphManager::Load(const std::string& prefix)
     out.node_index = next_index_ - 1;
     out.timestamp = last_node_time_s_;
     latest_ = out;
+    // Persisted files store the latest timestamp but not a complete per-node
+    // timeline. Index only the pose whose epoch is known; subsequent live
+    // ticks extend the history without guessing timestamps for older poses.
+    node_time_index_.clear();
+    node_time_index_.emplace_back(last_node_time_s_, out.node_index);
   }
 
   return true;

--- a/ros2/src/fusion_graph/test/test_gnss_timestamp.cpp
+++ b/ros2/src/fusion_graph/test/test_gnss_timestamp.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Regression tests for delayed GNSS measurement association. A receiver or
+// bridge may deliver a fix after the robot has advanced through several graph
+// nodes; the factor must constrain the pose at header.stamp, not callback time.
+
+#include <cmath>
+#include <limits>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+
+fg::GraphParams MakeParams()
+{
+  fg::GraphParams gp;
+  gp.node_period_s = 0.1;
+  gp.stationary_node_period_s = 0.0;
+  gp.stationary_motion_thresh_m = 0.0;
+  gp.stationary_motion_thresh_theta = 0.0;
+  gp.wheel_sigma_x = 0.01;
+  gp.wheel_sigma_y = 0.01;
+  gp.wheel_sigma_theta = 0.01;
+  gp.gyro_sigma_theta = 0.01;
+  gp.adaptive_noise_enabled_gain = 0.0;
+  gp.prior_sigma_xy = 0.001;
+  gp.prior_sigma_theta = 0.001;
+  gp.lever_arm_x = 0.0;
+  gp.lever_arm_y = 0.0;
+  return gp;
+}
+
+void DriveOneMetre(fg::GraphManager& gm, double timestamp_s)
+{
+  gm.AddWheelTwist(1.0, 0.0, 0.0, 1.0);
+  gm.AddGyroDelta(0.0, 1.0);
+  ASSERT_TRUE(gm.Tick(timestamp_s).has_value());
+}
+
+}  // namespace
+
+TEST(GnssTimestamp, FindsNewestLiveNodeAtOrBeforeEpoch)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 10.0);
+  DriveOneMetre(gm, 11.0);
+  DriveOneMetre(gm, 12.0);
+
+  EXPECT_EQ(gm.FindNodeAtOrBefore(10.0), std::optional<uint64_t>(0));
+  EXPECT_EQ(gm.FindNodeAtOrBefore(11.0), std::optional<uint64_t>(1));
+  EXPECT_EQ(gm.FindNodeAtOrBefore(11.5), std::optional<uint64_t>(1));
+  EXPECT_EQ(gm.FindNodeAtOrBefore(12.0), std::optional<uint64_t>(2));
+  EXPECT_EQ(gm.FindNodeAtOrBefore(20.0), std::optional<uint64_t>(2));
+  EXPECT_FALSE(gm.FindNodeAtOrBefore(9.99).has_value());
+  EXPECT_FALSE(gm.FindNodeAtOrBefore(std::numeric_limits<double>::quiet_NaN()).has_value());
+}
+
+TEST(GnssTimestamp, DelayedFixConstrainsMeasurementEpoch)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+  DriveOneMetre(gm, 1.0);
+  DriveOneMetre(gm, 2.0);
+
+  const auto measurement_node = gm.FindNodeAtOrBefore(1.0);
+  ASSERT_EQ(measurement_node, std::optional<uint64_t>(1));
+  ASSERT_TRUE(gm.QueueGnss(1.0, 0.0, 0.001, /*robust=*/false, measurement_node));
+
+  DriveOneMetre(gm, 3.0);
+  const auto historical = gm.GetPose(1);
+  const auto current = gm.GetPose(3);
+  ASSERT_TRUE(historical.has_value());
+  ASSERT_TRUE(current.has_value());
+
+  EXPECT_NEAR(historical->x(), 1.0, 0.03);
+  EXPECT_NEAR(current->x(), 3.0, 0.08);
+  EXPECT_NEAR(current->y(), 0.0, 0.03);
+}
+
+TEST(GnssTimestamp, RejectsTargetThatIsNotInLiveGraph)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  EXPECT_FALSE(gm.QueueGnss(0.0,
+                            0.0,
+                            0.01,
+                            /*robust=*/false,
+                            std::optional<uint64_t>(999)));
+}
+
+TEST(GnssTimestamp, UnstampedFixRetainsNextNodeFallback)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+  DriveOneMetre(gm, 1.0);
+  DriveOneMetre(gm, 2.0);
+
+  // A zero/unset ROS header stamp cannot be associated historically. Keep the
+  // legacy next-node behavior so unstamped sensor sources remain compatible.
+  ASSERT_TRUE(gm.QueueGnss(1.0, 0.0, 0.001));
+  DriveOneMetre(gm, 3.0);
+
+  const auto current = gm.GetPose(3);
+  ASSERT_TRUE(current.has_value());
+  EXPECT_LT(current->x(), 1.2);
+}
+
+TEST(GnssTimestamp, HistoryIsBoundedByGraphWindow)
+{
+  auto params = MakeParams();
+  params.max_graph_nodes = 2;
+  fg::GraphManager gm(params);
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+  DriveOneMetre(gm, 1.0);
+  DriveOneMetre(gm, 2.0);
+
+  EXPECT_FALSE(gm.FindNodeAtOrBefore(0.5).has_value());
+  EXPECT_EQ(gm.FindNodeAtOrBefore(1.0), std::optional<uint64_t>(1));
+  EXPECT_EQ(gm.FindNodeAtOrBefore(2.0), std::optional<uint64_t>(2));
+}
+
+TEST(GnssTimestamp, ResetAndClockRewindDiscardStaleEpochs)
+{
+  fg::GraphManager gm(MakeParams());
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 100.0);
+  DriveOneMetre(gm, 101.0);
+
+  // Simulated-time rewind: Tick self-heals the cadence and rebuilds the time
+  // index from the latest live pose in the new clock epoch.
+  EXPECT_FALSE(gm.Tick(5.0).has_value());
+  EXPECT_FALSE(gm.FindNodeAtOrBefore(4.99).has_value());
+  EXPECT_EQ(gm.FindNodeAtOrBefore(5.0), std::optional<uint64_t>(1));
+
+  gm.Reset();
+  EXPECT_FALSE(gm.FindNodeAtOrBefore(5.0).has_value());
+}


### PR DESCRIPTION
## Summary

- associate stamped GNSS measurements with the newest live graph node at or before the receiver epoch
- keep the legacy next-node fallback for sources that publish a zero/unset stamp
- reject too-old, future-skewed, or concurrently pruned targets instead of silently constraining an unrelated current pose
- keep the timestamp index bounded by the existing graph window and rebuild it safely across initialize, load, reset, and simulated-time rewind
- add focused regression coverage for lookup semantics and the resulting optimized trajectory

## Why

`OnGnss()` previously discarded `NavSatFix.header.stamp`. `QueueGnss()` consequently carried no measurement time, and `CreateNodeLocked()` always attached the factor to `k_curr` at the next timer tick.

For a delayed receiver/bridge, especially while the mower is moving or turning, this makes an antenna position measured at `t_measurement` constrain a later pose at `t_delivery`. Normal motion during the delay then appears to the optimizer as a position innovation.

The graph already has timestamped pose nodes, so this change retains a small ordered index and targets the correct existing key. The GNSS correction then propagates forward through the normal between-factors to the current pose.

Closes #436.

## Safety and compatibility

- no GNSS quality, covariance, wrong-fix, docking, yaw, scan-matching, or noise-model gates are changed
- zero/unset sensor timestamps preserve the previous behavior
- an unavailable historical key is dropped with a throttled warning; it never falls back to the wrong epoch
- persisted graphs only index the latest pose whose timestamp is actually known, rather than inventing historical epochs

## Validation

- `clang-format -n -Werror -style=file:ros2/.clang-format` on every touched C++ source/header: pass
- non-root ROS2 Kilted container build of `fusion_graph`: pass
- full CTest manifest: **19/19 passed**
  - all existing fusion graph unit tests
  - new `test_gnss_timestamp` binary with six regression cases
  - performance test
  - cppcheck, CMake lint, and XML lint
- `git diff --check`: pass
- staged diff secret scan: no findings

The new tests cover exact and between-node lookup, delayed-factor propagation, invalid/pruned targets, unstamped compatibility, graph-window bounding, reset, and simulated-time rewind.
