### PR TITLE
fix(gui): align schema defaults with robot template

### DIFF
--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -208,7 +208,7 @@
         "lidar_z": {
           "type": "number",
           "title": "LiDAR Offset Z",
-          "default": 0.22,
+          "default": 0.30,
           "description": "Body-frame up offset of LiDAR from base_footprint (metres)."
         },
         "lidar_yaw": {
@@ -670,7 +670,7 @@
         "obstacle_wait_timeout_s": {
           "type": "number",
           "title": "Obstacle Wait Timeout",
-          "default": 5.0,
+          "default": 2.5,
           "description": "How long (s) to wait in place when an obstacle blocks every detour before giving up on the current strip. Lets transient blockages (a person walking past) clear without aborting. Clamped to [0.5, 60.0] at launch."
         },
         "max_obstacle_avoidance_distance": {
@@ -764,7 +764,7 @@
         "yaw_goal_tolerance": {
           "type": "number",
           "title": "Yaw Goal Tolerance",
-          "default": 0.2,
+          "default": 0.1,
           "description": "Acceptable heading error at goal (radians)."
         },
         "coverage_xy_tolerance": {
@@ -776,7 +776,7 @@
         "progress_timeout_sec": {
           "type": "number",
           "title": "Progress Timeout",
-          "default": 10.0,
+          "default": 30.0,
           "description": "Seconds without progress before recovery."
         }
       }


### PR DESCRIPTION
## Problem

Four GUI schema defaults no longer matched the checked-in ROS2 robot template. The settings UI could therefore label values as “at default” even though a fresh robot configuration would run different values.

## Change

Align the schema with `ros2/src/mowgli_bringup/config/mowgli_robot.yaml`:

| Key | Schema before | Robot-template default |
| --- | ---: | ---: |
| `lidar_z` | 0.22 | 0.30 |
| `obstacle_wait_timeout_s` | 5.0 | 2.5 |
| `yaw_goal_tolerance` | 0.2 | 0.1 |
| `progress_timeout_sec` | 10.0 | 30.0 |

## Verification

- Schema JSON validation: passed
- Schema/template parity test: passed
- Full Go suite: passed
- `go vet ./...`: passed
- `go build ./...`: passed
- All Go commands ran with Go 1.24 in a non-root container and a read-only source mount
- Diff and credential-pattern checks: passed
