### PR TITLE
fix(coverage): record verified cutting footprint

### DIFF
--- a/gui/pkg/msgs/mowgli/types_generated.go
+++ b/gui/pkg/msgs/mowgli/types_generated.go
@@ -187,6 +187,7 @@ type Status struct {
 	MowerEscCurrent           float32                        `json:"mower_esc_current"`
 	MowerMotorTemperature     float32                        `json:"mower_motor_temperature"`
 	MowerMotorRpm             float32                        `json:"mower_motor_rpm"`
+	BladeStatusStamp          geometry.Stamp                 `json:"blade_status_stamp"`
 	FirmwareVersion           string                         `json:"firmware_version"`
 	FirmwareProtocolVersion   uint8                          `json:"firmware_protocol_version"`
 	FirmwareCompatible        bool                           `json:"firmware_compatible"`

--- a/gui/web/src/types/ros.generated.ts
+++ b/gui/web/src/types/ros.generated.ts
@@ -398,6 +398,7 @@ export type Status = {
   mower_esc_current?: number;
   mower_motor_temperature?: number;
   mower_motor_rpm?: number;
+  blade_status_stamp?: { sec: number; nanosec: number };
   firmware_version?: string;
   firmware_protocol_version?: number;
   firmware_compatible?: boolean;

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -1202,6 +1202,7 @@ private:
       msg.firmware_debug_enabled = firmware_debug_enabled_;
       msg.mower_esc_status = blade_active_ ? 1u : 0u;
       msg.mower_motor_rpm = blade_rpm_;
+      msg.blade_status_stamp = blade_status_time_;
       msg.mower_motor_temperature = blade_temperature_;
       msg.mower_esc_current = blade_esc_current_;
       // Firmware version handshake result (image <-> firmware compatibility).
@@ -2210,6 +2211,7 @@ private:
     // Update the Status message fields with live blade data
     blade_active_ = pkt.is_active != 0u;
     blade_rpm_ = static_cast<float>(pkt.rpm);
+    blade_status_time_ = now();
     blade_temperature_ = pkt.temperature;
     blade_esc_current_ = static_cast<float>(pkt.power_watts);
   }
@@ -2704,6 +2706,7 @@ private:
   // Blade motor state (updated from LlBladeStatus packets)
   bool blade_active_{false};
   float blade_rpm_{0.0f};
+  rclcpp::Time blade_status_time_{0, 0, RCL_ROS_TIME};
   float blade_temperature_{0.0f};
   float blade_esc_current_{0.0f};
   uint8_t last_reset_cause_{RESET_CAUSE_UNKNOWN};

--- a/ros2/src/mowgli_interfaces/msg/Status.msg
+++ b/ros2/src/mowgli_interfaces/msg/Status.msg
@@ -28,6 +28,10 @@ float32 mower_esc_temperature
 float32 mower_esc_current
 float32 mower_motor_temperature
 float32 mower_motor_rpm
+# Time of the most recent direct blade-controller report.  This differs from
+# `stamp`, which is refreshed for every mainboard status packet even when the
+# blade telemetry stream has stopped. A zero stamp means no report received.
+builtin_interfaces/Time blade_status_stamp
 
 # Firmware version handshake (image <-> firmware compatibility). Populated by
 # hardware_bridge from the STM32's CONFIG_RSP reply. firmware_compatible is

--- a/ros2/src/mowgli_map/CMakeLists.txt
+++ b/ros2/src/mowgli_map/CMakeLists.txt
@@ -187,6 +187,26 @@ if(BUILD_TESTING)
     mowgli_interfaces
   )
 
+  ament_add_gtest(test_mow_progress
+    test/test_mow_progress.cpp
+  )
+
+  target_link_libraries(test_mow_progress
+    mowgli_map_lib
+  )
+
+  target_include_directories(test_mow_progress PRIVATE include)
+
+  ament_target_dependencies(test_mow_progress
+    rclcpp
+    grid_map_core
+    grid_map_ros
+    grid_map_msgs
+    nav_msgs
+    geometry_msgs
+    mowgli_interfaces
+  )
+
   ament_add_gtest(test_obstacle_tracker
     test/test_obstacle_tracker.cpp
   )

--- a/ros2/src/mowgli_map/config/map_server.yaml
+++ b/ros2/src/mowgli_map/config/map_server.yaml
@@ -22,6 +22,14 @@ map_server_node:
     # cutting that serialization ~publish_rate× (transient_local still delivers
     # the latest grid to late subscribers immediately).
     mow_progress_publish_period_s: 2.0
+    # The `actually mowed` overlay follows this physical cutting-tool TF, not
+    # base_footprint. Override for mower-specific cutter frames.
+    mow_progress_tool_frame: "blade_link"
+    # Progress is recorded only while a fresh blade-controller report confirms
+    # active state and at least this RPM. Missing, stale, spin-up, stalled and
+    # spin-down telemetry all fail closed (they do not mark grass as cut).
+    mow_progress_min_blade_rpm: 1000.0
+    mow_progress_blade_telemetry_max_age_s: 1.0
     # Navigation margin around area boundaries for keepout mask.
     # Cells outside the area but within this distance of the boundary
     # edge are marked FREE (not lethal) in the keepout mask. Needed so

--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -42,6 +42,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include "mowgli_map/map_types.hpp"
+#include "mowgli_map/mow_progress.hpp"
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_msgs/msg/grid_map.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
@@ -111,6 +112,15 @@ public:
   {
     return tool_width_;
   }
+
+  /// Test-only: add a verified tool pose to the accumulated footprint.
+  void stamp_mow_progress_for_test(double x, double y)
+  {
+    stamp_mow_progress(x, y);
+  }
+
+  /// Test-only: return the mowed-layer value at a map-frame position.
+  float mow_progress_value_for_test(double x, double y) const;
 
   /// Clear all layers to their default values.
   void clear_map_layers();
@@ -190,7 +200,8 @@ private:
   /// Update mow blade state from mower status.
   void on_mower_status(mowgli_interfaces::msg::Status::ConstSharedPtr msg);
 
-  /// Latch the robot's map-frame position and check boundary violation.
+  /// Latch the robot's map-frame position, update verified cutting progress,
+  /// and check boundary violation.
   void on_odom(nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   /// Cache the latest /obstacle_tracker/obstacles message so the
@@ -206,9 +217,9 @@ private:
   /// Publish the grid_map and (when dirty) the keepout/speed costmap masks.
   void on_publish_timer();
 
-  /// Stamp a tool-width disc of "mowed" into mow_progress_map_ at the given
-  /// map-frame robot position. Lazily (re)creates the grid to mirror map_'s
-  /// geometry. Takes map_mutex_ internally — caller must NOT hold it.
+  /// Stamp a tool-width swept footprint into mow_progress_map_ ending at the
+  /// given map-frame tool position. Lazily (re)creates the grid to mirror
+  /// map_'s geometry. Takes map_mutex_ internally — caller must NOT hold it.
   void stamp_mow_progress(double x, double y);
 
   /// Publish mow_progress_map_ as a nav_msgs/OccupancyGrid on ~/mow_progress.
@@ -514,7 +525,16 @@ private:
   double mow_progress_publish_period_s_{2.0};
   rclcpp::Time last_mow_progress_pub_time_{0, 0, RCL_ROS_TIME};
 
-  bool mow_blade_enabled_{false};
+  std::string mow_progress_tool_frame_{"blade_link"};
+  double mow_progress_min_blade_rpm_{1000.0};
+  double mow_progress_blade_telemetry_max_age_s_{1.0};
+  bool mow_blade_requested_{false};
+  bool mow_blade_active_{false};
+  double mow_blade_rpm_{0.0};
+  rclcpp::Time mow_blade_telemetry_time_{0, 0, RCL_ROS_TIME};
+  MowProgressInhibitReason mow_progress_reason_{MowProgressInhibitReason::kBladeNotRequested};
+  bool have_last_mow_tool_position_{false};
+  grid_map::Position last_mow_tool_position_;
 
   /// Most recent map-frame robot position (latched in on_odom).
   double last_robot_x_{0.0};

--- a/ros2/src/mowgli_map/include/mowgli_map/mow_progress.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/mow_progress.hpp
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 MowgliNext contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#ifndef MOWGLI_MAP__MOW_PROGRESS_HPP_
+#define MOWGLI_MAP__MOW_PROGRESS_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+namespace mowgli_map
+{
+
+enum class MowProgressInhibitReason
+{
+  kActive,
+  kBladeNotRequested,
+  kTelemetryMissingOrStale,
+  kBladeInactive,
+  kRpmTooLow,
+};
+
+/// Decide whether a pose may be added to the "actually mowed" overlay.
+///
+/// This deliberately requires both command intent and fresh blade-controller
+/// evidence.  A missing or stale telemetry timestamp is never treated as a
+/// positive observation.
+inline MowProgressInhibitReason GetMowProgressInhibitReason(bool blade_requested,
+                                                            bool telemetry_fresh,
+                                                            bool blade_active,
+                                                            double blade_rpm,
+                                                            double min_blade_rpm)
+{
+  if (!blade_requested)
+  {
+    return MowProgressInhibitReason::kBladeNotRequested;
+  }
+  if (!telemetry_fresh)
+  {
+    return MowProgressInhibitReason::kTelemetryMissingOrStale;
+  }
+  if (!blade_active)
+  {
+    return MowProgressInhibitReason::kBladeInactive;
+  }
+  if (!std::isfinite(blade_rpm) || blade_rpm < min_blade_rpm)
+  {
+    return MowProgressInhibitReason::kRpmTooLow;
+  }
+  return MowProgressInhibitReason::kActive;
+}
+
+inline const char* ToString(MowProgressInhibitReason reason)
+{
+  switch (reason)
+  {
+    case MowProgressInhibitReason::kActive:
+      return "verified blade activity";
+    case MowProgressInhibitReason::kBladeNotRequested:
+      return "blade not requested";
+    case MowProgressInhibitReason::kTelemetryMissingOrStale:
+      return "blade telemetry missing or stale";
+    case MowProgressInhibitReason::kBladeInactive:
+      return "blade controller reports inactive";
+    case MowProgressInhibitReason::kRpmTooLow:
+      return "blade RPM below threshold";
+  }
+  return "unknown";
+}
+
+/// Number of evenly spaced disc centres needed to cover a segment without a
+/// gap larger than one grid cell. The endpoint is included by callers.
+inline std::size_t SweepStepCount(double distance, double resolution)
+{
+  return std::max<std::size_t>(1,
+                               static_cast<std::size_t>(
+                                   std::ceil(distance / std::max(resolution, 1e-9))));
+}
+
+}  // namespace mowgli_map
+
+#endif  // MOWGLI_MAP__MOW_PROGRESS_HPP_

--- a/ros2/src/mowgli_map/src/area_manager.cpp
+++ b/ros2/src/mowgli_map/src/area_manager.cpp
@@ -190,6 +190,7 @@ void MapServerNode::init_map()
   // Drop any accumulated mowed-progress overlay: a fresh map (startup or a map
   // delete) means coverage starts over. stamp_mow_progress lazily recreates it.
   mow_progress_map_ = grid_map::GridMap();
+  have_last_mow_tool_position_ = false;
 
   RCLCPP_DEBUG(get_logger(),
                "Grid map created: %zu×%zu cells",
@@ -593,6 +594,8 @@ void MapServerNode::clear_map_layers()
 {
   map_[std::string(layers::OCCUPANCY)].setConstant(defaults::OCCUPANCY);
   map_[std::string(layers::CLASSIFICATION)].setConstant(defaults::CLASSIFICATION);
+  mow_progress_map_ = grid_map::GridMap();
+  have_last_mow_tool_position_ = false;
 }
 void MapServerNode::on_set_docking_point(
     const mowgli_interfaces::srv::SetDockingPoint::Request::SharedPtr req,

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -72,6 +72,11 @@ MapServerNode::MapServerNode(const rclcpp::NodeOptions& options)
   robot_yaml_path_ = declare_parameter<std::string>("robot_yaml_path", kRuntimeRobotYaml);
   publish_rate_ = declare_parameter<double>("publish_rate", 1.0);
   mow_progress_publish_period_s_ = declare_parameter<double>("mow_progress_publish_period_s", 2.0);
+  mow_progress_tool_frame_ =
+      declare_parameter<std::string>("mow_progress_tool_frame", "blade_link");
+  mow_progress_min_blade_rpm_ = declare_parameter<double>("mow_progress_min_blade_rpm", 1000.0);
+  mow_progress_blade_telemetry_max_age_s_ =
+      declare_parameter<double>("mow_progress_blade_telemetry_max_age_s", 1.0);
   keepout_nav_margin_ = declare_parameter<double>("keepout_nav_margin", 0.45);
   // Hard area-boundary enforcement: when true (operator default), the keepout
   // mask marks every cell OUTSIDE the union of all areas (mowing + navigation)
@@ -568,7 +573,10 @@ void MapServerNode::on_occupancy_grid(nav_msgs::msg::OccupancyGrid::ConstSharedP
 
 void MapServerNode::on_mower_status(mowgli_interfaces::msg::Status::ConstSharedPtr msg)
 {
-  mow_blade_enabled_ = msg->mow_enabled;
+  mow_blade_requested_ = msg->mow_enabled;
+  mow_blade_active_ = msg->mower_esc_status != 0U;
+  mow_blade_rpm_ = msg->mower_motor_rpm;
+  mow_blade_telemetry_time_ = rclcpp::Time(msg->blade_status_stamp);
   last_is_charging_ = msg->is_charging;
   last_status_time_ = now();
 }
@@ -620,10 +628,49 @@ void MapServerNode::on_odom(nav_msgs::msg::Odometry::ConstSharedPtr /*msg*/)
   last_robot_x_ = x;
   last_robot_y_ = y;
 
-  // Accumulate the mowed footprint while the blade is running.
-  if (mow_blade_enabled_)
+  const rclcpp::Time now_t = now();
+  const bool telemetry_fresh =
+      mow_blade_telemetry_time_.nanoseconds() > 0 &&
+      (now_t - mow_blade_telemetry_time_).seconds() >= 0.0 &&
+      (now_t - mow_blade_telemetry_time_).seconds() <= mow_progress_blade_telemetry_max_age_s_;
+  const auto reason = GetMowProgressInhibitReason(mow_blade_requested_,
+                                                  telemetry_fresh,
+                                                  mow_blade_active_,
+                                                  mow_blade_rpm_,
+                                                  mow_progress_min_blade_rpm_);
+  if (reason != mow_progress_reason_)
   {
-    stamp_mow_progress(x, y);
+    RCLCPP_INFO(get_logger(),
+                "Mow-progress stamping %s: %s",
+                reason == MowProgressInhibitReason::kActive ? "enabled" : "inhibited",
+                ToString(reason));
+    mow_progress_reason_ = reason;
+  }
+
+  if (reason == MowProgressInhibitReason::kActive)
+  {
+    try
+    {
+      const auto tool_tf =
+          tf_buffer_->lookupTransform(map_frame_, mow_progress_tool_frame_, tf2::TimePointZero);
+      stamp_mow_progress(tool_tf.transform.translation.x, tool_tf.transform.translation.y);
+    }
+    catch (const tf2::TransformException& ex)
+    {
+      have_last_mow_tool_position_ = false;
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "Mow-progress stamping inhibited: no %s -> %s transform: %s",
+                           map_frame_.c_str(),
+                           mow_progress_tool_frame_.c_str(),
+                           ex.what());
+    }
+  }
+  else
+  {
+    // Never sweep across a period in which cutting was unverified.
+    have_last_mow_tool_position_ = false;
   }
 
   check_boundary_violation(x, y);
@@ -810,14 +857,47 @@ void MapServerNode::stamp_mow_progress(double x, double y)
 
   const grid_map::Position center(x, y);
   const double radius = std::max(tool_width_ * 0.5, mow_progress_map_.getResolution());
-  for (grid_map::CircleIterator it(mow_progress_map_, center, radius); !it.isPastEnd(); ++it)
+  const auto stamp_disc = [this, &layer, radius](const grid_map::Position& position)
   {
-    if (mow_progress_map_.at(layer, *it) < 100.0F)
+    for (grid_map::CircleIterator it(mow_progress_map_, position, radius); !it.isPastEnd(); ++it)
     {
-      mow_progress_map_.at(layer, *it) = 100.0F;
-      mow_progress_dirty_ = true;
+      if (mow_progress_map_.at(layer, *it) < 100.0F)
+      {
+        mow_progress_map_.at(layer, *it) = 100.0F;
+        mow_progress_dirty_ = true;
+      }
+    }
+  };
+
+  if (have_last_mow_tool_position_)
+  {
+    const double distance = (center - last_mow_tool_position_).norm();
+    const size_t steps = SweepStepCount(distance, mow_progress_map_.getResolution());
+    for (size_t step = 1; step <= steps; ++step)
+    {
+      const double fraction = static_cast<double>(step) / static_cast<double>(steps);
+      stamp_disc(last_mow_tool_position_ + fraction * (center - last_mow_tool_position_));
     }
   }
+  else
+  {
+    stamp_disc(center);
+  }
+  last_mow_tool_position_ = center;
+  have_last_mow_tool_position_ = true;
+}
+
+float MapServerNode::mow_progress_value_for_test(double x, double y) const
+{
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  const std::string layer = "mowed";
+  grid_map::Index index;
+  if (!mow_progress_map_.exists(layer) ||
+      !mow_progress_map_.getIndex(grid_map::Position(x, y), index))
+  {
+    return 0.0F;
+  }
+  return mow_progress_map_.at(layer, index);
 }
 
 void MapServerNode::publish_mow_progress()

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -853,6 +853,9 @@ void MapServerNode::stamp_mow_progress(double x, double y)
     mow_progress_map_.setFrameId(map_frame_);
     mow_progress_map_.setGeometry(map_.getLength(), map_.getResolution(), map_.getPosition());
     mow_progress_map_[layer].setConstant(0.0F);
+    // The previous point belonged to different grid geometry, so it must not
+    // be joined to the first pose in the fresh overlay.
+    have_last_mow_tool_position_ = false;
   }
 
   const grid_map::Position center(x, y);

--- a/ros2/src/mowgli_map/src/progress_tracker.cpp
+++ b/ros2/src/mowgli_map/src/progress_tracker.cpp
@@ -123,7 +123,7 @@ void MapServerNode::check_boundary_violation(double x, double y)
   // both states legitimately place the robot outside any defined polygon, so
   // an ERROR-level log would just spam the rosout. The /boundary_violation
   // topics are still published unconditionally so the BT can react.
-  if (!inside_any && mow_blade_enabled_)
+  if (!inside_any && mow_blade_requested_)
   {
     if (lethal_msg.data)
     {

--- a/ros2/src/mowgli_map/test/test_mow_progress.cpp
+++ b/ros2/src/mowgli_map/test/test_mow_progress.cpp
@@ -57,4 +57,25 @@ TEST(MowProgress, StampsTheCompleteStraightToolSweep)
   rclcpp::shutdown();
 }
 
+TEST(MowProgress, DoesNotSweepAcrossAProgressReset)
+{
+  rclcpp::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("resolution", 0.05);
+  options.append_parameter_override("map_size_x", 4.0);
+  options.append_parameter_override("map_size_y", 4.0);
+  options.append_parameter_override("tool_width", 0.10);
+  auto node = std::make_shared<mowgli_map::MapServerNode>(options);
+
+  node->stamp_mow_progress_for_test(-1.0, 0.0);
+  node->clear_map_layers();
+  node->stamp_mow_progress_for_test(1.0, 0.0);
+
+  EXPECT_FLOAT_EQ(node->mow_progress_value_for_test(0.0, 0.0), 0.0F);
+  EXPECT_FLOAT_EQ(node->mow_progress_value_for_test(1.0, 0.0), 100.0F);
+
+  node.reset();
+  rclcpp::shutdown();
+}
+
 }  // namespace

--- a/ros2/src/mowgli_map/test/test_mow_progress.cpp
+++ b/ros2/src/mowgli_map/test/test_mow_progress.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 MowgliNext contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+#include "mowgli_map/map_server_node.hpp"
+#include "mowgli_map/mow_progress.hpp"
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using mowgli_map::GetMowProgressInhibitReason;
+using mowgli_map::MowProgressInhibitReason;
+
+TEST(MowProgress, RequiresFreshVerifiedBladeActivity)
+{
+  EXPECT_EQ(GetMowProgressInhibitReason(true, true, true, 3000.0, 1000.0),
+            MowProgressInhibitReason::kActive);
+  EXPECT_EQ(GetMowProgressInhibitReason(true, true, false, 3000.0, 1000.0),
+            MowProgressInhibitReason::kBladeInactive);
+  EXPECT_EQ(GetMowProgressInhibitReason(true, true, true, 999.0, 1000.0),
+            MowProgressInhibitReason::kRpmTooLow);
+  EXPECT_EQ(GetMowProgressInhibitReason(true, false, true, 3000.0, 1000.0),
+            MowProgressInhibitReason::kTelemetryMissingOrStale);
+  EXPECT_EQ(GetMowProgressInhibitReason(false, true, true, 3000.0, 1000.0),
+            MowProgressInhibitReason::kBladeNotRequested);
+}
+
+TEST(MowProgress, SweepsEveryGridCellAlongStraightMotion)
+{
+  EXPECT_EQ(mowgli_map::SweepStepCount(0.0, 0.05), 1U);
+  EXPECT_EQ(mowgli_map::SweepStepCount(0.05, 0.05), 1U);
+  EXPECT_EQ(mowgli_map::SweepStepCount(0.21, 0.05), 5U);
+}
+
+TEST(MowProgress, StampsTheCompleteStraightToolSweep)
+{
+  rclcpp::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("resolution", 0.05);
+  options.append_parameter_override("map_size_x", 4.0);
+  options.append_parameter_override("map_size_y", 4.0);
+  options.append_parameter_override("tool_width", 0.10);
+  auto node = std::make_shared<mowgli_map::MapServerNode>(options);
+
+  node->stamp_mow_progress_for_test(-1.0, 0.0);
+  node->stamp_mow_progress_for_test(1.0, 0.0);
+
+  EXPECT_FLOAT_EQ(node->mow_progress_value_for_test(-1.0, 0.0), 100.0F);
+  EXPECT_FLOAT_EQ(node->mow_progress_value_for_test(0.0, 0.0), 100.0F);
+  EXPECT_FLOAT_EQ(node->mow_progress_value_for_test(1.0, 0.0), 100.0F);
+
+  node.reset();
+  rclcpp::shutdown();
+}
+
+}  // namespace

--- a/ros2/src/mowgli_simulation/src/fake_hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_simulation/src/fake_hardware_bridge_node.cpp
@@ -193,6 +193,7 @@ private:
     status.mower_esc_current = mow_enabled_ ? 0.5f : 0.0f;
     status.mower_motor_temperature = mow_enabled_ ? 30.0f : 25.0f;
     status.mower_motor_rpm = mow_enabled_ ? 3000.0f : 0.0f;
+    status.blade_status_stamp = now;
     // is_charging mirrors near_dock — opennav_docking, dock_yaw_to_set_pose,
     // BoundaryGuard, calibrate_imu_yaw, and the BT all gate on this.
     status.is_charging = near_dock;


### PR DESCRIPTION
## Summary

Fixes #447 by making the mowing-progress overlay represent the verified physical cutting footprint:

- use the configurable `blade_link` TF instead of `base_footprint` as the footprint centre
- sweep between consecutive verified tool poses so low-rate updates do not leave coverage gaps
- reset the sweep anchor whenever progress or map geometry resets, so a fresh overlay cannot be joined to a prior path
- require fresh blade-controller telemetry, active state, and a configurable RPM threshold before recording progress
- fail closed during spin-up, spin-down, stalls, stale/missing telemetry, or unavailable tool TF
- add the blade-telemetry timestamp to the shared status contract, populated by hardware and simulation

The GUI continues to render the published OccupancyGrid directly. This does not alter blade, emergency, or motion authority.

## Validation

- `clang-format -n` for all touched C++ files using `ros2/.clang-format`
- non-root ROS container build: `mowgli_map`, `mowgli_hardware`, `mowgli_simulation`
- full `mowgli_map` CTest suite: 7/7 passed
- full `mowgli_hardware` CTest suite: 8/8 passed
- `git diff --check`

No live mower or hardware commands were performed.