### PR TITLE
feat(gnss): add Waveshare LC29H(DA) 1 Hz preset

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -270,6 +270,13 @@
           "default": "auto",
           "description": "Universal GNSS receiver family. Auto is recommended unless you know you need a specific parser."
         },
+        "gnss_hardware_preset": {
+          "type": "string",
+          "enum": ["", "waveshare_lc29h_da"],
+          "default": "",
+          "title": "GNSS Hardware Preset",
+          "description": "Named hardware preset that applies compatible receiver-family, serial, rate, and receiver-configuration settings."
+        },
         "gnss_receiver_model": {
           "type": "string",
           "title": "Receiver Model",
@@ -323,6 +330,11 @@
           ],
           "default": 5,
           "description": "Requested Universal GNSS receiver update/output rate in Hz."
+        },
+        "gnss_config_apply_enabled": {
+          "type": "boolean",
+          "title": "Apply Receiver Configuration at Startup",
+          "description": "Whether the GNSS sidecar may apply a supported receiver profile before it opens the serial port."
         },
         "gnss_config_baud": {
           "type": "integer",

--- a/gui/web/src/components/settings/PositioningSection.tsx
+++ b/gui/web/src/components/settings/PositioningSection.tsx
@@ -10,11 +10,13 @@ import {
     GNSS_BAUD_OPTIONS,
     GNSS_ACTION_SETTINGS_KEYS,
     GNSS_EXECUTION_BAUD_OPTIONS,
+    GNSS_HARDWARE_PRESET_OPTIONS,
     GNSS_PROFILE_OPTIONS,
     GNSS_PROFILE_RATE_OPTIONS,
     GNSS_RECEIVER_FAMILY_OPTIONS,
     GNSS_SIGNAL_PROFILE_OPTIONS,
     GNSS_SIGNAL_PROFILE_CUSTOM_HELP_TEXT,
+    gnssHardwarePresetSettings,
     normalizeGnssProfile,
     normalizeGnssString,
     normalizeGnssSignalProfile,
@@ -250,6 +252,28 @@ export const PositioningSection: React.FC<Props> = ({
                             {t("settingsPositioning.expertGnssDescription")}
                         </Paragraph>
                         <Form layout="vertical" size="small">
+                            <Row gutter={[16, 0]}>
+                                <Col xs={24}>
+                                    <Form.Item
+                                        label={t("gnssConfig.hardwarePreset.label")}
+                                        tooltip={t("gnssConfig.hardwarePreset.tooltip")}
+                                        extra={t("gnssConfig.hardwarePreset.waveshareLc29hDa.description")}
+                                    >
+                                        <Select
+                                            value={values.gnss_hardware_preset ?? ""}
+                                            onChange={(preset) => {
+                                                for (const [key, value] of Object.entries(gnssHardwarePresetSettings(preset))) {
+                                                    onChange(key, value);
+                                                }
+                                            }}
+                                            options={GNSS_HARDWARE_PRESET_OPTIONS.map((option) => ({
+                                                value: option.value,
+                                                label: t(option.label),
+                                            }))}
+                                        />
+                                    </Form.Item>
+                                </Col>
+                            </Row>
                             <Row gutter={[16, 0]}>
                                 <Col xs={24} sm={12}>
                                     <Form.Item label={t("settingsPositioning.receiverProfileLabel")} tooltip={t("settingsPositioning.receiverProfileTooltip")}>

--- a/gui/web/src/components/settings/gnssConfig.test.ts
+++ b/gui/web/src/components/settings/gnssConfig.test.ts
@@ -5,6 +5,7 @@ import {
     GNSS_ADVANCED_SETTINGS_BY_FAMILY,
     GNSS_ACTION_SETTINGS_KEYS,
     GNSS_EXECUTION_BAUD_OPTIONS,
+    gnssHardwarePresetSettings,
     gnssProfileLabel,
     gnssSignalProfileDescription,
     gnssSignalProfileLabel,
@@ -15,6 +16,20 @@ import {
 } from "./gnssConfig.ts";
 
 describe("gnssConfig", () => {
+    it("applies the Waveshare LC29H(DA) 1 Hz receiver preset without a write-side profile", () => {
+        expect(gnssHardwarePresetSettings("waveshare_lc29h_da")).toMatchObject({
+            gnss_hardware_preset: "waveshare_lc29h_da",
+            gnss_receiver_family: "nmea",
+            gnss_serial_baud: 115200,
+            gnss_config_baud: 115200,
+            gnss_execution_baud: "115200",
+            gnss_profile: "runtime_only",
+            gnss_profile_rate_hz: 1,
+            gnss_config_apply_enabled: false,
+        });
+        expect(gnssHardwarePresetSettings("")).toEqual({ gnss_hardware_preset: "" });
+    });
+
     it("normalizes Unicore signal-group whitespace", () => {
         expect(normalizeGnssSignalGroup("  3   6  ")).toBe("3 6");
         expect(normalizeGnssSignalGroup("3,6")).toBe("3 6");

--- a/gui/web/src/components/settings/gnssConfig.ts
+++ b/gui/web/src/components/settings/gnssConfig.ts
@@ -5,6 +5,28 @@ export const GNSS_RECEIVER_FAMILY_OPTIONS = [
     { value: "nmea", label: "gnssConfig.receiverFamily.nmea.label" },
 ] as const;
 
+export const GNSS_HARDWARE_PRESET_OPTIONS = [
+    { value: "", label: "gnssConfig.hardwarePreset.manual.label" },
+    { value: "waveshare_lc29h_da", label: "gnssConfig.hardwarePreset.waveshareLc29hDa.label" },
+] as const;
+
+export const gnssHardwarePresetSettings = (preset: string): Record<string, string | number | boolean> => {
+    if (preset === "waveshare_lc29h_da") {
+        return {
+            gnss_hardware_preset: preset,
+            gnss_receiver_family: "nmea",
+            gnss_serial_baud: 115200,
+            gnss_config_baud: 115200,
+            gnss_execution_baud: "115200",
+            gnss_profile: "runtime_only",
+            gnss_profile_rate_hz: 1,
+            gnss_config_apply_enabled: false,
+        };
+    }
+
+    return { gnss_hardware_preset: "" };
+};
+
 export const GNSS_BAUD_OPTIONS = [
     { value: 115200, label: "115200" },
     { value: 230400, label: "230400" },

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -93,6 +93,7 @@ const SECTION_DEFINITIONS: SectionMeta[] = [
         keys: [
             "datum_lat", "datum_lon", "datum_alt",
             "gnss_receiver_family", "gnss_serial_device", "gnss_serial_baud",
+            "gnss_hardware_preset", "gnss_config_apply_enabled",
             "gnss_config_baud", "gnss_execution_baud", "gnss_profile", "gnss_signal_profile",
             "gnss_profile_rate_hz", "gnss_signal_group",
             "gnss_unicore_pvt_algorithm", "gnss_unicore_rtk_reliability",

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -1835,6 +1835,17 @@
         "label": "NMEA"
       }
     },
+    "hardwarePreset": {
+      "label": "GNSS hardware preset",
+      "tooltip": "Applies a documented receiver setup. Choose Manual before changing the individual settings for a preset receiver.",
+      "manual": {
+        "label": "Manual / no preset"
+      },
+      "waveshareLc29hDa": {
+        "label": "Waveshare LC29H(DA) GPS/RTK HAT (1 Hz)",
+        "description": "Uses generic NMEA at 115200 baud, 1 Hz, and runtime-only mode. It never writes a receiver configuration."
+      }
+    },
     "profile": {
       "runtime_only": {
         "label": "Runtime only"

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -1831,6 +1831,17 @@
         "label": "NMEA"
       }
     },
+    "hardwarePreset": {
+      "label": "Préréglage matériel GNSS",
+      "tooltip": "Applique une configuration documentée du récepteur. Choisissez Manuel avant de modifier les réglages individuels d'un récepteur préréglé.",
+      "manual": {
+        "label": "Manuel / aucun préréglage"
+      },
+      "waveshareLc29hDa": {
+        "label": "Waveshare LC29H(DA) GPS/RTK HAT (1 Hz)",
+        "description": "Utilise NMEA générique à 115200 bauds, 1 Hz et le mode exécution seule. Aucune configuration n'est écrite dans le récepteur."
+      }
+    },
     "profile": {
       "runtime_only": {
         "label": "Exécution seule"

--- a/gui/web/src/pages/OnboardingPage.tsx
+++ b/gui/web/src/pages/OnboardingPage.tsx
@@ -40,11 +40,13 @@ import {
     GNSS_BAUD_OPTIONS,
     GNSS_ACTION_SETTINGS_KEYS,
     GNSS_EXECUTION_BAUD_OPTIONS,
+    GNSS_HARDWARE_PRESET_OPTIONS,
     GNSS_PROFILE_OPTIONS,
     GNSS_PROFILE_RATE_OPTIONS,
     GNSS_RECEIVER_FAMILY_OPTIONS,
     GNSS_SIGNAL_PROFILE_OPTIONS,
     GNSS_SIGNAL_PROFILE_CUSTOM_HELP_TEXT,
+    gnssHardwarePresetSettings,
     normalizeGnssProfile,
     normalizeGnssString,
     normalizeGnssSignalProfile,
@@ -454,6 +456,28 @@ const GpsStep: React.FC<GpsStepProps> = ({ values, onChange, gpsRestarting, onPe
                             {t("onboardingPage.expertGnssSettingsDesc")}
                         </Paragraph>
                         <Form layout="vertical">
+                            <Row gutter={16}>
+                                <Col xs={24}>
+                                    <Form.Item
+                                        label={t("gnssConfig.hardwarePreset.label")}
+                                        tooltip={t("gnssConfig.hardwarePreset.tooltip")}
+                                        extra={t("gnssConfig.hardwarePreset.waveshareLc29hDa.description")}
+                                    >
+                                        <Select
+                                            value={values.gnss_hardware_preset ?? ""}
+                                            onChange={(preset) => {
+                                                for (const [key, value] of Object.entries(gnssHardwarePresetSettings(preset))) {
+                                                    onChange(key, value);
+                                                }
+                                            }}
+                                            options={GNSS_HARDWARE_PRESET_OPTIONS.map((option) => ({
+                                                label: t(option.label),
+                                                value: option.value,
+                                            }))}
+                                        />
+                                    </Form.Item>
+                                </Col>
+                            </Row>
                             <Row gutter={16}>
                                 <Col xs={24} sm={12}>
                                     <Form.Item

--- a/gui/web/src/utils/containers.ts
+++ b/gui/web/src/utils/containers.ts
@@ -100,6 +100,7 @@ export const restartGps = (api: GuiApi) =>
  * require an immediate mowgli-gps restart.
  */
 export const GPS_RESTART_KEYS = new Set<string>([
+    "gnss_hardware_preset",
     "gnss_receiver_family",
     "gnss_serial_device",
     "gnss_serial_baud",

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -338,6 +338,7 @@ mowgli:
     # GPS / Positioning
     # -----------------------------------------------------------------
     gnss_receiver_family: "auto"
+    gnss_hardware_preset: ""
     gnss_serial_device: "/dev/ttyAMA4"
     gnss_serial_baud: 921600
     datum_lat: 0.000000000     # map origin latitude  (set per-site)

--- a/sensors/gps/start_gps.sh
+++ b/sensors/gps/start_gps.sh
@@ -79,6 +79,17 @@ resolve_receiver_family() {
   printf 'auto\n'
 }
 
+resolve_hardware_preset() {
+  local yaml_preset
+  yaml_preset="$(parse_yaml_any gnss_hardware_preset)"
+  if [ -n "$yaml_preset" ]; then
+    printf '%s\n' "$(normalize_lower "$yaml_preset")"
+    return 0
+  fi
+
+  printf '%s\n' "$(normalize_lower "${GNSS_HARDWARE_PRESET:-}")"
+}
+
 resolve_transport() {
   local yaml_transport
   yaml_transport="$(parse_yaml_any gnss_transport)"
@@ -455,6 +466,26 @@ signal_profile="$(resolve_signal_profile)"
 receiver_model="$(resolve_receiver_model)"
 signal_group="$(resolve_signal_group)"
 rover_dynamic_mode="$(resolve_rover_dynamic_mode)"
+hardware_preset="$(resolve_hardware_preset)"
+
+case "$hardware_preset" in
+  "")
+    ;;
+  waveshare_lc29h_da)
+    # Waveshare's LC29H(DA) exposes standard NMEA and is limited to 1 Hz.
+    # Keep it runtime-only: the generic NMEA path deliberately has no
+    # write-side configuration contract.
+    receiver_family="nmea"
+    serial_baud="115200"
+    publish_rate_hz="1.0"
+    config_apply_enabled="false"
+    config_profile="runtime_only"
+    ;;
+  *)
+    echo "[start_gps.sh] ERROR: unknown gnss_hardware_preset=${hardware_preset}"
+    exit 1
+    ;;
+esac
 
 if [ "$transport" = "serial" ] && [ ! -e "$serial_device" ]; then
   echo "[start_gps.sh] ERROR: selected GNSS serial device does not exist: ${serial_device}"
@@ -495,6 +526,10 @@ fi
 # pre-configured receiver still runs. The apply must complete before
 # receiver_node opens the device.
 apply_receiver_profile() {
+  if [ "$receiver_family" = "nmea" ]; then
+    echo "[start_gps.sh] Receiver profile auto-apply skipped for generic NMEA; leaving receiver configuration unchanged."
+    return 0
+  fi
   if [ "$config_apply_enabled" != "true" ]; then
     echo "[start_gps.sh] Receiver profile auto-apply disabled (gnss_config_apply_enabled=false); leaving receiver config unchanged."
     return 0
@@ -565,7 +600,7 @@ ntrip_cmd=(
   -r "rtcm:=${internal_rtcm_topic}"
 )
 
-echo "[start_gps.sh] Runtime=universal receiver_family=${receiver_family} transport=${transport} device=${serial_device} baud=${serial_baud} rate_hz=${publish_rate_hz}"
+echo "[start_gps.sh] Runtime=universal preset=${hardware_preset:-manual} receiver_family=${receiver_family} transport=${transport} device=${serial_device} baud=${serial_baud} rate_hz=${publish_rate_hz}"
 
 if [ "$GNSS_DRY_RUN" = "true" ]; then
   if [ "$config_apply_enabled" = "true" ] && [ "$transport" = "serial" ]; then

--- a/sensors/gps/tests/fixtures/waveshare_lc29h_da.yaml
+++ b/sensors/gps/tests/fixtures/waveshare_lc29h_da.yaml
@@ -1,0 +1,5 @@
+mowgli:
+  ros__parameters:
+    gnss_hardware_preset: waveshare_lc29h_da
+    gnss_serial_device: /dev/null
+    ntrip_enabled: false

--- a/sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh
+++ b/sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh
@@ -5,10 +5,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 START_GPS="$SCRIPT_DIR/../start_gps.sh"
 CONFIG="$SCRIPT_DIR/fixtures/waveshare_lc29h_da.yaml"
+TEST_SETUP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_SETUP_DIR"' EXIT
+ROS_SETUP_BASH="$TEST_SETUP_DIR/ros_setup.bash"
+GNSS_SIDECAR_SETUP_BASH="$TEST_SETUP_DIR/gnss_sidecar_setup.bash"
+touch "$ROS_SETUP_BASH" "$GNSS_SIDECAR_SETUP_BASH"
 
 output="$(GNSS_CONFIG_PATH="$CONFIG" \
-  ROS_SETUP_BASH=/dev/null \
-  GNSS_SIDECAR_SETUP_BASH=/dev/null \
+  ROS_SETUP_BASH="$ROS_SETUP_BASH" \
+  GNSS_SIDECAR_SETUP_BASH="$GNSS_SIDECAR_SETUP_BASH" \
   GNSS_DRY_RUN=true \
   bash "$START_GPS")"
 

--- a/sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh
+++ b/sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Static dry-run coverage for the LC29H(DA) GNSS hardware preset.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+START_GPS="$SCRIPT_DIR/../start_gps.sh"
+CONFIG="$SCRIPT_DIR/fixtures/waveshare_lc29h_da.yaml"
+
+output="$(GNSS_CONFIG_PATH="$CONFIG" \
+  ROS_SETUP_BASH=/dev/null \
+  GNSS_SIDECAR_SETUP_BASH=/dev/null \
+  GNSS_DRY_RUN=true \
+  bash "$START_GPS")"
+
+grep -Fq 'preset=waveshare_lc29h_da receiver_family=nmea' <<<"$output"
+grep -Fq 'baud=115200 rate_hz=1.0' <<<"$output"
+grep -Fq 'receiver_node' <<<"$output"
+grep -Fq -- '-p receiver_family:=nmea' <<<"$output"
+grep -Fq -- '-p serial_baud:=115200' <<<"$output"
+grep -Fq -- '-p publish_rate_hz:=1.0' <<<"$output"
+if grep -Fq '[start_gps.sh] config_apply' <<<"$output"; then
+  echo "LC29H(DA) preset must not invoke receiver configuration" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a named Waveshare LC29H(DA) GPS/RTK HAT preset to onboarding and expert GNSS settings
- use the documented generic-NMEA runtime settings: 115200 baud, 1 Hz, runtime-only
- keep generic NMEA receivers read-only at startup, avoiding unsupported receiver-side profile writes
- add schema, template, localisation, and dry-run coverage

The preset is intentionally limited to the LC29H(DA) 1 Hz configuration; it does not change manual or other generic-NMEA setups.

## Validation

- `bash -n sensors/gps/start_gps.sh sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh`
- `bash sensors/gps/tests/test_start_gps_waveshare_lc29h_da.sh`
- `vitest run src/components/settings/gnssConfig.test.ts` (10 tests passed)
- `tsc && vite build`

`go test ./pkg/api` currently reaches an existing schema/template parity failure for unrelated defaults (`yaw_goal_tolerance`, `progress_timeout_sec`, `obstacle_wait_timeout_s`, and `lidar_z`); this change adds no new divergence.

Hardware has not been connected or driven for this PR.

## Related upstream work

[Universal GNSS #2](https://github.com/mowglinext/universal-gnss/pull/2) adds rate-derived receiver liveness timing (four seconds at 1 Hz). This Mowgli PR deliberately keeps the current public submodule revision until that upstream change is merged.

Refs #435.