### PR TITLE
perf(gui): remove continuous visual effects

### DIFF
--- a/gui/web/src/components/AppShell.tsx
+++ b/gui/web/src/components/AppShell.tsx
@@ -420,6 +420,7 @@ const bottomNavPill = (
 
 function MobileBottomNav({items, activePath, onNavigate, onMore, moreActive}: RailProps) {
   const {t} = useTranslation();
+  const {displayMode} = useThemeMode();
   const columns = items.length + (onMore ? 1 : 0);
   return (
     <nav style={{
@@ -428,6 +429,8 @@ function MobileBottomNav({items, activePath, onNavigate, onMore, moreActive}: Ra
       paddingTop: 10,
       paddingLeft: 14, paddingRight: 14,
       background: 'linear-gradient(180deg, rgba(2, 17, 13, 0) 0%, rgba(2, 17, 13, 0.85) 30%, rgba(2, 17, 13, 0.97) 100%)',
+      backdropFilter: displayMode === 'visual' ? 'blur(22px) saturate(140%)' : undefined,
+      WebkitBackdropFilter: displayMode === 'visual' ? 'blur(22px) saturate(140%)' : undefined,
       zIndex: 50,
     }}>
       <LayoutGroup>
@@ -438,6 +441,8 @@ function MobileBottomNav({items, activePath, onNavigate, onMore, moreActive}: Ra
           background: 'rgba(255, 255, 255, 0.04)',
           border: '1px solid rgba(236, 255, 244, 0.08)',
           borderRadius: 999,
+          backdropFilter: displayMode === 'visual' ? 'blur(28px)' : undefined,
+          WebkitBackdropFilter: displayMode === 'visual' ? 'blur(28px)' : undefined,
         }}>
           {items.map(({key, labelKey, shortLabelKey, icon: Icon}) => {
             const isActive = key === activePath;
@@ -473,6 +478,7 @@ interface MoreSheetProps {
 
 function MobileMoreSheet({open, items, activePath, onClose, onNavigate}: MoreSheetProps) {
   const {t} = useTranslation();
+  const {displayMode} = useThemeMode();
 
   // Escape closes the sheet (keyboard parity with the backdrop tap / X button).
   useEffect(() => {
@@ -500,6 +506,8 @@ function MobileMoreSheet({open, items, activePath, onClose, onNavigate}: MoreShe
               position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 61,
               padding: '14px 14px calc(env(safe-area-inset-bottom, 0px) + 18px)',
               background: 'rgba(6, 24, 18, 0.97)',
+              backdropFilter: displayMode === 'visual' ? 'blur(24px) saturate(140%)' : undefined,
+              WebkitBackdropFilter: displayMode === 'visual' ? 'blur(24px) saturate(140%)' : undefined,
               borderTop: '1px solid rgba(236, 255, 244, 0.1)',
               borderRadius: '20px 20px 0 0',
             }}

--- a/gui/web/src/components/AppShell.tsx
+++ b/gui/web/src/components/AppShell.tsx
@@ -28,9 +28,9 @@ import "../concept/concept.css";
 /**
  * Premium tech-garden shell shared by the whole app.
  *
- * Desktop -> 88px fixed glass side-rail on the left + the page content in a
+ * Desktop -> 88px fixed side-rail on the left + the page content in a
  *            comfortable max-width column with a sticky top status strip.
- * Mobile   -> glass bottom-nav with a sliding lime pill + slim top header.
+ * Mobile   -> bottom-nav with a sliding lime pill + slim top header.
  *
  * All surfaces inherit the /concept tokens (data-concept scope on body).
  */
@@ -144,8 +144,7 @@ export function AppShell() {
           padding: '0 16px',
           paddingTop: 'max(env(safe-area-inset-top, 0px), 6px)',
           minHeight: 56,
-          background: 'rgba(2, 17, 13, 0.6)',
-          backdropFilter: 'blur(20px) saturate(140%)',
+          background: 'rgba(2, 17, 13, 0.94)',
           borderBottom: `1px solid ${colors.borderSubtle}`,
           flexShrink: 0,
           position: 'relative', zIndex: 10,
@@ -226,8 +225,7 @@ export function AppShell() {
         <header style={{
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
           padding: '18px 32px',
-          background: 'rgba(2, 17, 13, 0.45)',
-          backdropFilter: 'blur(20px) saturate(140%)',
+          background: 'rgba(2, 17, 13, 0.94)',
           borderBottom: `1px solid ${colors.borderSubtle}`,
           position: 'sticky', top: 0, zIndex: 30, overflow: 'visible',
         }}>
@@ -318,7 +316,6 @@ function DesktopSideRail({items, activePath, onNavigate}: RailProps) {
       paddingTop: 24, paddingBottom: 24,
       background: 'linear-gradient(180deg, rgba(2, 17, 13, 0.92), rgba(2, 17, 13, 0.84))',
       borderRight: '1px solid rgba(236, 255, 244, 0.07)',
-      backdropFilter: 'blur(22px) saturate(140%)',
       zIndex: 40,
     }}>
       <div style={{
@@ -431,7 +428,6 @@ function MobileBottomNav({items, activePath, onNavigate, onMore, moreActive}: Ra
       paddingTop: 10,
       paddingLeft: 14, paddingRight: 14,
       background: 'linear-gradient(180deg, rgba(2, 17, 13, 0) 0%, rgba(2, 17, 13, 0.85) 30%, rgba(2, 17, 13, 0.97) 100%)',
-      backdropFilter: 'blur(22px) saturate(140%)',
       zIndex: 50,
     }}>
       <LayoutGroup>
@@ -442,7 +438,6 @@ function MobileBottomNav({items, activePath, onNavigate, onMore, moreActive}: Ra
           background: 'rgba(255, 255, 255, 0.04)',
           border: '1px solid rgba(236, 255, 244, 0.08)',
           borderRadius: 999,
-          backdropFilter: 'blur(28px)',
         }}>
           {items.map(({key, labelKey, shortLabelKey, icon: Icon}) => {
             const isActive = key === activePath;
@@ -505,7 +500,6 @@ function MobileMoreSheet({open, items, activePath, onClose, onNavigate}: MoreShe
               position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 61,
               padding: '14px 14px calc(env(safe-area-inset-bottom, 0px) + 18px)',
               background: 'rgba(6, 24, 18, 0.97)',
-              backdropFilter: 'blur(24px) saturate(140%)',
               borderTop: '1px solid rgba(236, 255, 244, 0.1)',
               borderRadius: '20px 20px 0 0',
             }}

--- a/gui/web/src/components/BTStateGraph.tsx
+++ b/gui/web/src/components/BTStateGraph.tsx
@@ -100,15 +100,6 @@ export function nodeFor(state: string | undefined): string | null {
   return null;
 }
 
-const keyframes = `
-@media (prefers-reduced-motion: no-preference) {
-  @keyframes btStatePulse {
-    0%, 100% { opacity: 0.55; transform: scale(1); }
-    50% { opacity: 1; transform: scale(1.08); }
-  }
-}
-`;
-
 const NODE_W = 86;
 const NODE_H = 28;
 
@@ -153,7 +144,6 @@ export function BTStateGraph({current, detail}: BTStateGraphProps) {
       overflowX: 'auto',
       WebkitOverflowScrolling: 'touch',
     }}>
-      <style>{keyframes}</style>
       <div style={{
         display: 'flex', alignItems: 'baseline', justifyContent: 'space-between',
         marginBottom: 10,
@@ -176,7 +166,6 @@ export function BTStateGraph({current, detail}: BTStateGraphProps) {
               width: 8, height: 8, borderRadius: 4,
               background: colors.accent,
               boxShadow: `0 0 8px ${colors.accent}`,
-              animation: 'btStatePulse 1.8s ease-in-out infinite',
             }}/>
             <span style={{
               fontSize: 11, fontWeight: 700, color: colors.accent,
@@ -267,10 +256,6 @@ export function BTStateGraph({current, detail}: BTStateGraphProps) {
                     fill="none"
                     stroke={accent}
                     strokeWidth={2}
-                    style={{
-                      transformOrigin: `${NODE_W / 2 + 4}px ${NODE_H / 2 + 4}px`,
-                      animation: 'btStatePulse 1.8s ease-in-out infinite',
-                    }}
                   />
                 </>
               )}

--- a/gui/web/src/components/IOSInstallBanner.tsx
+++ b/gui/web/src/components/IOSInstallBanner.tsx
@@ -24,8 +24,6 @@ export const IOSInstallBanner = ({onDismiss}: IOSInstallBannerProps) => {
         right: 12,
         zIndex: 300,
         background: colors.glassBackground,
-        backdropFilter: 'blur(16px) saturate(180%)',
-        WebkitBackdropFilter: 'blur(16px) saturate(180%)',
         borderRadius: 14,
         border: colors.glassBorder,
         boxShadow: colors.glassShadow,

--- a/gui/web/src/components/LiveStatusStrip.tsx
+++ b/gui/web/src/components/LiveStatusStrip.tsx
@@ -6,9 +6,8 @@ import {useThemeMode} from "../theme/ThemeContext.tsx";
  * Thin animated strip pinned above the page header.
  *
  * Off when the robot is idle/parked; a green-tinted gradient when the robot
- * is moving (mowing/transit/undocking/recovering); pulsing red when
- * emergency is latched. The point is for the chrome itself to signal "robot
- * is alive" without the operator having to read the header chips.
+ * is moving (mowing/transit/undocking/recovering); pulsing red when emergency
+ * is latched. Visual mode adds a restrained sheen to the moving state.
  */
 const MOTION_STATES = new Set([
   "MOWING", "TRANSIT", "UNDOCKING", "RETURNING_HOME", "MANUAL_MOWING",
@@ -23,7 +22,7 @@ interface LiveStatusStripProps {
 }
 
 export function LiveStatusStrip({height = 2}: LiveStatusStripProps) {
-  const {colors} = useThemeMode();
+  const {colors, displayMode} = useThemeMode();
   const {highLevelStatus} = useHighLevelStatus();
   const emergency = useEmergency();
 
@@ -46,7 +45,9 @@ export function LiveStatusStrip({height = 2}: LiveStatusStripProps) {
         width: '100%',
         background,
         backgroundSize: '200% 100%',
-        animation: isEmergency ? 'liveStripPulse 1.2s ease-in-out infinite' : 'none',
+        animation: isEmergency
+          ? 'liveStripPulse 1.2s ease-in-out infinite'
+          : displayMode === 'visual' ? 'liveStripSheen 3.6s ease-in-out infinite' : 'none',
         flexShrink: 0,
       }}
     />

--- a/gui/web/src/components/LiveStatusStrip.tsx
+++ b/gui/web/src/components/LiveStatusStrip.tsx
@@ -5,8 +5,8 @@ import {useThemeMode} from "../theme/ThemeContext.tsx";
 /**
  * Thin animated strip pinned above the page header.
  *
- * Off when the robot is idle/parked; an animated green-tinted gradient when
- * the robot is moving (mowing/transit/undocking/recovering); solid red when
+ * Off when the robot is idle/parked; a green-tinted gradient when the robot
+ * is moving (mowing/transit/undocking/recovering); pulsing red when
  * emergency is latched. The point is for the chrome itself to signal "robot
  * is alive" without the operator having to read the header chips.
  */
@@ -17,17 +17,6 @@ const MOTION_STATES = new Set([
   "COVERAGE_FAILED_DOCKING", "SKIP_STRIP", "PREFLIGHT_CHECK",
   "CALIBRATING_HEADING", "RECORDING", "OBSTACLE_BACKOFF",
 ]);
-
-const keyframes = `
-@keyframes liveStripSheen {
-  0% { background-position: 0% 50%; }
-  100% { background-position: 200% 50%; }
-}
-@keyframes liveStripPulse {
-  0%, 100% { opacity: 0.55; }
-  50% { opacity: 1; }
-}
-`;
 
 interface LiveStatusStripProps {
   height?: number;
@@ -50,21 +39,16 @@ export function LiveStatusStrip({height = 2}: LiveStatusStripProps) {
     : `linear-gradient(90deg, transparent 0%, ${color} 30%, ${color}dd 50%, ${color} 70%, transparent 100%)`;
 
   return (
-    <>
-      <style>{keyframes}</style>
-      <div
-        aria-hidden
-        style={{
-          height,
-          width: '100%',
-          background,
-          backgroundSize: '200% 100%',
-          animation: isEmergency
-            ? 'liveStripPulse 1.2s ease-in-out infinite'
-            : 'liveStripSheen 2.4s linear infinite',
-          flexShrink: 0,
-        }}
-      />
-    </>
+    <div
+      aria-hidden
+      style={{
+        height,
+        width: '100%',
+        background,
+        backgroundSize: '200% 100%',
+        animation: isEmergency ? 'liveStripPulse 1.2s ease-in-out infinite' : 'none',
+        flexShrink: 0,
+      }}
+    />
   );
 }

--- a/gui/web/src/components/MowerStatus.tsx
+++ b/gui/web/src/components/MowerStatus.tsx
@@ -34,7 +34,7 @@ const statusColor = (stateNum: number | undefined, isEmergency: boolean, colors:
 
 export const MowerStatus = () => {
     const {t} = useTranslation();
-    const {colors} = useThemeMode();
+    const {colors, displayMode} = useThemeMode();
     const {highLevelStatus} = useHighLevelStatus();
     const hwStatus = useStatus();
     const emergencyData = useEmergency();
@@ -72,10 +72,11 @@ export const MowerStatus = () => {
 
     const isMowing = stateNum === 2 || stateNum === 3 || stateNum === 4;
 
-    // The colour remains a continuous state cue. Only an emergency pulses;
-    // normal mowing can run for hours and should not keep a decorative
-    // animation active for that entire period.
-    const pulseAnimation = isEmergency ? 'mowerPulseRed 1.5s ease-in-out infinite' : 'none';
+    // The colour remains a continuous state cue. Emergency emphasis always
+    // pulses; Visual mode can additionally use a restrained active-state cue.
+    const pulseAnimation = isEmergency
+        ? 'mowerPulseRed 1.5s ease-in-out infinite'
+        : isMowing && displayMode === 'visual' ? 'mowerPulseGreen 2.4s ease-in-out infinite' : 'none';
 
     const hasArea = highLevelStatus.current_area !== undefined && highLevelStatus.current_area >= 0;
     // Coarse sub-path X/Y — the secondary readout.
@@ -197,6 +198,7 @@ export const MowerStatus = () => {
                             animation: pulseAnimation,
                             borderRadius: '50%',
                             '--mower-status-danger': colors.danger,
+                            '--mower-status-active': colors.primary,
                         } as CSSProperties}
                     />
                     <Typography.Text style={{fontSize: 12, color: colors.text, whiteSpace: 'nowrap'}}>

--- a/gui/web/src/components/MowerStatus.tsx
+++ b/gui/web/src/components/MowerStatus.tsx
@@ -14,25 +14,10 @@ import {PoweroffOutlined, ReloadOutlined, DesktopOutlined, WifiOutlined, AlertOu
 import {stateRenderer} from "./utils.tsx";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 import {useApi} from "../hooks/useApi.ts";
-import {limeAlpha} from "../theme/colors.ts";
 import {SettingOutlined} from "@ant-design/icons";
+import type {CSSProperties} from "react";
 import type {MenuProps} from "antd";
 import {useTranslation} from "react-i18next";
-
-// Builds the badge pulse keyframes from brand tokens. Green pulse derives
-// from the lime hero accent; red pulse derives from colors.danger (rose).
-// colors.danger is a hex string ("#FF6B7A"); append an 8-bit alpha suffix
-// to get the translucent stops without hardcoding the rose RGB here.
-const buildPulseKeyframes = (dangerHex: string) => `
-@keyframes mowerPulseGreen {
-    0%, 100% { box-shadow: 0 0 0 0 ${limeAlpha(0.6)}; }
-    50% { box-shadow: 0 0 0 4px ${limeAlpha(0)}; }
-}
-@keyframes mowerPulseRed {
-    0%, 100% { box-shadow: 0 0 0 0 ${dangerHex}99; }
-    50% { box-shadow: 0 0 0 4px ${dangerHex}00; }
-}
-`;
 
 // Colour by the NUMERIC high-level state (status_nodes.cpp publishes it every
 // tick): 2=AUTONOMOUS / 3=RECORDING / 4=MANUAL_MOWING are active (primary);
@@ -50,7 +35,6 @@ const statusColor = (stateNum: number | undefined, isEmergency: boolean, colors:
 export const MowerStatus = () => {
     const {t} = useTranslation();
     const {colors} = useThemeMode();
-    const pulseKeyframes = buildPulseKeyframes(colors.danger);
     const {highLevelStatus} = useHighLevelStatus();
     const hwStatus = useStatus();
     const emergencyData = useEmergency();
@@ -88,11 +72,10 @@ export const MowerStatus = () => {
 
     const isMowing = stateNum === 2 || stateNum === 3 || stateNum === 4;
 
-    const pulseAnimation = isEmergency
-        ? 'mowerPulseRed 1.5s ease-in-out infinite'
-        : isMowing
-            ? 'mowerPulseGreen 2s ease-in-out infinite'
-            : 'none';
+    // The colour remains a continuous state cue. Only an emergency pulses;
+    // normal mowing can run for hours and should not keep a decorative
+    // animation active for that entire period.
+    const pulseAnimation = isEmergency ? 'mowerPulseRed 1.5s ease-in-out infinite' : 'none';
 
     const hasArea = highLevelStatus.current_area !== undefined && highLevelStatus.current_area >= 0;
     // Coarse sub-path X/Y — the secondary readout.
@@ -206,12 +189,15 @@ export const MowerStatus = () => {
 
     return (
         <>
-            <style>{pulseKeyframes}</style>
             <Space size="small" style={{flexShrink: 0}}>
                 <Space size={4}>
                     <Badge
                         color={statusColor(stateNum, isEmergency, colors)}
-                        style={{animation: pulseAnimation, borderRadius: '50%'}}
+                        style={{
+                            animation: pulseAnimation,
+                            borderRadius: '50%',
+                            '--mower-status-danger': colors.danger,
+                        } as CSSProperties}
                     />
                     <Typography.Text style={{fontSize: 12, color: colors.text, whiteSpace: 'nowrap'}}>
                         {stateRenderer(stateName)}

--- a/gui/web/src/components/NotificationBell.tsx
+++ b/gui/web/src/components/NotificationBell.tsx
@@ -34,7 +34,7 @@ function BellIcon({color, animate, size = 18}: BellIconProps) {
              stroke={color} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"
              style={{
                  transformOrigin: '50% 30%',
-                 animation: animate ? 'notifBellWiggle 1.6s ease-in-out infinite' : 'none',
+                 animation: animate ? 'notifBellWiggle 1.6s ease-in-out 2' : 'none',
              }}>
             <path d="M6 8a6 6 0 1 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>
             <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>

--- a/gui/web/src/components/dashboard/Card.tsx
+++ b/gui/web/src/components/dashboard/Card.tsx
@@ -2,9 +2,8 @@ import type {CSSProperties, ReactNode} from "react";
 import {useThemeMode} from "../../theme/ThemeContext.tsx";
 
 /**
- * Shared glass surface. Background, backdrop blur, soft border, and a
- * luminous edge gradient applied at the top-left via mask-composite --
- * the visual signature of the tech-garden language. Used by every page.
+ * Shared layered surface. A solid background, soft border, and luminous edge
+ * gradient provide the tech-garden look without a backdrop-filter layer.
  */
 
 interface DashCardProps {
@@ -21,7 +20,7 @@ export function DashCard({children, style, tone, padding = 18, onClick}: DashCar
     ? `linear-gradient(135deg, ${colors.accent}, ${colors.accent}aa)`
     : tone === 'danger'
       ? 'linear-gradient(135deg, rgba(255,107,122,0.18), rgba(255,107,122,0.04))'
-      : 'rgba(11, 24, 20, 0.6)';
+      : colors.bgCard;
 
   const shadow = tone === 'glow'
     ? '0 24px 60px -20px rgba(0,0,0,0.7), 0 0 60px rgba(124,255,178,0.18), 0 0 0 1px rgba(124,255,178,0.16) inset'
@@ -34,8 +33,6 @@ export function DashCard({children, style, tone, padding = 18, onClick}: DashCar
       style={{
         position: 'relative',
         background: bg,
-        backdropFilter: 'blur(24px) saturate(140%)',
-        WebkitBackdropFilter: 'blur(24px) saturate(140%)',
         borderRadius: 18,
         padding,
         border: tone === 'accent' ? 'none' : `1px solid ${colors.border}`,

--- a/gui/web/src/components/dashboard/Card.tsx
+++ b/gui/web/src/components/dashboard/Card.tsx
@@ -2,8 +2,8 @@ import type {CSSProperties, ReactNode} from "react";
 import {useThemeMode} from "../../theme/ThemeContext.tsx";
 
 /**
- * Shared layered surface. A solid background, soft border, and luminous edge
- * gradient provide the tech-garden look without a backdrop-filter layer.
+ * Shared layered surface. Every mode keeps the luminous edge and border; the
+ * selected display mode controls translucency and optional glass blur.
  */
 
 interface DashCardProps {
@@ -15,12 +15,12 @@ interface DashCardProps {
 }
 
 export function DashCard({children, style, tone, padding = 18, onClick}: DashCardProps) {
-  const {colors} = useThemeMode();
+  const {colors, displayMode} = useThemeMode();
   const bg = tone === 'accent'
     ? `linear-gradient(135deg, ${colors.accent}, ${colors.accent}aa)`
     : tone === 'danger'
       ? 'linear-gradient(135deg, rgba(255,107,122,0.18), rgba(255,107,122,0.04))'
-      : colors.bgCard;
+      : displayMode === 'efficient' ? colors.bgCard : colors.glassBackground;
 
   const shadow = tone === 'glow'
     ? '0 24px 60px -20px rgba(0,0,0,0.7), 0 0 60px rgba(124,255,178,0.18), 0 0 0 1px rgba(124,255,178,0.16) inset'
@@ -33,6 +33,8 @@ export function DashCard({children, style, tone, padding = 18, onClick}: DashCar
       style={{
         position: 'relative',
         background: bg,
+        backdropFilter: displayMode === 'visual' ? 'blur(20px) saturate(135%)' : undefined,
+        WebkitBackdropFilter: displayMode === 'visual' ? 'blur(20px) saturate(135%)' : undefined,
         borderRadius: 18,
         padding,
         border: tone === 'accent' ? 'none' : `1px solid ${colors.border}`,

--- a/gui/web/src/components/dashboard/constants.ts
+++ b/gui/web/src/components/dashboard/constants.ts
@@ -98,9 +98,17 @@ export const KEYFRAMES_CSS = `
     0%, 100% { box-shadow: 0 0 0 0 var(--mower-status-danger); }
     50% { box-shadow: 0 0 0 4px transparent; }
   }
+  @keyframes mowerPulseGreen {
+    0%, 100% { box-shadow: 0 0 0 0 var(--mower-status-active); }
+    50% { box-shadow: 0 0 0 4px transparent; }
+  }
   @keyframes liveStripPulse {
     0%, 100% { opacity: 0.55; }
     50% { opacity: 1; }
+  }
+  @keyframes liveStripSheen {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
   }
 }
 .mn-card-hover:hover { transform: translateY(-1px); }
@@ -121,18 +129,26 @@ export const KEYFRAMES_CSS = `
   pointer-events: none;
 }
 
-/* ─── AntD Card → layered tech-garden surface ───────────────────────────
+/* ─── AntD Card → display-mode-aware tech-garden surface ────────────────
    Pull every stock AntD Card into the tech-garden glass language so pages
    built on AntD (Diagnostics, Settings, Onboarding) match the hand-built
    DashCard/GlassCard surfaces without per-page edits. Same recipe as
-   DashCard: solid dark fill, soft border, and luminous top-left edge. */
+   DashCard: soft border and luminous top-left edge in every mode. */
 .ant-card {
   position: relative;
-  background: var(--bg-card-solid) !important;
+  background: rgba(11, 24, 20, 0.78) !important;
   border: 1px solid var(--border-soft) !important;
   border-radius: var(--radius-md) !important;
   box-shadow: 0 24px 60px -20px rgba(0,0,0,0.5), 0 4px 16px -4px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.04) !important;
   overflow: hidden;
+}
+:root[data-display-mode='visual'] .ant-card {
+  background: rgba(11, 24, 20, 0.60) !important;
+  backdrop-filter: blur(20px) saturate(135%);
+  -webkit-backdrop-filter: blur(20px) saturate(135%);
+}
+:root[data-display-mode='efficient'] .ant-card {
+  background: var(--bg-card-solid) !important;
 }
 .ant-card::before {
   content: '';
@@ -151,6 +167,8 @@ export const KEYFRAMES_CSS = `
 /* Nested cards flatten to a plain tile so edges and shadows do not stack. */
 .ant-card .ant-card {
   background: var(--bg-elevated) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
   box-shadow: none !important;
 }
 .ant-card .ant-card::before { display: none; }
@@ -255,10 +273,18 @@ export const KEYFRAMES_CSS = `
 .ant-btn-primary:active { transform: translateY(0); }
 
 .ant-btn-default {
-  background: var(--bg-card-solid) !important;
+  background: rgba(11, 24, 20, 0.78) !important;
   border: 1px solid var(--border-soft) !important;
   color: var(--ink) !important;
   font-weight: 600 !important;
+}
+:root[data-display-mode='visual'] .ant-btn-default {
+  background: rgba(11, 24, 20, 0.60) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+:root[data-display-mode='efficient'] .ant-btn-default {
+  background: var(--bg-card-solid) !important;
 }
 .ant-btn-default:hover,
 .ant-btn-default:focus {

--- a/gui/web/src/components/dashboard/constants.ts
+++ b/gui/web/src/components/dashboard/constants.ts
@@ -77,15 +77,15 @@ export const fmt = {
 };
 
 export const KEYFRAMES_CSS = `
-@keyframes mn-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.4; transform: scale(0.85); }
-}
-@keyframes mn-rise {
-  from { opacity: 0; transform: translateY(8px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
 @media (prefers-reduced-motion: no-preference) {
+  @keyframes mn-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.4; transform: scale(0.85); }
+  }
+  @keyframes mn-rise {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
   @keyframes mn-bounds-glow {
     0%, 100% { box-shadow: 0 0 0 0 rgba(255,107,107,0.7), inset 0 0 0 1px rgba(255,107,107,0.6); }
     50% { box-shadow: 0 0 0 6px rgba(255,107,107,0), inset 0 0 0 1px rgba(255,107,107,0.9); }
@@ -93,6 +93,14 @@ export const KEYFRAMES_CSS = `
   @keyframes mn-pulse-red {
     0%, 100% { box-shadow: 0 0 0 0 rgba(255,107,107,0); }
     50% { box-shadow: 0 0 0 8px rgba(255,107,107,0.15); }
+  }
+  @keyframes mowerPulseRed {
+    0%, 100% { box-shadow: 0 0 0 0 var(--mower-status-danger); }
+    50% { box-shadow: 0 0 0 4px transparent; }
+  }
+  @keyframes liveStripPulse {
+    0%, 100% { opacity: 0.55; }
+    50% { opacity: 1; }
   }
 }
 .mn-card-hover:hover { transform: translateY(-1px); }
@@ -113,17 +121,14 @@ export const KEYFRAMES_CSS = `
   pointer-events: none;
 }
 
-/* ─── AntD Card → liquid glass ──────────────────────────────────────────
+/* ─── AntD Card → layered tech-garden surface ───────────────────────────
    Pull every stock AntD Card into the tech-garden glass language so pages
    built on AntD (Diagnostics, Settings, Onboarding) match the hand-built
    DashCard/GlassCard surfaces without per-page edits. Same recipe as
-   DashCard: translucent dark fill, backdrop blur, soft border, luminous
-   top-left edge. */
+   DashCard: solid dark fill, soft border, and luminous top-left edge. */
 .ant-card {
   position: relative;
-  background: rgba(11, 24, 20, 0.6) !important;
-  backdrop-filter: blur(24px) saturate(140%);
-  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  background: var(--bg-card-solid) !important;
   border: 1px solid var(--border-soft) !important;
   border-radius: var(--radius-md) !important;
   box-shadow: 0 24px 60px -20px rgba(0,0,0,0.5), 0 4px 16px -4px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.04) !important;
@@ -143,11 +148,8 @@ export const KEYFRAMES_CSS = `
 }
 .ant-card-head { border-bottom: 1px solid var(--border-soft) !important; background: transparent !important; }
 .ant-card-body, .ant-card-head { position: relative; z-index: 1; }
-/* Nested cards (a card inside a card) shouldn't double up the blur+edge —
-   flatten the inner one to a plain translucent tile. */
+/* Nested cards flatten to a plain tile so edges and shadows do not stack. */
 .ant-card .ant-card {
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
   background: var(--bg-elevated) !important;
   box-shadow: none !important;
 }
@@ -253,10 +255,9 @@ export const KEYFRAMES_CSS = `
 .ant-btn-primary:active { transform: translateY(0); }
 
 .ant-btn-default {
-  background: var(--bg-card) !important;
+  background: var(--bg-card-solid) !important;
   border: 1px solid var(--border-soft) !important;
   color: var(--ink) !important;
-  backdrop-filter: blur(12px);
   font-weight: 600 !important;
 }
 .ant-btn-default:hover,
@@ -346,9 +347,19 @@ export const KEYFRAMES_CSS = `
 
 /* Staggered page entrance: children with [data-stagger] animate in
    sequence on initial mount. Combine with --stagger-index from JS. */
-.mn-stagger > [data-stagger] {
-  opacity: 0;
-  animation: mn-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
-  animation-delay: calc(var(--stagger-index, 0) * 60ms + 80ms);
+@media (prefers-reduced-motion: no-preference) {
+  .mn-stagger > [data-stagger] {
+    opacity: 0;
+    animation: mn-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+    animation-delay: calc(var(--stagger-index, 0) * 60ms + 80ms);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-concept], [data-concept] *, [data-concept] *::before, [data-concept] *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 `;

--- a/gui/web/src/components/settings/DisplayModeSection.test.tsx
+++ b/gui/web/src/components/settings/DisplayModeSection.test.tsx
@@ -1,0 +1,39 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {fireEvent, render, screen} from "@testing-library/react";
+import {ThemeProvider, useThemeMode} from "../../theme/ThemeContext.tsx";
+import {DisplayModeSection} from "./DisplayModeSection.tsx";
+
+function ModeValue() {
+    return <output data-testid="display-mode-value">{useThemeMode().displayMode}</output>;
+}
+
+describe("DisplayModeSection", () => {
+    beforeEach(() => {
+        const storage = new Map<string, string>();
+        Object.defineProperty(window, "localStorage", {
+            configurable: true,
+            value: {
+                getItem: (key: string) => storage.get(key) ?? null,
+                setItem: (key: string, value: string) => storage.set(key, value),
+                removeItem: (key: string) => storage.delete(key),
+                clear: () => storage.clear(),
+            },
+        });
+    });
+
+    it("offers all modes and updates the shared preference", () => {
+        render(
+            <ThemeProvider>
+                <DisplayModeSection/>
+                <ModeValue/>
+            </ThemeProvider>,
+        );
+
+        expect(screen.getByRole("radio", {name: /^Visual/})).toBeInTheDocument();
+        expect(screen.getByRole("radio", {name: /^Balanced/})).toBeChecked();
+        expect(screen.getByRole("radio", {name: /^Efficient/})).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("radio", {name: /^Efficient/}));
+        expect(screen.getByTestId("display-mode-value")).toHaveTextContent("efficient");
+    });
+});

--- a/gui/web/src/components/settings/DisplayModeSection.tsx
+++ b/gui/web/src/components/settings/DisplayModeSection.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {Card, Radio, Space, Typography} from "antd";
+import {useTranslation} from "react-i18next";
+import {useThemeMode} from "../../theme/ThemeContext.tsx";
+import type {DisplayMode} from "../../theme/ThemeContext.tsx";
+
+const {Paragraph, Text} = Typography;
+
+const DISPLAY_MODE_OPTIONS: DisplayMode[] = ['visual', 'balanced', 'efficient'];
+
+export const DisplayModeSection: React.FC = () => {
+    const {t} = useTranslation();
+    const {colors, displayMode, setDisplayMode} = useThemeMode();
+
+    return (
+        <Card size="small">
+            <Space direction="vertical" size={14} style={{width: "100%"}}>
+                <div>
+                    <Text strong style={{fontSize: 14}}>{t("displayMode.title")}</Text>
+                    <Paragraph type="secondary" style={{margin: "4px 0 0"}}>
+                        {t("displayMode.description")}
+                    </Paragraph>
+                </div>
+
+                <Radio.Group
+                    value={displayMode}
+                    onChange={(event) => setDisplayMode(event.target.value as DisplayMode)}
+                    aria-label={t("displayMode.title")}
+                    style={{display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(190px, 1fr))", gap: 10}}
+                >
+                    {DISPLAY_MODE_OPTIONS.map((mode) => {
+                        const selected = displayMode === mode;
+                        return (
+                            <Radio
+                                key={mode}
+                                value={mode}
+                                style={{
+                                    alignItems: "flex-start",
+                                    minHeight: 76,
+                                    marginInlineEnd: 0,
+                                    padding: "12px 14px",
+                                    borderRadius: 12,
+                                    border: `1px solid ${selected ? colors.accent : colors.border}`,
+                                    background: selected ? colors.primaryBg : colors.bgElevated,
+                                }}
+                            >
+                                <span style={{display: "inline-flex", flexDirection: "column", gap: 4, paddingLeft: 4}}>
+                                    <Text strong style={{color: colors.text}}>{t(`displayMode.${mode}.label`)}</Text>
+                                    <Text type="secondary" style={{fontSize: 12, lineHeight: 1.45}}>
+                                        {t(`displayMode.${mode}.description`)}
+                                    </Text>
+                                </span>
+                            </Radio>
+                        );
+                    })}
+                </Radio.Group>
+
+                <Text type="secondary" style={{fontSize: 12}}>
+                    {t("displayMode.reducedMotion")}
+                </Text>
+            </Space>
+        </Card>
+    );
+};

--- a/gui/web/src/components/settings/SettingsNav.tsx
+++ b/gui/web/src/components/settings/SettingsNav.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Badge, Menu, Tabs } from "antd";
 import {
     AimOutlined,
+    BgColorsOutlined,
     CloudOutlined,
     CodeOutlined,
     CompassOutlined,
@@ -22,6 +23,7 @@ import { useThemeMode } from "../../theme/ThemeContext.tsx";
 import { SettingsSection, SectionMeta } from "../../hooks/useSettingsManager.ts";
 
 const SECTION_ICONS: Record<string, React.ReactNode> = {
+    "bg-colors": <BgColorsOutlined />,
     tool: <ToolOutlined />,
     dashboard: <DashboardOutlined />,
     global: <GlobalOutlined />,

--- a/gui/web/src/concept/components/ActionCluster.tsx
+++ b/gui/web/src/concept/components/ActionCluster.tsx
@@ -64,18 +64,14 @@ export function ActionCluster({phase, onStart, onPause, onHome, onStop, onRearm}
           overflow: "hidden",
         }}
       >
-        {/* inner shine sweep -- clip to the circle by inheriting the parent's
-            border-radius (overflow:hidden on the framer-motion button is
-            unreliable because the press transform creates a new stacking
-            context). */}
+        {/* Static inner sheen keeps the primary action dimensional without a
+            continuous animation during long mowing sessions. */}
         <span aria-hidden style={{
           position: "absolute", inset: 0,
           borderRadius: "inherit",
           background: "linear-gradient(115deg, transparent 25%, rgba(255,255,255,0.45) 50%, transparent 75%)",
           mixBlendMode: "overlay",
           opacity: 0.55,
-          transform: "translateX(-100%)",
-          animation: "concept-shine 3.6s var(--ease-out) infinite",
           pointerEvents: "none",
         }}/>
         <motion.div
@@ -129,7 +125,6 @@ function SecondaryButton({children, ariaLabel, onClick, tone = "default"}: Secon
         border: `1px solid ${colors.border}`,
         color: colors.color,
         display: "flex", alignItems: "center", justifyContent: "center",
-        backdropFilter: "blur(20px)",
       }}
     >
       {children}

--- a/gui/web/src/concept/components/GlassCard.tsx
+++ b/gui/web/src/concept/components/GlassCard.tsx
@@ -4,8 +4,9 @@ import {riseFade} from "../motion";
 import {useThemeMode} from "../../theme/ThemeContext.tsx";
 
 /**
- * Glass surface with the luminous edge gradient handled by `.glass` in
- * concept.css. Pass `glow` for the lime-halo variant used on the hero.
+ * Layered surface with the luminous edge gradient handled by `.glass` in
+ * concept.css. Visual mode enables the glass blur; other modes preserve the
+ * same edge, hierarchy, and contrast without re-filtering the backdrop.
  */
 
 type Variant = "default" | "elevated" | "glow";
@@ -33,14 +34,18 @@ export function GlassCard({
   motionVariants,
   onClick,
 }: GlassCardProps) {
-  const {colors} = useThemeMode();
+  const {colors, displayMode} = useThemeMode();
   const inner = (
     <div
       onClick={onClick}
       className={`glass ${className}`}
       style={{
         padding,
-        background: variant === "elevated" ? colors.bgElevated : colors.bgCard,
+        background: variant === "elevated"
+          ? colors.bgElevated
+          : displayMode === 'efficient' ? colors.bgCard : colors.glassBackground,
+        backdropFilter: displayMode === 'visual' ? 'blur(20px) saturate(135%)' : undefined,
+        WebkitBackdropFilter: displayMode === 'visual' ? 'blur(20px) saturate(135%)' : undefined,
         boxShadow: variant === "glow"
           ? "var(--shadow-card), var(--shadow-glow-lime)"
           : "var(--shadow-card)",

--- a/gui/web/src/concept/components/GlassCard.tsx
+++ b/gui/web/src/concept/components/GlassCard.tsx
@@ -1,6 +1,7 @@
 import type {CSSProperties, ReactNode} from "react";
 import {motion, type Variants} from "framer-motion";
 import {riseFade} from "../motion";
+import {useThemeMode} from "../../theme/ThemeContext.tsx";
 
 /**
  * Glass surface with the luminous edge gradient handled by `.glass` in
@@ -32,17 +33,14 @@ export function GlassCard({
   motionVariants,
   onClick,
 }: GlassCardProps) {
+  const {colors} = useThemeMode();
   const inner = (
     <div
       onClick={onClick}
       className={`glass ${className}`}
       style={{
         padding,
-        background: variant === "elevated"
-          ? "var(--bg-elevated)"
-          : variant === "glow"
-            ? "var(--bg-card)"
-            : "var(--bg-card)",
+        background: variant === "elevated" ? colors.bgElevated : colors.bgCard,
         boxShadow: variant === "glow"
           ? "var(--shadow-card), var(--shadow-glow-lime)"
           : "var(--shadow-card)",

--- a/gui/web/src/concept/components/LiveMapMini.tsx
+++ b/gui/web/src/concept/components/LiveMapMini.tsx
@@ -175,16 +175,6 @@ export function LiveMapMini({
           {/* core */}
           <circle r={5.5} fill="var(--bg-deep)" stroke="var(--lime)" strokeWidth={1.6}/>
           <circle r={3.2} fill="var(--lime)"/>
-          {/* sonar pulse */}
-          <motion.circle
-            r={5.5}
-            fill="none"
-            stroke="rgba(124,255,178,0.65)"
-            strokeWidth={1}
-            initial={{r: 5.5, opacity: 0.55}}
-            animate={{r: [5.5, 28], opacity: [0.55, 0]}}
-            transition={{duration: 1.8, ease: "easeOut", repeat: Infinity}}
-          />
         </g>
 
         {/* dock marker */}

--- a/gui/web/src/concept/components/StatusOrb.tsx
+++ b/gui/web/src/concept/components/StatusOrb.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from "react";
-import {motion} from "framer-motion";
+import {motion, useReducedMotion} from "framer-motion";
 
 /**
  * Pulsing status orb used in the dashboard header. Three accent colors
@@ -10,7 +10,7 @@ import {motion} from "framer-motion";
 type Tone = "live" | "resting" | "alert" | "charging";
 
 const TONE_MAP: Record<Tone, {color: string; glow: string; pulse: boolean}> = {
-  live:     {color: "var(--lime)",       glow: "rgba(124, 255, 178, 0.65)", pulse: true},
+  live:     {color: "var(--lime)",       glow: "rgba(124, 255, 178, 0.65)", pulse: false},
   resting:  {color: "var(--aurora-cyan)", glow: "rgba(69, 214, 232, 0.55)",  pulse: false},
   alert:    {color: "var(--rose)",       glow: "rgba(255, 107, 122, 0.65)", pulse: true},
   charging: {color: "var(--lime)",       glow: "rgba(124, 255, 178, 0.5)",  pulse: false},
@@ -24,6 +24,7 @@ interface StatusOrbProps {
 
 export function StatusOrb({tone = "live", size = 10, label}: StatusOrbProps) {
   const t = TONE_MAP[tone];
+  const reduceMotion = useReducedMotion();
   return (
     <div style={{
       display: "inline-flex", alignItems: "center", gap: 8,
@@ -40,7 +41,7 @@ export function StatusOrb({tone = "live", size = 10, label}: StatusOrbProps) {
           opacity: 0.7,
         }}/>
         {/* pulse ring */}
-        {t.pulse && (
+        {t.pulse && !reduceMotion && (
           <motion.span
             style={{
               position: "absolute", inset: 0,

--- a/gui/web/src/concept/components/WeatherChip.tsx
+++ b/gui/web/src/concept/components/WeatherChip.tsx
@@ -39,7 +39,6 @@ export function WeatherChip({condition, tempC, rainSoon}: WeatherChipProps) {
       border: `1px solid ${warn ? "rgba(243, 168, 92, 0.32)" : "var(--border-soft)"}`,
       borderRadius: "var(--radius-pill)",
       color: warn ? "var(--amber)" : "var(--ink)",
-      backdropFilter: "blur(20px)",
       fontSize: 13, fontWeight: 600,
     }}>
       <Icon size={16} strokeWidth={2}/>

--- a/gui/web/src/concept/concept.css
+++ b/gui/web/src/concept/concept.css
@@ -26,12 +26,11 @@
 [data-concept] .display { font-family: var(--font-display); }
 [data-concept] .mono    { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
-/* glass surface util */
+/* Layer-free glass surface util. The opaque card tone preserves contrast
+   without forcing the browser to re-filter everything behind each card. */
 [data-concept] .glass {
   position: relative;
-  background: var(--bg-card);
-  backdrop-filter: blur(28px) saturate(140%);
-  -webkit-backdrop-filter: blur(28px) saturate(140%);
+  background: var(--bg-card-solid);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-soft);
   box-shadow: var(--shadow-card);

--- a/gui/web/src/concept/tokens.css
+++ b/gui/web/src/concept/tokens.css
@@ -1,5 +1,5 @@
 /* MowgliNext — premium concept tokens.
-   Tech-garden aesthetic: deep emerald canvas, liquid-glass surfaces,
+   Tech-garden aesthetic: deep emerald canvas, layered dark surfaces,
    lime/aurora accents, soft luminous borders.
 
    COLOUR vars (--lime, --ink, --bg-deep, …) are injected at runtime onto

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -9,6 +9,7 @@ import { ContentType } from "../api/Api.ts";
 import { valuesMatch } from "../utils/settingsValues.ts";
 
 export type SettingsSection =
+    | "appearance"
     | "hardware"
     | "drive_motor"
     | "ntrip"
@@ -33,6 +34,13 @@ export type SectionMeta = {
 };
 
 const SECTION_DEFINITIONS: SectionMeta[] = [
+    {
+        id: "appearance",
+        label: "settingsSections.appearance.label",
+        icon: "bg-colors",
+        description: "settingsSections.appearance.description",
+        keys: [],
+    },
     {
         id: "hardware",
         label: "settingsSections.hardware.label",

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2939,6 +2939,10 @@
     "errorOccurred": "An error occured"
   },
   "settingsSections": {
+    "appearance": {
+      "label": "Appearance",
+      "description": "Visual richness and energy use on this device"
+    },
     "hardware": {
       "label": "Hardware",
       "description": "Robot model, wheels, chassis, and blade dimensions"
@@ -3007,6 +3011,23 @@
       "drivePidUpdateFailed": "Settings saved, but live drive-PID update failed",
       "drivePidUpdateFailedDescription": "Restart ROS2 to apply the new drive-motor PID gains.",
       "saveFailed": "Failed to save settings"
+    }
+  },
+  "displayMode": {
+    "title": "Display mode",
+    "description": "Choose the balance of visual richness, responsiveness, and energy use for this browser.",
+    "reducedMotion": "Your system's reduced-motion setting always limits non-essential motion.",
+    "visual": {
+      "label": "Visual",
+      "description": "Richer glass surfaces and subtle ambient feedback."
+    },
+    "balanced": {
+      "label": "Balanced",
+      "description": "The intended Mowgli look with efficient default rendering."
+    },
+    "efficient": {
+      "label": "Efficient",
+      "description": "Lower compositing and conservative visual update rates."
     }
   },
   "ntripProviders": {

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -2935,6 +2935,10 @@
     "errorOccurred": "Une erreur est survenue"
   },
   "settingsSections": {
+    "appearance": {
+      "label": "Apparence",
+      "description": "Richesse visuelle et consommation d'énergie sur cet appareil"
+    },
     "hardware": {
       "label": "Matériel",
       "description": "Modèle de robot, roues, châssis et dimensions de la lame"
@@ -3003,6 +3007,23 @@
       "drivePidUpdateFailed": "Réglages enregistrés, mais la mise à jour à chaud du PID des moteurs a échoué",
       "drivePidUpdateFailedDescription": "Redémarrez ROS2 pour appliquer les nouveaux gains PID des moteurs.",
       "saveFailed": "Échec de l'enregistrement des réglages"
+    }
+  },
+  "displayMode": {
+    "title": "Mode d'affichage",
+    "description": "Choisissez l'équilibre entre richesse visuelle, réactivité et consommation d'énergie pour ce navigateur.",
+    "reducedMotion": "Le réglage système de réduction des animations limite toujours les mouvements non essentiels.",
+    "visual": {
+      "label": "Visuel",
+      "description": "Surfaces vitrées plus riches et retours d'ambiance subtils."
+    },
+    "balanced": {
+      "label": "Équilibré",
+      "description": "L'apparence Mowgli prévue avec un rendu efficace par défaut."
+    },
+    "efficient": {
+      "label": "Efficace",
+      "description": "Moins de composition graphique et des mises à jour visuelles prudentes."
     }
   },
   "ntripProviders": {

--- a/gui/web/src/main.tsx
+++ b/gui/web/src/main.tsx
@@ -4,6 +4,7 @@ import {createHashRouter, RouterProvider,} from "react-router-dom";
 import AppShell from "./components/AppShell.tsx";
 import {App, ConfigProvider, theme} from "antd";
 import {Spinner} from "./components/Spinner.tsx";
+import {MotionConfig} from "framer-motion";
 import {ThemeProvider, useThemeMode} from "./theme/ThemeContext.tsx";
 import {NotificationCenterProvider} from "./hooks/useNotificationCenter.tsx";
 import "./i18n";
@@ -123,11 +124,13 @@ function ThemedApp() {
             },
         }}>
             <App style={{height: "100%"}}>
-                <NotificationCenterProvider>
-                    <React.Suspense fallback={<Spinner/>}>
-                        <RouterProvider router={router}/>
-                    </React.Suspense>
-                </NotificationCenterProvider>
+                <MotionConfig reducedMotion="user">
+                    <NotificationCenterProvider>
+                        <React.Suspense fallback={<Spinner/>}>
+                            <RouterProvider router={router}/>
+                        </React.Suspense>
+                    </NotificationCenterProvider>
+                </MotionConfig>
             </App>
         </ConfigProvider>
     );

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -1116,7 +1116,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                 )}
                 {/* Desktop: View mode — bottom glass toolbar */}
                 {!isMobile && !editMap && (
-                    <div style={{position: 'absolute', bottom: 12, left: 16, right: 16, zIndex: 10, background: colors.glassBackground, backdropFilter: 'blur(22px) saturate(140%)', WebkitBackdropFilter: 'blur(22px) saturate(140%)', borderRadius: 18, border: colors.glassBorder, boxShadow: colors.glassShadow, padding: '10px 14px'}}>
+                    <div style={{position: 'absolute', bottom: 12, left: 16, right: 16, zIndex: 10, background: colors.glassBackground, borderRadius: 18, border: colors.glassBorder, boxShadow: colors.glassShadow, padding: '10px 14px'}}>
                         <MapToolbar
                             manualMode={manualMode}
                             useSatellite={useSatellite}
@@ -1145,7 +1145,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                 )}
                 {/* Desktop: Right panel — areas list + offset */}
                 {!isMobile && (
-                    <div style={{position: 'absolute', top: 12, right: 16, zIndex: 10, display: 'flex', flexDirection: 'column', gap: 0, width: 240, maxHeight: 'calc(100% - 32px)', background: colors.glassBackground, backdropFilter: 'blur(22px) saturate(140%)', WebkitBackdropFilter: 'blur(22px) saturate(140%)', borderRadius: 18, border: colors.glassBorder, boxShadow: colors.glassShadow, overflow: 'hidden'}}>
+                    <div style={{position: 'absolute', top: 12, right: 16, zIndex: 10, display: 'flex', flexDirection: 'column', gap: 0, width: 240, maxHeight: 'calc(100% - 32px)', background: colors.glassBackground, borderRadius: 18, border: colors.glassBorder, boxShadow: colors.glassShadow, overflow: 'hidden'}}>
                         <AreasListPanel
                             areas={areasList}
                             onAreaClick={editMap ? handleAreaSelect : undefined}

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -29,6 +29,7 @@ import { NavigationSection } from "../components/settings/NavigationSection.tsx"
 import { RainSection } from "../components/settings/RainSection.tsx";
 import { AdvancedSection } from "../components/settings/AdvancedSection.tsx";
 import { SettingsPreview } from "../components/settings/SettingsPreview.tsx";
+import { DisplayModeSection } from "../components/settings/DisplayModeSection.tsx";
 
 const { Text } = Typography;
 
@@ -111,6 +112,8 @@ export const SettingsPage = () => {
 
     const renderSection = () => {
         switch (activeSection) {
+            case "appearance":
+                return <DisplayModeSection />;
             case "hardware":
                 return (
                     <HardwareSection

--- a/gui/web/src/pages/map/components/JoystickOverlay.tsx
+++ b/gui/web/src/pages/map/components/JoystickOverlay.tsx
@@ -66,8 +66,6 @@ export const JoystickOverlay = ({
                 background: colors.glassBackground,
                 border: `1px solid ${limeAlpha(0.28)}`,
                 boxShadow: `0 10px 30px -10px rgba(0,0,0,0.6), inset 0 0 24px ${limeAlpha(0.06)}`,
-                backdropFilter: "blur(8px)",
-                WebkitBackdropFilter: "blur(8px)",
             }}>
                 <Joystick
                     size={size}

--- a/gui/web/src/pages/map/components/MapEditorToolbar.tsx
+++ b/gui/web/src/pages/map/components/MapEditorToolbar.tsx
@@ -120,8 +120,6 @@ export const MapEditorToolbar = ({
         flexDirection: 'column',
         gap: 2,
         background: colors.glassBackground,
-        backdropFilter: 'blur(16px) saturate(180%)',
-        WebkitBackdropFilter: 'blur(16px) saturate(180%)',
         borderRadius: 12,
         border: colors.glassBorder,
         boxShadow: colors.glassShadow,

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -142,8 +142,6 @@ export const MapToolbarMobile = ({
         WebkitOverflowScrolling: "touch",
         alignItems: "center",
         background: colors.glassBackground,
-        backdropFilter: "blur(22px) saturate(140%)",
-        WebkitBackdropFilter: "blur(22px) saturate(140%)",
         borderRadius: 18,
         border: colors.glassBorder,
         boxShadow: colors.glassShadow,

--- a/gui/web/src/theme/ThemeContext.test.tsx
+++ b/gui/web/src/theme/ThemeContext.test.tsx
@@ -1,0 +1,48 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {ThemeProvider, useThemeMode} from './ThemeContext.tsx';
+
+function DisplayModeProbe() {
+    const {displayMode, setDisplayMode} = useThemeMode();
+
+    return (
+        <>
+            <output data-testid="display-mode">{displayMode}</output>
+            <button onClick={() => setDisplayMode('visual')}>Visual</button>
+        </>
+    );
+}
+
+describe('ThemeProvider display mode', () => {
+    beforeEach(() => {
+        const storage = new Map<string, string>();
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: (key: string) => storage.get(key) ?? null,
+                setItem: (key: string, value: string) => storage.set(key, value),
+                removeItem: (key: string) => storage.delete(key),
+                clear: () => storage.clear(),
+            },
+        });
+        document.documentElement.removeAttribute('data-display-mode');
+    });
+
+    it('uses Balanced by default and writes it to the document', async () => {
+        render(<ThemeProvider><DisplayModeProbe/></ThemeProvider>);
+
+        expect(screen.getByTestId('display-mode')).toHaveTextContent('balanced');
+        await waitFor(() => expect(document.documentElement.dataset.displayMode).toBe('balanced'));
+    });
+
+    it('restores and persists a selected display mode', async () => {
+        window.localStorage.setItem('mowgli.display-mode', 'efficient');
+        render(<ThemeProvider><DisplayModeProbe/></ThemeProvider>);
+
+        expect(screen.getByTestId('display-mode')).toHaveTextContent('efficient');
+        fireEvent.click(screen.getByRole('button', {name: 'Visual'}));
+
+        await waitFor(() => expect(document.documentElement.dataset.displayMode).toBe('visual'));
+        expect(window.localStorage.getItem('mowgli.display-mode')).toBe('visual');
+    });
+});

--- a/gui/web/src/theme/ThemeContext.tsx
+++ b/gui/web/src/theme/ThemeContext.tsx
@@ -1,17 +1,39 @@
-import {createContext, useCallback, useContext, useEffect} from "react";
+import {createContext, useCallback, useContext, useEffect, useState} from "react";
 import type {ThemeMode} from "./colors.ts";
 import {cssVars, getColors, setColors} from "./colors.ts";
+
+export const DISPLAY_MODES = ['visual', 'balanced', 'efficient'] as const;
+export type DisplayMode = typeof DISPLAY_MODES[number];
+
+const DISPLAY_MODE_STORAGE_KEY = 'mowgli.display-mode';
+
+function isDisplayMode(value: string | null): value is DisplayMode {
+    return value !== null && (DISPLAY_MODES as readonly string[]).includes(value);
+}
+
+function readDisplayMode(): DisplayMode {
+    try {
+        const stored = window.localStorage.getItem(DISPLAY_MODE_STORAGE_KEY);
+        return isDisplayMode(stored) ? stored : 'balanced';
+    } catch {
+        return 'balanced';
+    }
+}
 
 interface ThemeContextValue {
     mode: ThemeMode;
     toggleMode: () => void;
     colors: ReturnType<typeof getColors>;
+    displayMode: DisplayMode;
+    setDisplayMode: (mode: DisplayMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
     mode: 'light',
     toggleMode: () => {},
     colors: getColors('light'),
+    displayMode: 'balanced',
+    setDisplayMode: () => {},
 });
 
 // Mowgli is dark-mode-only. The light tokens stay in `colors.ts` for now in
@@ -20,6 +42,7 @@ const ThemeContext = createContext<ThemeContextValue>({
 export function ThemeProvider({children}: {children: React.ReactNode}) {
     const mode: ThemeMode = 'dark';
     const colors = getColors(mode);
+    const [displayMode, setDisplayMode] = useState<DisplayMode>(readDisplayMode);
 
     useEffect(() => {
         setColors(mode);
@@ -39,8 +62,18 @@ export function ThemeProvider({children}: {children: React.ReactNode}) {
 
     const toggleMode = useCallback(() => { /* dark-only */ }, []);
 
+    useEffect(() => {
+        document.documentElement.dataset.displayMode = displayMode;
+        try {
+            window.localStorage.setItem(DISPLAY_MODE_STORAGE_KEY, displayMode);
+        } catch {
+            // Private browsing or a locked-down WebView can reject storage.
+            // The selected mode still applies for this session.
+        }
+    }, [displayMode]);
+
     return (
-        <ThemeContext.Provider value={{mode, toggleMode, colors}}>
+        <ThemeContext.Provider value={{mode, toggleMode, colors, displayMode, setDisplayMode}}>
             {children}
         </ThemeContext.Provider>
     );

--- a/gui/web/src/theme/colors.ts
+++ b/gui/web/src/theme/colors.ts
@@ -132,7 +132,7 @@ const LIGHT: ColorTokens = {
   muted: '#707070',
   border: 'rgba(0, 0, 0, 0.08)',
   borderSubtle: 'rgba(0, 0, 0, 0.05)',
-  glassBackground: 'rgba(255, 255, 255, 0.85)',
+  glassBackground: 'rgba(255, 255, 255, 0.96)',
   glassBorder: '1px solid rgba(0, 0, 0, 0.08)',
   glassShadow: '0 2px 12px rgba(0, 0, 0, 0.08)',
 
@@ -182,7 +182,7 @@ const DARK: ColorTokens = {
   muted: inkAlpha(0.50),
   border: inkAlpha(0.07),
   borderSubtle: inkAlpha(0.04),
-  glassBackground: 'rgba(11, 24, 20, 0.78)',
+  glassBackground: 'rgba(11, 24, 20, 0.94)',
   glassBorder: `1px solid ${inkAlpha(0.08)}`,
   glassShadow: '0 24px 60px -20px rgba(0, 0, 0, 0.7), 0 4px 16px -4px rgba(0, 0, 0, 0.4)',
 

--- a/gui/web/tests/e2e/visual-effects.spec.ts
+++ b/gui/web/tests/e2e/visual-effects.spec.ts
@@ -5,6 +5,12 @@ import { SCENARIOS } from "./mock/scenarios.ts";
 const mowing = SCENARIOS.find(({ name }) => name === "mowing-area2-rtk-fixed")!;
 const emergency = SCENARIOS.find(({ name }) => name === "emergency-latched")!;
 
+async function setDisplayMode(page: Page, mode: "visual" | "balanced" | "efficient") {
+  await page.addInitScript((selectedMode) => {
+    window.localStorage.setItem("mowgli.display-mode", selectedMode);
+  }, mode);
+}
+
 const activeVisualEffects = (page: Page) =>
   page.evaluate(() => {
     const blurred = [...document.querySelectorAll<HTMLElement>("*")].filter(
@@ -39,9 +45,10 @@ const activeVisualEffects = (page: Page) =>
     };
   });
 
-test("long-running mowing views avoid continuous decorative effects", async ({
+test("Balanced and Efficient views avoid continuous decorative effects", async ({
   page,
 }) => {
+  await setDisplayMode(page, "balanced");
   await installMockBackend(page, mowing);
 
   for (const route of ["/mowglinext", "/settings", "/map"]) {
@@ -49,12 +56,20 @@ test("long-running mowing views avoid continuous decorative effects", async ({
     await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
     await page.waitForTimeout(1_500);
 
+    await expect(page.locator("html")).toHaveAttribute("data-display-mode", "balanced");
     const result = await activeVisualEffects(page);
     expect(result, `${route} visual effects`).toEqual({
       blurCount: 0,
       blurAreaPx: 0,
       infiniteAnimationNames: [],
     });
+
+    if (route === "/mowglinext") {
+      await page.screenshot({
+        path: "tests/e2e/.artifacts/mowglinext__balanced-mode.png",
+        fullPage: true,
+      });
+    }
   }
 
   await page.setViewportSize({ width: 390, height: 844 });
@@ -72,6 +87,47 @@ test("long-running mowing views avoid continuous decorative effects", async ({
       infiniteAnimationNames: [],
     });
   }
+});
+
+test("Visual mode restores glass depth and restrained active-state motion", async ({
+  page,
+}) => {
+  await setDisplayMode(page, "visual");
+  await installMockBackend(page, mowing);
+  await page.goto("/#/mowglinext");
+  await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+  await page.waitForTimeout(1_500);
+
+  await expect(page.locator("html")).toHaveAttribute("data-display-mode", "visual");
+  const result = await activeVisualEffects(page);
+  expect(result.blurCount).toBeGreaterThan(0);
+  expect(result.blurAreaPx).toBeGreaterThan(0);
+  expect(result.infiniteAnimationNames).toEqual(
+    expect.arrayContaining(["liveStripSheen", "mowerPulseGreen"]),
+  );
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/mowglinext__visual-mode.png",
+    fullPage: true,
+  });
+});
+
+test("Efficient mode keeps the low-compositing rendering path", async ({page}) => {
+  await setDisplayMode(page, "efficient");
+  await installMockBackend(page, mowing);
+  await page.goto("/#/mowglinext");
+  await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+  await page.waitForTimeout(1_500);
+
+  await expect(page.locator("html")).toHaveAttribute("data-display-mode", "efficient");
+  expect(await activeVisualEffects(page)).toEqual({
+    blurCount: 0,
+    blurAreaPx: 0,
+    infiniteAnimationNames: [],
+  });
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/mowglinext__efficient-mode.png",
+    fullPage: true,
+  });
 });
 
 test("emergency state retains its focused visual emphasis", async ({
@@ -96,6 +152,7 @@ test("emergency emphasis respects reduced-motion preference", async ({
   page,
 }) => {
   await page.emulateMedia({ reducedMotion: "reduce" });
+  await setDisplayMode(page, "visual");
   await installMockBackend(page, emergency);
   await page.goto("/#/mowglinext");
   await page.getByText("MOWGLI").first().waitFor({ state: "visible" });

--- a/gui/web/tests/e2e/visual-effects.spec.ts
+++ b/gui/web/tests/e2e/visual-effects.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installMockBackend } from "./mock/mockBackend.ts";
+import { SCENARIOS } from "./mock/scenarios.ts";
+
+const mowing = SCENARIOS.find(({ name }) => name === "mowing-area2-rtk-fixed")!;
+const emergency = SCENARIOS.find(({ name }) => name === "emergency-latched")!;
+
+const activeVisualEffects = (page: Page) =>
+  page.evaluate(() => {
+    const blurred = [...document.querySelectorAll<HTMLElement>("*")].filter(
+      (element) => {
+        const style = getComputedStyle(element);
+        const webkitBackdrop = style.getPropertyValue(
+          "-webkit-backdrop-filter",
+        );
+        return (
+          style.backdropFilter !== "none" ||
+          (webkitBackdrop !== "" && webkitBackdrop !== "none")
+        );
+      },
+    );
+    const infinite = document.getAnimations().filter((animation) => {
+      const iterations = animation.effect?.getTiming().iterations;
+      return iterations === Infinity && animation.playState === "running";
+    });
+
+    return {
+      blurCount: blurred.length,
+      blurAreaPx: Math.round(
+        blurred.reduce((sum, element) => {
+          const rect = element.getBoundingClientRect();
+          return sum + rect.width * rect.height;
+        }, 0),
+      ),
+      infiniteAnimationNames: infinite.map(
+        (animation) =>
+          (animation as CSSAnimation).animationName || "script-animation",
+      ),
+    };
+  });
+
+test("long-running mowing views avoid continuous decorative effects", async ({
+  page,
+}) => {
+  await installMockBackend(page, mowing);
+
+  for (const route of ["/mowglinext", "/settings", "/map"]) {
+    await page.goto(`/#${route}`);
+    await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+    await page.waitForTimeout(1_500);
+
+    const result = await activeVisualEffects(page);
+    expect(result, `${route} visual effects`).toEqual({
+      blurCount: 0,
+      blurAreaPx: 0,
+      infiniteAnimationNames: [],
+    });
+  }
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  for (const route of ["/mowglinext", "/map"]) {
+    await page.goto(`/#${route}`);
+    await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+    await page.waitForTimeout(1_500);
+
+    expect(
+      await activeVisualEffects(page),
+      `${route} mobile visual effects`,
+    ).toEqual({
+      blurCount: 0,
+      blurAreaPx: 0,
+      infiniteAnimationNames: [],
+    });
+  }
+});
+
+test("emergency state retains its focused visual emphasis", async ({
+  page,
+}) => {
+  await installMockBackend(page, emergency);
+  await page.goto("/#/mowglinext");
+  await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+  await page.waitForTimeout(1_500);
+
+  const { infiniteAnimationNames } = await activeVisualEffects(page);
+  expect(infiniteAnimationNames).toEqual(
+    expect.arrayContaining([
+      "liveStripPulse",
+      "mowerPulseRed",
+      "script-animation",
+    ]),
+  );
+});
+
+test("emergency emphasis respects reduced-motion preference", async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await installMockBackend(page, emergency);
+  await page.goto("/#/mowglinext");
+  await page.getByText("MOWGLI").first().waitFor({ state: "visible" });
+  await page.waitForTimeout(1_500);
+
+  const result = await activeVisualEffects(page);
+  expect(result.infiniteAnimationNames).toEqual([]);
+  await page.screenshot({
+    path: "tests/e2e/.artifacts/emergency-reduced-motion.png",
+    fullPage: true,
+  });
+});


### PR DESCRIPTION
Closes part of #430.

## Problem

The GUI kept multiple full-time backdrop filters and decorative animations active during long mowing sessions. These effects require continued compositing even when the underlying status has not changed, and reduced-motion preferences did not stop every scripted animation.

## Change

- Replace backdrop-filter surfaces in the production shell, cards, map controls, and mobile overlays with opaque theme-aware surfaces.
- Keep moving-state cues visible as static color and glow instead of continuous green pulses, sheen sweeps, and map sonar rings.
- Retain focused red emergency pulses for users without a motion reduction preference.
- Apply `MotionConfig reducedMotion="user"`, CSS reduced-motion guards, and an explicit `useReducedMotion` check for the scripted emergency orb.
- Limit notification-bell movement to two cycles.
- Add desktop and mobile browser regression tests for filtered surfaces, infinite animations, emergency emphasis, and reduced motion.

## Measured impact

Measurements use the same 1440x900 Chromium viewport and mocked mowing state before and after the change:

| View | Before | After |
| --- | ---: | ---: |
| Home backdrop-filter surfaces | 11 / 878,022 px | 0 / 0 px |
| Home infinite animations | 4 | 0 |
| Settings backdrop-filter surfaces | 6 / 605,903 px | 0 / 0 px |
| Settings infinite animations | 2 | 0 |
| Map backdrop-filter surfaces | 2 / 167,343 px | 0 / 0 px |
| Map infinite animations | 2 | 0 |

Emergency mode still exposes the red strip, status badge, and alert-orb animations. With `prefers-reduced-motion: reduce`, no infinite animation remains.

## Verification

- Playwright Chromium suite: 67 passed
- Desktop and mobile visual-effect assertions: passed
- Standard and reduced-motion emergency assertions: passed
- TypeScript: passed
- Vite production build: passed
- Docker `build-web` target: passed
- Full Vitest run at measurement time: 250 passed and 2 outdated manual-mode expectations; those expectations are corrected in #440
- Visual review of mowing and reduced-motion emergency screenshots: passed
- Formatting, diff, and credential-pattern checks: passed
