### PR TITLE
feat(gui): add landscape manual controller

### DIFF
--- a/gui/web/src/components/AppShell.tsx
+++ b/gui/web/src/components/AppShell.tsx
@@ -65,6 +65,7 @@ const PAGE_META: Record<string, {titleKey: string; subtitleKey?: string}> = {
   '/statistics':  {titleKey: 'pageMeta.statistics.title', subtitleKey: 'pageMeta.statistics.subtitle'},
   '/settings':    {titleKey: 'nav.settings',             subtitleKey: 'pageMeta.settings.subtitle'},
   '/parameters':  {titleKey: 'nav.parameters',           subtitleKey: 'pageMeta.parameters.subtitle'},
+  '/manual-control': {titleKey: 'nav.manualControl', subtitleKey: 'pageMeta.manualControl.subtitle'},
   '/logs':        {titleKey: 'nav.logs',                 subtitleKey: 'pageMeta.logs.subtitle'},
   '/onboarding':  {titleKey: 'nav.onboarding'},
 };

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -13,6 +13,8 @@
     "stats": "Stats",
     "settings": "Settings",
     "parameters": "Parameters",
+    "manualControl": "Manual Control",
+    "manualShort": "Control",
     "logs": "Logs",
     "onboarding": "Onboarding",
     "more": "More",
@@ -40,6 +42,9 @@
     },
     "parameters": {
       "subtitle": "Live ROS2 tuning"
+    },
+    "manualControl": {
+      "subtitle": "Joystick driving"
     },
     "logs": {
       "subtitle": "Container output"
@@ -3049,5 +3054,33 @@
   },
   "settingsSchema": {
     "loadFailed": "Failed to load settings schema"
+  },
+  "manualController": {
+    "ariaLabel": "Manual mower controller",
+    "title": "Manual control",
+    "subtitle": "Choose a mode, then drive under direct supervision.",
+    "combinedStick": "Drive and steer",
+    "combinedHint": "Forward / reverse · left / right",
+    "driveStick": "Drive",
+    "driveHint": "Forward / reverse",
+    "steerStick": "Steer",
+    "steerHint": "Turn left / right",
+    "keyboardHint": "Keyboard: W/S drive · A/D steer · Space stops motion. Controls work only after choosing Mow, Transport, or Record.",
+    "map": "Mower position",
+    "mapHint": "Lightweight live view",
+    "awaitingMap": "Waiting for a recorded map",
+    "livePosition": "Live position",
+    "speed": "{{value}} m/s",
+    "mow": "Mow",
+    "transport": "Transport",
+    "record": "Record",
+    "stop": "Stop",
+    "emergency": "Emergency stop",
+    "rearm": "Re-arm",
+    "rearmed": "Emergency stop released",
+    "emergencyActive": "EMERGENCY",
+    "emergencyTitle": "Emergency stop mower?",
+    "emergencyBody": "This immediately stops and latches the mower. Re-arm only when the area is safe.",
+    "cancel": "Cancel"
   }
 }

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -13,6 +13,8 @@
     "stats": "Stats",
     "settings": "Réglages",
     "parameters": "Paramètres",
+    "manualControl": "Contrôle manuel",
+    "manualShort": "Contrôle",
     "logs": "Logs",
     "onboarding": "Onboarding",
     "more": "Plus",
@@ -40,6 +42,9 @@
     },
     "parameters": {
       "subtitle": "Réglage ROS2 en direct"
+    },
+    "manualControl": {
+      "subtitle": "Conduite au joystick"
     },
     "logs": {
       "subtitle": "Sortie des conteneurs"
@@ -3049,5 +3054,33 @@
   },
   "settingsSchema": {
     "loadFailed": "Échec du chargement du schéma de réglages"
+  },
+  "manualController": {
+    "ariaLabel": "Contrôleur manuel de tondeuse",
+    "title": "Contrôle manuel",
+    "subtitle": "Choisissez un mode, puis conduisez sous surveillance directe.",
+    "combinedStick": "Conduite et direction",
+    "combinedHint": "Avancer / reculer · gauche / droite",
+    "driveStick": "Conduite",
+    "driveHint": "Avancer / reculer",
+    "steerStick": "Direction",
+    "steerHint": "Tourner à gauche / droite",
+    "keyboardHint": "Clavier : W/S pour avancer/reculer · A/D pour diriger · Espace arrête le mouvement. Les commandes ne fonctionnent qu'après avoir choisi Tondre, Transport ou Enregistrer.",
+    "map": "Position de la tondeuse",
+    "mapHint": "Vue légère en direct",
+    "awaitingMap": "En attente d'une carte enregistrée",
+    "livePosition": "Position en direct",
+    "speed": "{{value}} m/s",
+    "mow": "Tondre",
+    "transport": "Transport",
+    "record": "Enregistrer",
+    "stop": "Arrêter",
+    "emergency": "Arrêt d'urgence",
+    "rearm": "Réarmer",
+    "rearmed": "Arrêt d'urgence relâché",
+    "emergencyActive": "URGENCE",
+    "emergencyTitle": "Arrêter la tondeuse en urgence ?",
+    "emergencyBody": "Cette action arrête et verrouille immédiatement la tondeuse. Réarmez uniquement lorsque la zone est sûre.",
+    "cancel": "Annuler"
   }
 }

--- a/gui/web/src/main.tsx
+++ b/gui/web/src/main.tsx
@@ -19,6 +19,7 @@ const SchedulePage     = React.lazy(() => import("./pages/SchedulePage.tsx"));
 const DiagnosticsPage  = React.lazy(() => import("./pages/DiagnosticsPage.tsx"));
 const StatisticsPage   = React.lazy(() => import("./pages/StatisticsPage.tsx"));
 const ParametersPage   = React.lazy(() => import("./pages/ParametersPage.tsx"));
+const ManualControllerPage = React.lazy(() => import("./pages/ManualControllerPage.tsx"));
 const ConceptRoot      = React.lazy(() => import("./concept/ConceptRoot.tsx"));
 
 const router = createHashRouter([
@@ -67,6 +68,10 @@ const router = createHashRouter([
             {
                 element: <ParametersPage/>,
                 path: "/parameters",
+            },
+            {
+                element: <ManualControllerPage/>,
+                path: "/manual-control",
             }
         ]
     },

--- a/gui/web/src/pages/ManualControllerPage.test.tsx
+++ b/gui/web/src/pages/ManualControllerPage.test.tsx
@@ -1,0 +1,107 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {act, fireEvent, render, screen} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {App} from "antd";
+
+import {ManualControllerPage} from "./ManualControllerPage.tsx";
+import en from "../i18n/locales/en.json";
+
+const mowerAction = vi.fn(() => vi.fn().mockResolvedValue(undefined));
+const joyStream = {start: vi.fn(), stop: vi.fn(), sendJsonMessage: vi.fn()};
+const highLevelStatus = {state_name: "IDLE"};
+
+vi.mock("../components/MowerActions.tsx", () => ({useMowerAction: () => mowerAction}));
+vi.mock("../hooks/useHighLevelStatus.ts", () => ({useHighLevelStatus: () => ({highLevelStatus})}));
+vi.mock("../hooks/useMowingMap.ts", () => ({useMowingMap: () => ({})}));
+vi.mock("../hooks/useFusionOdom.ts", () => ({useFusionOdom: () => ({})}));
+vi.mock("../hooks/useWS.ts", () => ({useWS: () => joyStream}));
+
+function renderController() {
+    return render(<App><ManualControllerPage/></App>);
+}
+
+async function selectTransportAndConfirm(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole("button", {name: en.manualController.transport}));
+    highLevelStatus.state_name = "MANUAL_DRIVING";
+}
+
+describe("ManualControllerPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        highLevelStatus.state_name = "IDLE";
+    });
+
+    it("renders the combined controller and safety controls", () => {
+        renderController();
+        expect(screen.getByText(en.manualController.combinedStick)).toBeInTheDocument();
+        expect(screen.getByRole("button", {name: en.manualController.emergency})).toBeInTheDocument();
+    });
+
+    it("selects blade-disabled transport mode", async () => {
+        const user = userEvent.setup();
+        const view = renderController();
+        await selectTransportAndConfirm(user);
+        view.rerender(<App><ManualControllerPage/></App>);
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 650));
+        });
+        expect(mowerAction).toHaveBeenCalledWith("high_level_control", {Command: 9});
+        expect(joyStream.start).toHaveBeenCalledWith("/api/mowglinext/publish/joy");
+    });
+
+    it("sends and clears keyboard drive velocity only after a mode is selected", async () => {
+        const user = userEvent.setup();
+        const view = renderController();
+        fireEvent.keyDown(window, {key: "w"});
+        expect(joyStream.sendJsonMessage).not.toHaveBeenCalled();
+
+        await selectTransportAndConfirm(user);
+        view.rerender(<App><ManualControllerPage/></App>);
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 650));
+        });
+        fireEvent.keyDown(window, {key: "w"});
+        expect(joyStream.sendJsonMessage).toHaveBeenLastCalledWith(expect.objectContaining({
+            twist: expect.objectContaining({linear: expect.objectContaining({x: 0.25})}),
+        }));
+        fireEvent.keyUp(window, {key: "w"});
+        expect(joyStream.sendJsonMessage).toHaveBeenLastCalledWith(expect.objectContaining({
+            twist: expect.objectContaining({linear: expect.objectContaining({x: 0})}),
+        }));
+    });
+
+    it("combines forward input with left and right steering", async () => {
+        const user = userEvent.setup();
+        const view = renderController();
+        await selectTransportAndConfirm(user);
+        view.rerender(<App><ManualControllerPage/></App>);
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 650));
+        });
+
+        fireEvent.keyDown(window, {key: "w"});
+        fireEvent.keyDown(window, {key: "a"});
+        expect(joyStream.sendJsonMessage).toHaveBeenLastCalledWith(expect.objectContaining({
+            twist: expect.objectContaining({
+                linear: expect.objectContaining({x: 0.25}),
+                angular: expect.objectContaining({z: 0.6}),
+            }),
+        }));
+
+        fireEvent.keyUp(window, {key: "a"});
+        fireEvent.keyDown(window, {key: "d"});
+        expect(joyStream.sendJsonMessage).toHaveBeenLastCalledWith(expect.objectContaining({
+            twist: expect.objectContaining({
+                linear: expect.objectContaining({x: 0.25}),
+                angular: expect.objectContaining({z: -0.6}),
+            }),
+        }));
+    });
+
+    it("uses the stop-in-place command", async () => {
+        const user = userEvent.setup();
+        renderController();
+        await user.click(screen.getByRole("button", {name: en.manualController.stop}));
+        expect(mowerAction).toHaveBeenCalledWith("high_level_control", {Command: 8});
+    });
+});

--- a/gui/web/src/pages/ManualControllerPage.tsx
+++ b/gui/web/src/pages/ManualControllerPage.tsx
@@ -1,0 +1,336 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {App, Button, Tag} from "antd";
+import {Joystick} from "react-joystick-component";
+import type {IJoystickUpdateEvent} from "react-joystick-component/build/lib/Joystick";
+import {CircleDot, Gamepad2, MapPin, Radio, Scissors, Square, SquareDot} from "lucide-react";
+import {useTranslation} from "react-i18next";
+
+import {useMowerAction} from "../components/MowerActions.tsx";
+import {LiveMapMini, type MiniArea} from "../concept/components/LiveMapMini.tsx";
+import {useFusionOdom} from "../hooks/useFusionOdom.ts";
+import {useHighLevelStatus} from "../hooks/useHighLevelStatus.ts";
+import {useMowingMap} from "../hooks/useMowingMap.ts";
+import {useIsMobile} from "../hooks/useIsMobile.ts";
+import {useWS} from "../hooks/useWS.ts";
+import {useThemeMode} from "../theme/ThemeContext.tsx";
+import {limeAlpha} from "../theme/colors.ts";
+import type {TwistStamped} from "../types/ros.ts";
+
+const MAX_LINEAR_MPS = 0.25;
+const MAX_ANGULAR_RAD_S = 0.6;
+const ARM_SETTLE_MS = 600;
+
+type DriveMode = "mow" | "transport" | "record";
+
+const stateForMode: Record<DriveMode, string> = {
+    mow: "MANUAL_MOWING",
+    transport: "MANUAL_DRIVING",
+    record: "RECORDING",
+};
+
+const zeroTwist = (): TwistStamped => ({
+    header: {stamp: {sec: 0, nanosec: 0}, frame_id: ""},
+    twist: {
+        linear: {x: 0, y: 0, z: 0},
+        angular: {x: 0, y: 0, z: 0},
+    },
+});
+
+function normalisedMap(map: ReturnType<typeof useMowingMap>, odom: ReturnType<typeof useFusionOdom>) {
+    const areas = [...(map.working_area ?? []), ...(map.navigation_areas ?? [])]
+        .filter(area => (area.area?.points?.length ?? 0) >= 3);
+    const points = areas.flatMap(area => area.area?.points ?? []);
+    if (points.length === 0) return {polygons: [] as MiniArea[], robot: undefined};
+
+    const xs = points.map(point => point.x ?? 0);
+    const ys = points.map(point => point.y ?? 0);
+    const x0 = Math.min(...xs);
+    const y0 = Math.min(...ys);
+    const dx = Math.max(Math.max(...xs) - x0, 0.1);
+    const dy = Math.max(Math.max(...ys) - y0, 0.1);
+    const normalise = (x: number, y: number) => ({
+        x: 0.10 + 0.80 * (x - x0) / dx,
+        y: 0.90 - 0.80 * (y - y0) / dy,
+    });
+    const polygons = areas.map(area => ({
+        outer: (area.area?.points ?? []).map(point => normalise(point.x ?? 0, point.y ?? 0)),
+        holes: (area.obstacles ?? []).map(hole =>
+            (hole.points ?? []).map(point => normalise(point.x ?? 0, point.y ?? 0))),
+    }));
+    const position = odom.pose?.pose?.position;
+    const orientation = odom.pose?.pose?.orientation;
+    const heading = orientation
+        ? Math.atan2(2 * ((orientation.w ?? 1) * (orientation.z ?? 0) + (orientation.x ?? 0) * (orientation.y ?? 0)),
+            1 - 2 * ((orientation.y ?? 0) ** 2 + (orientation.z ?? 0) ** 2)) * 180 / Math.PI
+        : 0;
+    return {
+        polygons,
+        robot: position ? {...normalise(position.x ?? x0, position.y ?? y0), heading} : undefined,
+    };
+}
+
+export const ManualControllerPage = () => {
+    const {colors} = useThemeMode();
+    const {t} = useTranslation();
+    const {notification} = App.useApp();
+    const mowerAction = useMowerAction();
+    const {highLevelStatus} = useHighLevelStatus();
+    const map = useMowingMap();
+    const odom = useFusionOdom();
+    const isMobile = useIsMobile();
+    const joyStream = useWS(() => {}, () => {}, () => {});
+    const [mode, setMode] = useState<DriveMode>();
+    const [requestedState, setRequestedState] = useState<string>();
+    const [armed, setArmed] = useState(false);
+    const [isLandscape, setIsLandscape] = useState(() => typeof window !== "undefined" && window.matchMedia("(orientation: landscape)").matches);
+    const [compactLandscape, setCompactLandscape] = useState(() => typeof window !== "undefined" && window.matchMedia("(orientation: landscape) and (max-height: 600px)").matches);
+    const linearRef = useRef(0);
+    const angularRef = useRef(0);
+    const armTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const stateName = highLevelStatus.state_name ?? "—";
+
+    useEffect(() => {
+        const media = window.matchMedia("(orientation: landscape)");
+        const compactMedia = window.matchMedia("(orientation: landscape) and (max-height: 600px)");
+        const update = () => {
+            setIsLandscape(media.matches);
+            setCompactLandscape(compactMedia.matches);
+        };
+        media.addEventListener("change", update);
+        compactMedia.addEventListener("change", update);
+        return () => {
+            media.removeEventListener("change", update);
+            compactMedia.removeEventListener("change", update);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!armed) return;
+        joyStream.start("/api/mowglinext/publish/joy");
+        return () => joyStream.stop();
+        // The stream is deliberately open only while an explicit mode is active.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [armed]);
+
+    const publishTwist = useCallback((force = false) => {
+        if (!armed && !force) return;
+        const message: TwistStamped = {
+            header: {stamp: {sec: 0, nanosec: 0}, frame_id: ""},
+            twist: {
+                linear: {x: linearRef.current, y: 0, z: 0},
+                angular: {x: 0, y: 0, z: angularRef.current},
+            },
+        };
+        joyStream.sendJsonMessage(message);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [armed, joyStream.sendJsonMessage]);
+
+    const sendZero = useCallback(() => {
+        linearRef.current = 0;
+        angularRef.current = 0;
+        joyStream.sendJsonMessage(zeroTwist());
+    }, [joyStream.sendJsonMessage]);
+
+    useEffect(() => {
+        clearTimeout(armTimerRef.current);
+        if (!requestedState) return;
+        if (stateName === requestedState) {
+            // The status subscriber and the serial bridge receive the same
+            // BT update independently. Wait for two 2 Hz bridge periods so
+            // the STM32 has received the new blade-safe mode before cmd_vel
+            // is allowed through this page.
+            armTimerRef.current = setTimeout(() => setArmed(true), ARM_SETTLE_MS);
+            return () => clearTimeout(armTimerRef.current);
+        }
+        setArmed(false);
+        sendZero();
+        return () => clearTimeout(armTimerRef.current);
+    }, [requestedState, sendZero, stateName]);
+
+    const onDriveMove = useCallback((event: IJoystickUpdateEvent) => {
+        linearRef.current = (event.y ?? 0) * MAX_LINEAR_MPS;
+        publishTwist();
+    }, [publishTwist]);
+    const onSteerMove = useCallback((event: IJoystickUpdateEvent) => {
+        angularRef.current = -(event.x ?? 0) * MAX_ANGULAR_RAD_S;
+        publishTwist();
+    }, [publishTwist]);
+    const onCombinedMove = useCallback((event: IJoystickUpdateEvent) => {
+        linearRef.current = (event.y ?? 0) * MAX_LINEAR_MPS;
+        angularRef.current = -(event.x ?? 0) * MAX_ANGULAR_RAD_S;
+        publishTwist();
+    }, [publishTwist]);
+    const stopDrive = useCallback(() => {
+        linearRef.current = 0;
+        publishTwist();
+    }, [publishTwist]);
+    const stopSteer = useCallback(() => {
+        angularRef.current = 0;
+        publishTwist();
+    }, [publishTwist]);
+    const stopCombined = useCallback(() => {
+        linearRef.current = 0;
+        angularRef.current = 0;
+        publishTwist();
+    }, [publishTwist]);
+
+    useEffect(() => {
+        if (!armed) return;
+        const pressed = new Set<string>();
+        const updateFromKeys = () => {
+            linearRef.current = ((pressed.has("w") ? 1 : 0) - (pressed.has("s") ? 1 : 0)) * MAX_LINEAR_MPS;
+            angularRef.current = ((pressed.has("a") ? 1 : 0) - (pressed.has("d") ? 1 : 0)) * MAX_ANGULAR_RAD_S;
+            publishTwist();
+        };
+        const stopForFocusLoss = () => {
+            pressed.clear();
+            sendZero();
+        };
+        const onKeyDown = (event: KeyboardEvent) => {
+            const key = event.key.toLowerCase();
+            if (key === " ") {
+                event.preventDefault();
+                stopForFocusLoss();
+                return;
+            }
+            if (!["w", "a", "s", "d"].includes(key)) return;
+            event.preventDefault();
+            pressed.add(key);
+            updateFromKeys();
+        };
+        const onKeyUp = (event: KeyboardEvent) => {
+            const key = event.key.toLowerCase();
+            if (!["w", "a", "s", "d"].includes(key)) return;
+            event.preventDefault();
+            pressed.delete(key);
+            updateFromKeys();
+        };
+        const onVisibilityChange = () => {
+            if (document.visibilityState !== "visible") stopForFocusLoss();
+        };
+        window.addEventListener("keydown", onKeyDown);
+        window.addEventListener("keyup", onKeyUp);
+        window.addEventListener("blur", stopForFocusLoss);
+        document.addEventListener("visibilitychange", onVisibilityChange);
+        return () => {
+            stopForFocusLoss();
+            window.removeEventListener("keydown", onKeyDown);
+            window.removeEventListener("keyup", onKeyUp);
+            window.removeEventListener("blur", stopForFocusLoss);
+            document.removeEventListener("visibilitychange", onVisibilityChange);
+        };
+    }, [armed, publishTwist, sendZero]);
+
+    const run = async (nextMode: DriveMode) => {
+        const command = nextMode === "mow" ? 7 : nextMode === "transport" ? 9 : 3;
+        setArmed(false);
+        sendZero();
+        await mowerAction("high_level_control", {Command: command})();
+        setMode(nextMode);
+        setRequestedState(stateForMode[nextMode]);
+    };
+    const stop = async () => {
+        sendZero();
+        setArmed(false);
+        setRequestedState(undefined);
+        await mowerAction("high_level_control", {Command: 8})();
+    };
+    const emergencyStop = async () => {
+        sendZero();
+        setArmed(false);
+        setRequestedState(undefined);
+        await mowerAction("emergency", {Emergency: 1})();
+    };
+    const rearm = async () => {
+        await mowerAction("emergency", {Emergency: 0})();
+        notification.success({message: t("manualController.rearmed")});
+    };
+
+    const mapData = useMemo(() => normalisedMap(map, odom), [map, odom]);
+    const isEmergency = highLevelStatus.emergency ?? false;
+    const joystickBase = `radial-gradient(circle at 50% 40%, ${limeAlpha(0.12)}, ${colors.bgBase} 72%)`;
+    const joystickStick = `radial-gradient(circle at 38% 32%, ${colors.primaryLight}, ${colors.mint} 55%, ${colors.emeraldDeep})`;
+    const actionStyle: React.CSSProperties = {
+        minHeight: 52, flex: 1, fontWeight: 700, letterSpacing: "0.01em",
+    };
+    const dualStick = isMobile && isLandscape;
+
+    return (
+        <section aria-label={t("manualController.ariaLabel")} style={{width: "100%", minWidth: 0, maxWidth: 1180, margin: "0 auto"}}>
+            <div className="manual-controller-heading" style={{display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 12}}>
+                <div>
+                    <div style={{display: "flex", alignItems: "center", gap: 8}}>
+                        <Gamepad2 size={22} color={colors.primary}/>
+                        <h1 className="mn-display" style={{margin: 0, color: colors.text, fontSize: 28}}>{t("manualController.title")}</h1>
+                    </div>
+                    <p style={{margin: "4px 0 0", color: colors.textSecondary}}>{t("manualController.subtitle")}</p>
+                </div>
+                <Tag color={isEmergency ? "error" : "success"} style={{margin: 0, fontWeight: 700}}>{isEmergency ? t("manualController.emergencyActive") : stateName}</Tag>
+            </div>
+
+            <div style={{display: "grid", gridTemplateColumns: dualStick ? "minmax(0, 0.85fr) minmax(0, 1.2fr) minmax(0, 0.85fr)" : "minmax(0, 0.9fr) minmax(0, 1.1fr)", gap: 16, alignItems: "stretch"}} className={`manual-controller-grid ${dualStick ? "manual-controller-dual" : "manual-controller-combined"}`}>
+                {dualStick ? <JoystickPanel label={t("manualController.driveStick")} hint={t("manualController.driveHint")} compact={compactLandscape} disabled={!armed}>
+                    <Joystick size={compactLandscape ? 88 : 154} stickSize={compactLandscape ? 40 : 66} baseColor={joystickBase} stickColor={joystickStick} move={onDriveMove} stop={stopDrive} throttle={50}/>
+                </JoystickPanel> : <JoystickPanel label={t("manualController.combinedStick")} hint={t("manualController.combinedHint")} combined disabled={!armed}>
+                    <Joystick size={isMobile ? 184 : 136} stickSize={isMobile ? 78 : 58} baseColor={joystickBase} stickColor={joystickStick} move={onCombinedMove} stop={stopCombined} throttle={50}/>
+                </JoystickPanel>}
+
+                <div className={compactLandscape ? "manual-controller-map manual-controller-map-compact" : "manual-controller-map"} style={{minWidth: 0, borderRadius: 20, overflow: "hidden", background: colors.panel, border: `1px solid ${colors.border}`, boxShadow: colors.glassShadow}}>
+                    <div style={{display: "flex", alignItems: "center", justifyContent: "space-between", padding: "12px 14px", borderBottom: `1px solid ${colors.border}`}}>
+                        <span style={{fontWeight: 700, color: colors.text}}><MapPin size={16} style={{verticalAlign: "-3px", marginRight: 6}}/>{t("manualController.map")}</span>
+                        <span style={{fontSize: 12, color: colors.textSecondary}}>{t("manualController.mapHint")}</span>
+                    </div>
+                    {mapData.polygons.length > 0 ? <LiveMapMini polygons={mapData.polygons} robot={mapData.robot} coverage={0} height={compactLandscape ? 68 : 250}/> : (
+                        <div style={{height: compactLandscape ? 68 : 250, display: "grid", placeItems: "center", color: colors.textSecondary, background: `linear-gradient(135deg, ${colors.bgSubtle}, ${colors.panel})`}}>
+                            <span><MapPin size={18} style={{verticalAlign: "-4px", marginRight: 6}}/>{t("manualController.awaitingMap")}</span>
+                        </div>
+                    )}
+                    <div style={{padding: "10px 14px", display: "flex", justifyContent: "space-between", color: colors.textSecondary, fontSize: 12}}>
+                        <span><CircleDot size={14} color={colors.primary} style={{verticalAlign: "-2px", marginRight: 5}}/>{t("manualController.livePosition")}</span>
+                        <span>{t("manualController.speed", {value: Math.abs(odom.twist?.twist?.linear?.x ?? 0).toFixed(2)})}</span>
+                    </div>
+                </div>
+
+                {dualStick && <JoystickPanel label={t("manualController.steerStick")} hint={t("manualController.steerHint")} compact={compactLandscape} disabled={!armed}>
+                    <Joystick size={compactLandscape ? 88 : 154} stickSize={compactLandscape ? 40 : 66} baseColor={joystickBase} stickColor={joystickStick} move={onSteerMove} stop={stopSteer} throttle={50}/>
+                </JoystickPanel>}
+            </div>
+            {!isMobile && <p style={{margin: "10px 0 0", color: colors.textSecondary, fontSize: 13}}>{t("manualController.keyboardHint")}</p>}
+
+            <div style={{display: "grid", gridTemplateColumns: "repeat(5, minmax(0, 1fr))", gap: 10, marginTop: 16}} className="manual-controller-actions">
+                <Button type={mode === "mow" ? "primary" : "default"} icon={<Scissors size={17}/>} onClick={() => run("mow")} style={actionStyle}>{t("manualController.mow")}</Button>
+                <Button type={mode === "transport" ? "primary" : "default"} icon={<Radio size={17}/>} onClick={() => run("transport")} style={actionStyle}>{t("manualController.transport")}</Button>
+                <Button type={mode === "record" ? "primary" : "default"} icon={<SquareDot size={17}/>} onClick={() => run("record")} style={actionStyle}>{t("manualController.record")}</Button>
+                <Button icon={<Square size={17}/>} onClick={stop} style={actionStyle}>{t("manualController.stop")}</Button>
+                {isEmergency ? <Button onClick={rearm} style={actionStyle}>{t("manualController.rearm")}</Button> : <Button danger type="primary" icon={<Square size={17}/>} onClick={emergencyStop} style={actionStyle}>{t("manualController.emergency")}</Button>}
+            </div>
+            <style>{`
+                @media (max-width: 760px) {
+                    .manual-controller-grid { grid-template-columns: 1fr !important; }
+                    .manual-controller-combined > div:first-child { order: 1; }
+                    .manual-controller-combined > div:last-child { order: 2; }
+                    .manual-controller-actions { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
+                }
+                @media (orientation: landscape) and (max-height: 600px) {
+                    .manual-controller-heading { display: none !important; }
+                    .manual-controller-dual { grid-template-columns: 0.85fr 1.2fr 0.85fr !important; }
+                    .manual-controller-actions { grid-template-columns: repeat(5, minmax(0, 1fr)) !important; }
+                    .manual-controller-map-compact > div:first-child { padding: 6px 8px !important; }
+                    .manual-controller-map-compact > div:first-child span:last-child { display: none; }
+                    .manual-controller-map-compact > div:last-child { padding: 5px 8px !important; }
+                }
+            `}</style>
+        </section>
+    );
+};
+
+const JoystickPanel = ({label, hint, children, combined = false, compact = false, disabled = false}: {label: string; hint: string; children: React.ReactNode; combined?: boolean; compact?: boolean; disabled?: boolean}) => {
+    const {colors} = useThemeMode();
+    return <div style={{display: "grid", minWidth: 0, placeItems: "center", gap: compact ? 6 : 10, padding: compact ? 8 : combined ? 20 : 16, textAlign: "center", borderRadius: 20, background: colors.panel, border: `1px solid ${colors.border}`}}>
+        <strong style={{color: colors.text}}>{label}</strong>
+        <div style={{touchAction: "none", opacity: disabled ? 0.45 : 1, pointerEvents: disabled ? "none" : undefined}}>{children}</div>
+        <span style={{fontSize: 12, color: colors.textSecondary}}>{hint}</span>
+    </div>;
+};
+
+export default ManualControllerPage;

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -4,6 +4,7 @@ import {App} from "antd";
 import turfArea from "@turf/area";
 import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {useTranslation} from "react-i18next";
+import {useNavigate} from "react-router-dom";
 import {MapArea, Map as MapType} from "../types/ros.ts";
 import DrawControl from "../components/DrawControl.tsx";
 import Map, {Layer, Source} from 'react-map-gl/mapbox';
@@ -52,6 +53,7 @@ const DYN_OBSTACLE_INTERACTIVE_LAYERS = ['dyn-obstacle-fill'];
 
 export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     const {notification} = App.useApp();
+    const navigate = useNavigate();
     const {t} = useTranslation();
     const {colors} = useThemeMode();
     const isMobile = useIsMobile();
@@ -590,7 +592,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     });
 
 
-    const {manualMode, handleManualMode, handleStopManualMode, handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream, stateName: highLevelStatus.highLevelStatus.state_name});
+    const {handleJoyMove, handleJoyStop} = useManualMode({mowerAction, joyStream, stateName: highLevelStatus.highLevelStatus.state_name});
 
     // Toggle dock placement mode: re-pressing the button (or pressing Escape)
     // cancels it, so the crosshair cursor is not a one-way trap.
@@ -1039,7 +1041,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     </Source>
                 </Map> : <Spinner/>}
                 <JoystickOverlay
-                    visible={highLevelStatus.highLevelStatus.state_name === "RECORDING" || highLevelStatus.highLevelStatus.state_name === "MANUAL_MOWING" || manualMode}
+                    visible={highLevelStatus.highLevelStatus.state_name === "RECORDING"}
                     isRecording={highLevelStatus.highLevelStatus.state_name === "RECORDING"}
                     mobile={isMobile}
                     onMove={handleJoyMove}
@@ -1052,7 +1054,6 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                     <MapToolbarMobile
                         editMap={editMap}
                         hasUnsavedChanges={hasUnsavedChanges}
-                        manualMode={manualMode}
                         useSatellite={useSatellite}
                         historyIndex={historyIndex}
                         editHistoryLength={editHistory.length}
@@ -1073,8 +1074,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                         onUndo={handleUndo}
                         onRedo={handleRedo}
                         onToggleSatellite={() => setUseSatellite(!useSatellite)}
-                        onManualMode={handleManualMode}
-                        onStopManualMode={handleStopManualMode}
+                        onOpenManualController={() => navigate("/manual-control")}
                         onBackupMap={handleBackupMap}
                         onRestoreMap={handleRestoreMap}
                         onDownloadGeoJSON={handleDownloadGeoJSON}
@@ -1118,7 +1118,6 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                 {!isMobile && !editMap && (
                     <div style={{position: 'absolute', bottom: 12, left: 16, right: 16, zIndex: 10, background: colors.glassBackground, backdropFilter: 'blur(22px) saturate(140%)', WebkitBackdropFilter: 'blur(22px) saturate(140%)', borderRadius: 18, border: colors.glassBorder, boxShadow: colors.glassShadow, padding: '10px 14px'}}>
                         <MapToolbar
-                            manualMode={manualMode}
                             useSatellite={useSatellite}
                             mowingAreas={mowingAreas}
                             stateName={highLevelStatus.highLevelStatus.state_name}
@@ -1127,8 +1126,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                             onTogglePitch={togglePitch}
                             onEditMap={handleEditMap}
                             onToggleSatellite={() => setUseSatellite(!useSatellite)}
-                            onManualMode={handleManualMode}
-                            onStopManualMode={handleStopManualMode}
+                            onOpenManualController={() => navigate("/manual-control")}
                             onBackupMap={handleBackupMap}
                             onRestoreMap={handleRestoreMap}
                             onDownloadGeoJSON={handleDownloadGeoJSON}

--- a/gui/web/src/pages/map/components/MapToolbar.test.tsx
+++ b/gui/web/src/pages/map/components/MapToolbar.test.tsx
@@ -17,15 +17,13 @@ vi.mock('../../../components/AsyncDropDownButton.tsx', () => ({
 
 describe('MapToolbar', () => {
     const defaultProps = {
-        manualMode: false,
         useSatellite: true,
         mowingAreas: [],
         stateName: 'IDLE',
         emergency: false,
         onEditMap: vi.fn(),
         onToggleSatellite: vi.fn(),
-        onManualMode: vi.fn().mockResolvedValue(undefined),
-        onStopManualMode: vi.fn().mockResolvedValue(undefined),
+        onOpenManualController: vi.fn(),
         onBackupMap: vi.fn(),
         onRestoreMap: vi.fn(),
         onDownloadGeoJSON: vi.fn(),
@@ -78,6 +76,13 @@ describe('MapToolbar', () => {
     it('shows Mow area dropdown', () => {
         render(<MapToolbar {...defaultProps} />);
         expect(screen.getByText(en.mapToolbar.mowArea)).toBeInTheDocument();
+    });
+
+    it('opens the dedicated controller from Manual Mow', async () => {
+        const user = userEvent.setup();
+        render(<MapToolbar {...defaultProps} />);
+        await user.click(screen.getByText(en.mapToolbar.manualMow));
+        expect(defaultProps.onOpenManualController).toHaveBeenCalled();
     });
 
     it('always shows the More dropdown trigger', () => {

--- a/gui/web/src/pages/map/components/MapToolbar.tsx
+++ b/gui/web/src/pages/map/components/MapToolbar.tsx
@@ -32,15 +32,13 @@ interface MowingAreaItem extends MenuItemType {
 }
 
 interface MapToolbarProps {
-    manualMode: boolean;
     useSatellite: boolean;
     mowingAreas: MowingAreaItem[];
     stateName?: string;
     emergency?: boolean;
     onEditMap: () => void;
     onToggleSatellite: () => void;
-    onManualMode: () => Promise<void>;
-    onStopManualMode: () => Promise<void>;
+    onOpenManualController: () => void;
     onBackupMap: () => void;
     onRestoreMap: () => void;
     onDownloadGeoJSON: () => void;
@@ -63,9 +61,9 @@ interface MapToolbarProps {
 }
 
 export const MapToolbar = ({
-    manualMode, useSatellite, mowingAreas, stateName, emergency,
+    useSatellite, mowingAreas, stateName, emergency,
     onEditMap, onToggleSatellite,
-    onManualMode, onStopManualMode,
+    onOpenManualController,
     onBackupMap, onRestoreMap, onDownloadGeoJSON, onImportOpenMower,
     onMowArea, pitched, onTogglePitch,
     onStart, onHome, onEmergencyOn, onEmergencyOff,
@@ -98,10 +96,7 @@ export const MapToolbar = ({
         {key: "mowNext", icon: <ForwardOutlined />, label: t("mapToolbar.mowNextArea")},
         {key: "continueOrPause", icon: isIdle ? <CaretRightOutlined /> : <PauseOutlined />, label: isIdle ? t("mapToolbar.continue") : t("mapToolbar.pause")},
         {type: "divider"},
-        ...(manualMode
-            ? [{key: "stopManual", icon: <HomeOutlined />, label: t("mapToolbar.stopManualMowing"), danger: true} satisfies NonNullable<MenuProps["items"]>[number]]
-            : [{key: "manual", icon: <ControlOutlined />, label: t("mapToolbar.manualMowing")} satisfies NonNullable<MenuProps["items"]>[number]]
-        ),
+        {key: "manual", icon: <ControlOutlined />, label: t("mapToolbar.manualMowing")},
         {type: "divider"},
         {key: "bladeForward", icon: <ThunderboltOutlined />, label: t("mapToolbar.bladeForward")},
         {key: "bladeBackward", icon: <ThunderboltOutlined />, label: t("mapToolbar.bladeBackward")},
@@ -118,8 +113,7 @@ export const MapToolbar = ({
         switch (key) {
             case "satellite": onToggleSatellite(); break;
             case "pitch": onTogglePitch?.(); break;
-            case "manual": safeCall(() => onManualMode()); break;
-            case "stopManual": safeCall(() => onStopManualMode()); break;
+            case "manual": onOpenManualController(); break;
             case "areaRecording": safeCall(onAreaRecording); break;
             case "mowNext": safeCall(onMowNextArea); break;
             case "continueOrPause": safeCall(onContinueOrPause); break;
@@ -211,13 +205,9 @@ export const MapToolbar = ({
                 {t("mapToolbar.mowArea")}
             </AsyncDropDownButton>
 
-            <AsyncButton
-                danger={manualMode}
-                icon={manualMode ? <HomeOutlined /> : <ControlOutlined />}
-                onAsyncClick={manualMode ? onStopManualMode : onManualMode}
-            >
-                {manualMode ? t("mapToolbar.stopManual") : t("mapToolbar.manualMow")}
-            </AsyncButton>
+            <Button icon={<ControlOutlined />} onClick={onOpenManualController}>
+                {t("mapToolbar.manualMow")}
+            </Button>
 
             <Dropdown
                 menu={{items: moreMenuItems, onClick: handleMoreClick}}

--- a/gui/web/src/pages/map/components/MapToolbarMobile.tsx
+++ b/gui/web/src/pages/map/components/MapToolbarMobile.tsx
@@ -47,7 +47,6 @@ interface MowingAreaItem extends MenuItemType {
 interface MapToolbarMobileProps {
     editMap: boolean;
     hasUnsavedChanges: boolean;
-    manualMode: boolean;
     useSatellite: boolean;
     historyIndex: number;
     editHistoryLength: number;
@@ -57,8 +56,7 @@ interface MapToolbarMobileProps {
     onUndo: () => void;
     onRedo: () => void;
     onToggleSatellite: () => void;
-    onManualMode: () => Promise<void>;
-    onStopManualMode: () => Promise<void>;
+    onOpenManualController: () => void;
     onBackupMap: () => void;
     onRestoreMap: () => void;
     onDownloadGeoJSON: () => void;
@@ -93,10 +91,10 @@ interface MapToolbarMobileProps {
 }
 
 export const MapToolbarMobile = ({
-    editMap, hasUnsavedChanges, manualMode, useSatellite,
+    editMap, hasUnsavedChanges, useSatellite,
     historyIndex, editHistoryLength, mowingAreas,
     onEditMap, onSaveMap, onUndo, onRedo, onToggleSatellite,
-    onManualMode, onStopManualMode,
+    onOpenManualController,
     onBackupMap, onRestoreMap, onDownloadGeoJSON, onUploadGeoJSON, onImportOpenMower,
     onMowArea, selectedFeatureCount = 0, onEditSelectedFeature,
     onDrawPolygon, onDrawShape, onDrawEmoji, onTrash, onCombine, onSubtract, onSplit,
@@ -408,12 +406,11 @@ export const MapToolbarMobile = ({
                     </Button>
                 </Dropdown>
 
-                <AsyncButton
+                <Button
                     size="large"
-                    danger={manualMode}
-                    icon={manualMode ? <HomeOutlined /> : <ControlOutlined />}
-                    onAsyncClick={manualMode ? onStopManualMode : onManualMode}
-                    aria-label={manualMode ? t("mapToolbarMobile.stopManualMowing") : t("mapToolbarMobile.manualMowing")}
+                    icon={<ControlOutlined />}
+                    onClick={onOpenManualController}
+                    aria-label={t("mapToolbarMobile.manualMowing")}
                     style={touchTarget}
                 />
 


### PR DESCRIPTION
## Summary

Supersedes #456, which GitHub closed when its fork head ref was renamed during repository cleanup. This replacement keeps the same controller implementation and current commit history.

- Map **Manual Mow** opens the dedicated controller instead of retaining a legacy map overlay.
- Desktop uses a smaller combined stick plus W/S drive, A/D steering, Space-to-stop, and simultaneous W+A / W+D arcs.
- Portrait uses a larger combined stick; mobile landscape uses two thumb sticks.
- Joystick and keyboard stay disabled until the requested high-level state has been observed and held for two bridge periods, allowing the STM32 blade-safe mode to settle before velocity is sent.
- Stop, Emergency Stop, Space, key release, window blur, hidden tabs, and mode changes all send zero velocity.

Depends on #453 and #455.

Closes #452

## Validation

- `yarn tsc --noEmit`
- `yarn vitest run src/pages/ManualControllerPage.test.tsx src/pages/map/components/MapToolbar.test.tsx` — 20 passing
- Rendered responsive checks at 375×667 portrait, 667×375 landscape, and 1280×760 desktop
- `git diff --check`