### PR TITLE
fix(behavior): key LocalizationGuard on GNSS health, not pivot covariance

### DIFF
--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -402,6 +402,21 @@ if(BUILD_TESTING)
     mowgli_interfaces
   )
 
+  # ---- test_localization_health ----
+  # Unit tests for the LocalizationGuard's input signal
+  # (localization_health.hpp). Pins the 2026-08-20 livelock: pivot/slip
+  # covariance inflation on a healthy RTK-Fixed receiver must NOT pause
+  # mowing, while the 2026-08-02 plain-GPS fallback still must.
+  # Header-only helper -> no source link.
+  ament_add_gtest(test_localization_health
+    test/test_localization_health.cpp
+  )
+
+  target_include_directories(test_localization_health PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
   # ---- test_battery_critical_resume ----
   # Regression for "robot stuck after a critical-battery charge": the
   # CriticalBatteryDock tail must AUTO-CONTINUE on recovery (undock, keep

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -238,13 +238,17 @@ struct BTContext
   /// operator" — blade/motors past this margin can do real damage.
   bool lethal_boundary_violation{false};
 
-  /// Set (with hysteresis, see behavior_tree_node's /odometry/filtered_map
-  /// callback) while the fused position uncertainty is too high to trust —
-  /// σ_xy above loc_sigma_pause_m latches it, dropping below
-  /// loc_sigma_resume_m clears it. The LocalizationGuard pauses blade-on
-  /// mowing while set: field incident 2026-08-02 — RTK dropped to plain GPS
-  /// (σ ≈ 1.5 m) for >60 s and FTC kept steering on the drifting estimate
-  /// until the robot physically left the area and BoundaryGuard tripped.
+  /// Set (with hysteresis, see behavior_tree_node's updateLocalizationHealthLocked)
+  /// while ABSOLUTE POSITION is untrustworthy. The LocalizationGuard pauses
+  /// blade-on mowing while set: field incident 2026-08-02 — RTK dropped to
+  /// plain GPS (σ ≈ 1.5 m) for >60 s and FTC kept steering on the drifting
+  /// estimate until the robot physically left the area and BoundaryGuard
+  /// tripped.
+  ///
+  /// Driven by GNSS solution quality from /gps/status, NOT by the fused
+  /// marginal covariance — fusion_graph inflates that deliberately on every
+  /// pivot, which livelocked mowing at 0 % on 2026-08-20. σ_xy survives only
+  /// as a generous divergence backstop. See localization_health.hpp.
   bool localization_degraded{false};
 
   /// Current navigation mode: "precise" or "degraded"

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
@@ -1,5 +1,17 @@
 // Copyright 2026 Mowgli Project
-// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 // LocalizationGuard input: is our ABSOLUTE POSITION trustworthy right now?
 // Pure logic, no ROS, so it is unit-testable standalone (see

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
@@ -1,0 +1,308 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// LocalizationGuard input: is our ABSOLUTE POSITION trustworthy right now?
+// Pure logic, no ROS, so it is unit-testable standalone (see
+// test_localization_health.cpp) — same shape as mowgli_hardware/dig_detector.hpp.
+//
+// ── Why this exists (and why it is NOT the fused covariance) ────────────────
+// The guard was added 2026-08-04 (#422) after the 2026-08-02 incident: RTK
+// fell back to plain GPS (σ ≈ 1.5 m) for >60 s and FTC kept steering on the
+// drifting estimate until the robot physically left the area. It keyed on
+// σ_xy from /odometry/filtered_map pose covariance.
+//
+// That was the wrong signal. fusion_graph DELIBERATELY releases the X
+// constraint as a design mechanism, so its marginal covariance balloons while
+// localization is perfectly healthy:
+//
+//   * pivot_wheel_sigma_x = 0.5 m/node whenever per-tick gyro dθ exceeds
+//     pivot_gate_dtheta_rad (~0.3 rad/s) — "effectively releasing the X
+//     constraint so GPS + scan-matching set XY" (graph_params.hpp).
+//   * adaptive_noise_enabled_gain = 10 inflates σ_x on the wheel↔gyro
+//     residual, up to ~1.05 m/node on a slip event.
+//
+// With node_period_s = 0.04 (25 Hz) and GNSS at 5 Hz there are ~5
+// GPS-unconstrained nodes per fix, so the head marginal reaches
+// sqrt(5)·0.5 ≈ 1.1 m on any pivot and sqrt(5)·0.092 ≈ 0.21 m in plain
+// driving — both above the old 0.15 m pause threshold. Parked, node cadence
+// drops to stationary_node_period_s = 5 s and GPS pins every node, so σ
+// settles at ~0.05 m, below the old 0.08 m resume threshold.
+//
+// The guard was therefore ONLY satisfiable while stopped, and FTC opens every
+// strip with a PRE_ROTATE pivot. Field 2026-08-20 (robot on RTK-Fixed at
+// hacc 0.014 m throughout): degrade at σ 0.57/0.74/0.81/0.92/0.99/1.07/1.38/
+// 1.86 m, recover at exactly 0.05 m every time, ten cycles in eight minutes,
+// FollowStrip pinned at pose 32/14104 (0%). A livelock — mowing never
+// started. 45a1cf8e made the guard actually halt the tree, which turned the
+// pre-existing false positive into a hard block (its own message records
+// "σ_xy = 0.83 m while the receiver held RTK-Fixed at 100 %").
+//
+// So: key the guard on what it actually cares about — GNSS solution quality
+// from the typed /gps/status contract, which reports the plain-GPS fallback
+// directly and does not move when the robot pivots.
+//
+// ── The σ backstop ─────────────────────────────────────────────────────────
+// One real hazard /gps/status cannot see: the localizer rejecting every fix
+// while the receiver stays healthy (the reverted GnssMobileGate runaway
+// documented in CLAUDE.md — "every fix rejected forever, GPS locked out, and
+// cov_xx ballooned to ~2.5 m σ"). So a SECOND, deliberately generous latch
+// keeps watching σ_xy. Its threshold must sit above the localizer's own
+// inflation ceiling (~2.35 m worst case above) — hence a 5 m default with a
+// long persistence, which no pivot can reach or sustain.
+//
+// This only ever PAUSES blade-on mowing. Firmware remains the sole blade
+// safety authority, and BoundaryGuard still independently covers "the robot
+// left the area".
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace mowgli_behavior
+{
+
+// RTK solution mode, mirroring mowgli_interfaces/GnssStatus RTK_MODE_*.
+// Duplicated as a plain enum so this header stays ROS-free and testable.
+enum class RtkMode : uint8_t
+{
+  kUnknown = 0,
+  kNone = 1,
+  kFloat = 2,
+  kFixed = 3,
+};
+
+/// Why the guard latched. Carried into the log line and asserted in tests.
+enum class LocalizationFault : uint8_t
+{
+  kNone = 0,
+  kGnssAccuracy,  ///< reported horizontal accuracy exceeded the pause threshold
+  kGnssFixLost,  ///< no accuracy available AND the receiver reports no RTK solution
+  kGnssStale,  ///< /gps/status stopped arriving
+  kSigmaBackstop,  ///< fused σ_xy implausible for long enough to mean divergence
+};
+
+struct LocalizationHealthCfg
+{
+  /// GNSS horizontal accuracy that pauses mowing [m], and the tighter value
+  /// that resumes it. Default 0.30/0.15 sits far above RTK-Fixed (~0.015 m)
+  /// and ordinary RTK-Float, but well under the ~1.5 m plain-GPS fallback the
+  /// guard exists to catch.
+  double gnss_acc_pause_m = 0.30;
+  double gnss_acc_resume_m = 0.15;
+
+  /// /gps/status older than this counts as a dead GNSS feed [s].
+  double gnss_stale_s = 5.0;
+
+  /// Debounce on the GNSS path: the condition must hold this long before the
+  /// latch flips, so per-epoch fix flicker does not chatter the guard.
+  double gnss_pause_persist_s = 3.0;
+  double gnss_resume_persist_s = 2.0;
+
+  /// Divergence backstop on the fused marginal [m]. MUST stay above the
+  /// localizer's deliberate pivot/slip inflation ceiling (~2.35 m) — see the
+  /// file header. Set 0 to disable the backstop entirely.
+  double sigma_backstop_pause_m = 5.0;
+  double sigma_backstop_resume_m = 2.0;
+  double sigma_backstop_persist_s = 10.0;
+};
+
+/// Hysteresis latch with independent enter/exit persistence.
+///
+/// `bad` and `good` are evaluated against DIFFERENT thresholds, so both are
+/// false inside the dead-band — which holds the latch wherever it already is.
+class PersistentLatch
+{
+public:
+  bool Update(double now_s, bool bad, bool good, double bad_persist_s, double good_persist_s)
+  {
+    if (!latched_)
+    {
+      good_since_s_ = -1.0;
+      if (!bad)
+      {
+        bad_since_s_ = -1.0;
+        return latched_;
+      }
+      if (bad_since_s_ < 0.0)
+        bad_since_s_ = now_s;
+      if (now_s - bad_since_s_ >= bad_persist_s)
+      {
+        latched_ = true;
+        bad_since_s_ = -1.0;
+      }
+      return latched_;
+    }
+
+    bad_since_s_ = -1.0;
+    if (!good)
+    {
+      good_since_s_ = -1.0;
+      return latched_;
+    }
+    if (good_since_s_ < 0.0)
+      good_since_s_ = now_s;
+    if (now_s - good_since_s_ >= good_persist_s)
+    {
+      latched_ = false;
+      good_since_s_ = -1.0;
+    }
+    return latched_;
+  }
+
+  bool latched() const
+  {
+    return latched_;
+  }
+
+  /// Seconds the pending (not yet flipped) condition has been held, or 0.
+  double pending_for_s(double now_s) const
+  {
+    const double since = latched_ ? good_since_s_ : bad_since_s_;
+    return since < 0.0 ? 0.0 : now_s - since;
+  }
+
+private:
+  bool latched_ = false;
+  double bad_since_s_ = -1.0;
+  double good_since_s_ = -1.0;
+};
+
+/// Everything the monitor knows about the current instant. Assembled by the
+/// caller from the two subscriptions; unavailable values are negative.
+struct LocalizationObservation
+{
+  /// True once ANY /gps/status has been received. While false the monitor
+  /// stays inert — see LocalizationHealthMonitor::Update.
+  bool gnss_seen = false;
+  /// Clock reading when the most recent /gps/status arrived [s].
+  double gnss_stamp_s = 0.0;
+  RtkMode rtk_mode = RtkMode::kUnknown;
+  /// Receiver-reported horizontal accuracy [m]; negative when unavailable
+  /// (capability bit clear, or NaN in the message).
+  double gnss_accuracy_m = -1.0;
+  /// σ_xy from the fused pose covariance [m]; negative when unavailable.
+  double fused_sigma_xy_m = -1.0;
+};
+
+/// Latches "absolute position is not trustworthy" from GNSS solution quality,
+/// with a generous fused-σ divergence backstop.
+class LocalizationHealthMonitor
+{
+public:
+  LocalizationHealthMonitor() = default;
+  explicit LocalizationHealthMonitor(const LocalizationHealthCfg& cfg) : cfg_(cfg)
+  {
+  }
+
+  /// Fold one observation in and return the latched degraded state.
+  bool Update(double now_s, const LocalizationObservation& obs)
+  {
+    // A guard that cannot observe its input must not block a bladed robot
+    // from operating. Legacy bring-ups without a /gps/status publisher keep
+    // mowing; BoundaryGuard still covers "the robot left the area".
+    if (!obs.gnss_seen)
+    {
+      fault_ = LocalizationFault::kNone;
+      return false;
+    }
+
+    const bool stale = (now_s - obs.gnss_stamp_s) > cfg_.gnss_stale_s;
+    const bool has_acc = obs.gnss_accuracy_m >= 0.0 && std::isfinite(obs.gnss_accuracy_m);
+    // Prefer the metric signal. rtk_mode only decides when the receiver does
+    // not report an accuracy at all — otherwise a receiver that leaves
+    // rtk_mode UNKNOWN while reporting 1.4 cm would be called degraded.
+    const bool no_rtk_solution =
+        obs.rtk_mode == RtkMode::kNone || obs.rtk_mode == RtkMode::kUnknown;
+
+    bool gnss_bad = stale;
+    bool gnss_good = !stale;
+    LocalizationFault pending = stale ? LocalizationFault::kGnssStale : LocalizationFault::kNone;
+    if (!stale)
+    {
+      if (has_acc)
+      {
+        gnss_bad = obs.gnss_accuracy_m > cfg_.gnss_acc_pause_m;
+        gnss_good = obs.gnss_accuracy_m < cfg_.gnss_acc_resume_m;
+        if (gnss_bad)
+          pending = LocalizationFault::kGnssAccuracy;
+      }
+      else
+      {
+        gnss_bad = no_rtk_solution;
+        gnss_good = !no_rtk_solution;
+        if (gnss_bad)
+          pending = LocalizationFault::kGnssFixLost;
+      }
+    }
+
+    const bool was_gnss = gnss_latch_.latched();
+    const bool gnss_degraded = gnss_latch_.Update(
+        now_s, gnss_bad, gnss_good, cfg_.gnss_pause_persist_s, cfg_.gnss_resume_persist_s);
+
+    // Divergence backstop. Disabled at 0, and skipped when σ is unavailable
+    // so a missing covariance never latches on its own.
+    bool sigma_degraded = false;
+    const bool was_sigma = sigma_latch_.latched();
+    if (cfg_.sigma_backstop_pause_m > 0.0 && obs.fused_sigma_xy_m >= 0.0 &&
+        std::isfinite(obs.fused_sigma_xy_m))
+    {
+      sigma_degraded = sigma_latch_.Update(now_s,
+                                           obs.fused_sigma_xy_m > cfg_.sigma_backstop_pause_m,
+                                           obs.fused_sigma_xy_m < cfg_.sigma_backstop_resume_m,
+                                           cfg_.sigma_backstop_persist_s,
+                                           cfg_.gnss_resume_persist_s);
+    }
+    else
+    {
+      sigma_degraded = was_sigma;
+    }
+
+    // Attribute the fault to whichever latch just closed; keep the existing
+    // attribution while both stay closed.
+    if (gnss_degraded && !was_gnss)
+      fault_ = pending;
+    else if (sigma_degraded && !was_sigma)
+      fault_ = LocalizationFault::kSigmaBackstop;
+    else if (!gnss_degraded && !sigma_degraded)
+      fault_ = LocalizationFault::kNone;
+
+    return gnss_degraded || sigma_degraded;
+  }
+
+  bool degraded() const
+  {
+    return gnss_latch_.latched() || sigma_latch_.latched();
+  }
+  LocalizationFault fault() const
+  {
+    return fault_;
+  }
+
+private:
+  LocalizationHealthCfg cfg_{};
+  PersistentLatch gnss_latch_{};
+  PersistentLatch sigma_latch_{};
+  LocalizationFault fault_ = LocalizationFault::kNone;
+};
+
+/// Short human-readable reason for the log line.
+inline const char* LocalizationFaultName(LocalizationFault fault)
+{
+  switch (fault)
+  {
+    case LocalizationFault::kGnssAccuracy:
+      return "GNSS accuracy";
+    case LocalizationFault::kGnssFixLost:
+      return "no RTK solution";
+    case LocalizationFault::kGnssStale:
+      return "GNSS feed stale";
+    case LocalizationFault::kSigmaBackstop:
+      return "fused-sigma divergence backstop";
+    case LocalizationFault::kNone:
+    default:
+      return "none";
+  }
+}
+
+}  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -31,6 +31,7 @@
 #include "mowgli_behavior/condition_nodes.hpp"
 #include "mowgli_behavior/coverage_nodes.hpp"
 #include "mowgli_behavior/coverage_persistence.hpp"
+#include "mowgli_behavior/localization_health.hpp"
 #include "mowgli_interfaces/gnss_status_utils.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
 #include "mowgli_interfaces/msg/emergency.hpp"
@@ -214,26 +215,32 @@ private:
                                                    context_->lethal_boundary_violation = msg->data;
                                                  });
 
-    // Localization-quality gate feed. σ_xy from the fused pose covariance,
-    // latched with hysteresis into context_->localization_degraded: above
-    // loc_sigma_pause_m ⇒ degraded (LocalizationGuard pauses blade-on
-    // mowing); only below loc_sigma_resume_m ⇒ trusted again. Field incident
-    // 2026-08-02: RTK fell back to plain GPS (σ ≈ 1.5 m) for >60 s and FTC
-    // kept steering on the drifting estimate until the robot physically
-    // left the area — pausing at σ > pause threshold ends that blind drive
-    // within one covariance update instead of at the boundary.
-    loc_sigma_pause_m_ = declare_parameter<double>("loc_sigma_pause_m", 0.15);
-    loc_sigma_resume_m_ = declare_parameter<double>("loc_sigma_resume_m", 0.08);
-    // Persistence debounce on TOP of the sigma hysteresis. The graph's
-    // marginal covariance spikes to ~0.8-0.9 m within seconds whenever a
-    // couple of GPS fixes are rejected/missed (wheel-only growth) and snaps
-    // back on the next accepted fix — field-measured 2026-08-02 at 32
-    // pause/resume flips in 15 min, which shredded mowing into stutter
-    // intervals (each resume restarts the strip with a pivot). Only a
-    // SUSTAINED degradation is worth pausing for; the incident this guard
-    // exists for lasted minutes.
-    loc_sigma_pause_persist_s_ = declare_parameter<double>("loc_sigma_pause_persist_s", 3.0);
-    loc_sigma_resume_persist_s_ = declare_parameter<double>("loc_sigma_resume_persist_s", 2.0);
+    // Localization-quality gate feed for LocalizationGuard, latched into
+    // context_->localization_degraded.
+    //
+    // The signal is GNSS SOLUTION QUALITY from the typed /gps/status contract
+    // — NOT the fused marginal covariance. fusion_graph deliberately releases
+    // the X constraint during pivots (pivot_wheel_sigma_x) and slip (adaptive
+    // noise gain), so its σ_xy swings to >1.8 m while the receiver holds
+    // RTK-Fixed at 1.4 cm; keying on it made the guard satisfiable ONLY while
+    // parked and livelocked mowing at 0 %. See localization_health.hpp for the
+    // full derivation and the 2026-08-20 field trace.
+    //
+    // σ_xy is still watched as a deliberately generous DIVERGENCE BACKSTOP
+    // (default 5 m), which no pivot can reach — that covers the localizer
+    // rejecting every fix while the receiver stays healthy.
+    LocalizationHealthCfg loc_cfg;
+    loc_cfg.gnss_acc_pause_m = declare_parameter<double>("loc_gnss_acc_pause_m", 0.30);
+    loc_cfg.gnss_acc_resume_m = declare_parameter<double>("loc_gnss_acc_resume_m", 0.15);
+    loc_cfg.gnss_stale_s = declare_parameter<double>("loc_gnss_stale_s", 5.0);
+    loc_cfg.gnss_pause_persist_s = declare_parameter<double>("loc_sigma_pause_persist_s", 3.0);
+    loc_cfg.gnss_resume_persist_s = declare_parameter<double>("loc_sigma_resume_persist_s", 2.0);
+    loc_cfg.sigma_backstop_pause_m = declare_parameter<double>("loc_sigma_pause_m", 5.0);
+    loc_cfg.sigma_backstop_resume_m = declare_parameter<double>("loc_sigma_resume_m", 2.0);
+    loc_cfg.sigma_backstop_persist_s =
+        declare_parameter<double>("loc_sigma_backstop_persist_s", 10.0);
+    loc_monitor_ = LocalizationHealthMonitor(loc_cfg);
+
     fused_odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
         "/odometry/filtered_map",
         rclcpp::QoS(5),
@@ -241,53 +248,9 @@ private:
         {
           const double sigma =
               std::sqrt(std::max({msg->pose.covariance[0], msg->pose.covariance[7], 0.0}));
-          const double now_s = get_clock()->now().seconds();
           std::lock_guard<std::mutex> lock(context_->context_mutex);
-          if (!context_->localization_degraded)
-          {
-            if (sigma > loc_sigma_pause_m_)
-            {
-              if (loc_deg_since_s_ < 0.0)
-                loc_deg_since_s_ = now_s;
-              if (now_s - loc_deg_since_s_ >= loc_sigma_pause_persist_s_)
-              {
-                context_->localization_degraded = true;
-                loc_rec_since_s_ = -1.0;
-                RCLCPP_WARN(get_logger(),
-                            "Localization degraded (σ_xy %.2f m > %.2f m for %.1f s) — "
-                            "pausing blade-on mowing until σ_xy < %.2f m.",
-                            sigma,
-                            loc_sigma_pause_m_,
-                            now_s - loc_deg_since_s_,
-                            loc_sigma_resume_m_);
-              }
-            }
-            else
-            {
-              loc_deg_since_s_ = -1.0;
-            }
-          }
-          else
-          {
-            if (sigma < loc_sigma_resume_m_)
-            {
-              if (loc_rec_since_s_ < 0.0)
-                loc_rec_since_s_ = now_s;
-              if (now_s - loc_rec_since_s_ >= loc_sigma_resume_persist_s_)
-              {
-                context_->localization_degraded = false;
-                loc_deg_since_s_ = -1.0;
-                RCLCPP_INFO(get_logger(),
-                            "Localization recovered (σ_xy %.2f m, stable %.1f s) — resuming.",
-                            sigma,
-                            now_s - loc_rec_since_s_);
-              }
-            }
-            else
-            {
-              loc_rec_since_s_ = -1.0;
-            }
-          }
+          loc_obs_.fused_sigma_xy_m = sigma;
+          updateLocalizationHealthLocked();
         });
 
     // GPS position for heading calibration during undock. RTK/fix-state comes
@@ -382,6 +345,18 @@ private:
         {
           std::lock_guard<std::mutex> lock(context_->context_mutex);
           has_authoritative_gnss_status_ = true;
+
+          // LocalizationGuard feed: the receiver's own view of solution
+          // quality. horizontal_accuracy_m is only trusted when the message's
+          // value_flags say it carries a live value; otherwise rtk_mode
+          // decides (see LocalizationHealthMonitor::Update).
+          loc_obs_.gnss_seen = true;
+          loc_obs_.gnss_stamp_s = get_clock()->now().seconds();
+          loc_obs_.rtk_mode = static_cast<mowgli_behavior::RtkMode>(msg->rtk_mode);
+          const auto acc = mowgli_interfaces::gnss_status_utils::HorizontalAccuracyMeters(*msg);
+          loc_obs_.gnss_accuracy_m = acc ? static_cast<double>(*acc) : -1.0;
+          updateLocalizationHealthLocked();
+
           context_->gps_fix_type = mowgli_interfaces::gnss_status_utils::BehaviorTreeFixType(*msg);
           context_->gps_quality = mowgli_interfaces::gnss_status_utils::NormalizedQuality(*msg);
 
@@ -572,6 +547,38 @@ private:
                                                 });
 
     RCLCPP_DEBUG(get_logger(), "~/clear_coverage_resume service + resume-available signal created");
+  }
+
+  // Fold the latest observation into the LocalizationGuard latch and log
+  // transitions. Caller MUST hold context_->context_mutex — both the
+  // /gps/status and /odometry/filtered_map callbacks take it before writing
+  // loc_obs_, so the monitor sees a consistent snapshot.
+  void updateLocalizationHealthLocked()
+  {
+    const double now_s = get_clock()->now().seconds();
+    const bool was_degraded = context_->localization_degraded;
+    const bool degraded = loc_monitor_.Update(now_s, loc_obs_);
+    if (degraded == was_degraded)
+      return;
+
+    context_->localization_degraded = degraded;
+    if (degraded)
+    {
+      RCLCPP_WARN(get_logger(),
+                  "Localization degraded (%s: GNSS acc %.3f m, rtk_mode %u, fused σ_xy %.2f m) — "
+                  "pausing blade-on mowing.",
+                  LocalizationFaultName(loc_monitor_.fault()),
+                  loc_obs_.gnss_accuracy_m,
+                  static_cast<unsigned>(loc_obs_.rtk_mode),
+                  loc_obs_.fused_sigma_xy_m);
+    }
+    else
+    {
+      RCLCPP_INFO(get_logger(),
+                  "Localization recovered (GNSS acc %.3f m, rtk_mode %u) — resuming.",
+                  loc_obs_.gnss_accuracy_m,
+                  static_cast<unsigned>(loc_obs_.rtk_mode));
+    }
   }
 
   // Re-publish the last HighLevelStatus at a steady cadence. PublishHighLevelStatus
@@ -918,12 +925,10 @@ private:
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr boundary_violation_sub_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr lethal_boundary_violation_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr fused_odom_sub_;
-  double loc_sigma_pause_m_{0.15};
-  double loc_sigma_resume_m_{0.08};
-  double loc_sigma_pause_persist_s_{3.0};
-  double loc_sigma_resume_persist_s_{2.0};
-  double loc_deg_since_s_{-1.0};
-  double loc_rec_since_s_{-1.0};
+  // LocalizationGuard state. Both feeds write loc_obs_ under
+  // context_->context_mutex and then call updateLocalizationHealthLocked().
+  LocalizationHealthMonitor loc_monitor_{};
+  LocalizationObservation loc_obs_{};
   rclcpp::Subscription<mowgli_interfaces::msg::AbsolutePose>::SharedPtr gps_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::GnssStatus>::SharedPtr gnss_status_sub_;
   rclcpp::Subscription<nav2_msgs::msg::CollisionMonitorState>::SharedPtr collision_monitor_sub_;

--- a/ros2/src/mowgli_behavior/test/test_localization_health.cpp
+++ b/ros2/src/mowgli_behavior/test/test_localization_health.cpp
@@ -1,5 +1,17 @@
 // Copyright 2026 Mowgli Project
-// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 // Unit tests for the LocalizationGuard's input signal
 // (mowgli_behavior/localization_health.hpp).

--- a/ros2/src/mowgli_behavior/test/test_localization_health.cpp
+++ b/ros2/src/mowgli_behavior/test/test_localization_health.cpp
@@ -1,0 +1,407 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Unit tests for the LocalizationGuard's input signal
+// (mowgli_behavior/localization_health.hpp).
+//
+// The headline regression is PivotCovarianceSpikeDoesNotDegrade: replaying the
+// 2026-08-20 field trace — RTK-Fixed at hacc 0.014 m throughout while the
+// fused marginal swung 0.05 m parked -> 1.86 m pivoting — must NOT pause
+// mowing. Under the old σ-only guard that trace was a livelock: ten
+// degrade/recover cycles in eight minutes with FollowStrip pinned at 0 %.
+
+#include <vector>
+
+#include "mowgli_behavior/localization_health.hpp"
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using mowgli_behavior::LocalizationFault;
+using mowgli_behavior::LocalizationHealthCfg;
+using mowgli_behavior::LocalizationHealthMonitor;
+using mowgli_behavior::LocalizationObservation;
+using mowgli_behavior::PersistentLatch;
+using mowgli_behavior::RtkMode;
+
+// A healthy RTK-Fixed epoch, as the live robot reports it.
+LocalizationObservation HealthyFix(double now_s, double sigma_xy = 0.05)
+{
+  LocalizationObservation obs;
+  obs.gnss_seen = true;
+  obs.gnss_stamp_s = now_s;
+  obs.rtk_mode = RtkMode::kFixed;
+  obs.gnss_accuracy_m = 0.014;
+  obs.fused_sigma_xy_m = sigma_xy;
+  return obs;
+}
+
+// Drive the monitor for `duration_s` at 5 Hz (the GNSS rate) with a
+// per-sample observation builder. Returns true if it EVER latched.
+template <typename MakeObs>
+bool RunFor(LocalizationHealthMonitor* mon, double start_s, double duration_s, MakeObs make)
+{
+  bool ever = false;
+  for (double t = start_s; t <= start_s + duration_s; t += 0.2)
+  {
+    if (mon->Update(t, make(t)))
+      ever = true;
+  }
+  return ever;
+}
+
+// ── The regression this change exists for ──────────────────────────────────
+
+TEST(LocalizationHealthTest, PivotCovarianceSpikeDoesNotDegrade)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // Field 2026-08-20: every degrade fired at one of these σ values while the
+  // receiver held RTK-Fixed; every recovery read exactly 0.05 m (parked).
+  const std::vector<double> field_sigmas = {
+      0.05, 0.57, 0.05, 0.74, 0.81, 0.05, 0.92, 0.99, 1.07, 0.05, 1.38, 1.86, 0.05};
+
+  double t = 100.0;
+  bool ever_degraded = false;
+  for (double sigma : field_sigmas)
+  {
+    // Hold each value for 15 s — far longer than any persistence window.
+    if (RunFor(&mon,
+               t,
+               15.0,
+               [sigma](double now)
+               {
+                 return HealthyFix(now, sigma);
+               }))
+      ever_degraded = true;
+    t += 15.2;
+  }
+
+  EXPECT_FALSE(ever_degraded) << "pivot/slip covariance inflation must not pause mowing "
+                                 "while the receiver reports RTK-Fixed at 1.4 cm";
+  EXPECT_FALSE(mon.degraded());
+  EXPECT_EQ(mon.fault(), LocalizationFault::kNone);
+}
+
+// ── The incident the guard exists for must still be caught ─────────────────
+
+TEST(LocalizationHealthTest, PlainGpsFallbackStillDegrades)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  ASSERT_FALSE(RunFor(&mon,
+                      0.0,
+                      10.0,
+                      [](double now)
+                      {
+                        return HealthyFix(now);
+                      }));
+
+  // 2026-08-02: RTK -> plain GPS, sigma ~1.5 m, for >60 s.
+  const bool degraded = RunFor(&mon,
+                               20.0,
+                               60.0,
+                               [](double now)
+                               {
+                                 LocalizationObservation obs;
+                                 obs.gnss_seen = true;
+                                 obs.gnss_stamp_s = now;
+                                 obs.rtk_mode = RtkMode::kNone;
+                                 obs.gnss_accuracy_m = 1.5;
+                                 obs.fused_sigma_xy_m = 1.5;
+                                 return obs;
+                               });
+
+  EXPECT_TRUE(degraded);
+  EXPECT_TRUE(mon.degraded());
+  EXPECT_EQ(mon.fault(), LocalizationFault::kGnssAccuracy);
+}
+
+TEST(LocalizationHealthTest, RecoveryReleasesTheLatch)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  ASSERT_TRUE(RunFor(&mon,
+                     0.0,
+                     30.0,
+                     [](double now)
+                     {
+                       LocalizationObservation obs;
+                       obs.gnss_seen = true;
+                       obs.gnss_stamp_s = now;
+                       obs.rtk_mode = RtkMode::kNone;
+                       obs.gnss_accuracy_m = 1.5;
+                       return obs;
+                     }));
+
+  // RTK-Fixed comes back; the resume persistence is 2 s.
+  RunFor(&mon,
+         40.0,
+         10.0,
+         [](double now)
+         {
+           return HealthyFix(now);
+         });
+  EXPECT_FALSE(mon.degraded());
+  EXPECT_EQ(mon.fault(), LocalizationFault::kNone);
+}
+
+// ── Debounce ───────────────────────────────────────────────────────────────
+
+TEST(LocalizationHealthTest, BriefAccuracyExcursionDoesNotFlipTheLatch)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // 2 s of bad accuracy, under the 3 s pause persistence.
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               2.0,
+                               [](double now)
+                               {
+                                 LocalizationObservation obs;
+                                 obs.gnss_seen = true;
+                                 obs.gnss_stamp_s = now;
+                                 obs.rtk_mode = RtkMode::kFloat;
+                                 obs.gnss_accuracy_m = 0.9;
+                                 return obs;
+                               });
+
+  EXPECT_FALSE(degraded);
+}
+
+TEST(LocalizationHealthTest, DeadBandHoldsTheLatchUntilAccuracyClearsResume)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  ASSERT_TRUE(RunFor(&mon,
+                     0.0,
+                     30.0,
+                     [](double now)
+                     {
+                       LocalizationObservation obs;
+                       obs.gnss_seen = true;
+                       obs.gnss_stamp_s = now;
+                       obs.rtk_mode = RtkMode::kFloat;
+                       obs.gnss_accuracy_m = 1.2;
+                       return obs;
+                     }));
+
+  // 0.20 m sits between resume (0.15) and pause (0.30): still latched.
+  RunFor(&mon,
+         40.0,
+         30.0,
+         [](double now)
+         {
+           LocalizationObservation obs;
+           obs.gnss_seen = true;
+           obs.gnss_stamp_s = now;
+           obs.rtk_mode = RtkMode::kFloat;
+           obs.gnss_accuracy_m = 0.20;
+           return obs;
+         });
+  EXPECT_TRUE(mon.degraded());
+}
+
+// ── Feed health ────────────────────────────────────────────────────────────
+
+TEST(LocalizationHealthTest, StaleGnssFeedDegrades)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+  ASSERT_FALSE(RunFor(&mon,
+                      0.0,
+                      10.0,
+                      [](double now)
+                      {
+                        return HealthyFix(now);
+                      }));
+
+  // /gps/status stops at t=10; clock keeps running.
+  LocalizationObservation frozen = HealthyFix(10.0);
+  bool degraded = false;
+  for (double t = 10.0; t <= 30.0; t += 0.2)
+    degraded = mon.Update(t, frozen);
+
+  EXPECT_TRUE(degraded);
+  EXPECT_EQ(mon.fault(), LocalizationFault::kGnssStale);
+}
+
+TEST(LocalizationHealthTest, MonitorIsInertBeforeAnyGnssStatus)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // Legacy bring-up: no /gps/status publisher, huge fused sigma. The guard
+  // must not block — BoundaryGuard still covers leaving the area.
+  LocalizationObservation obs;
+  obs.gnss_seen = false;
+  obs.fused_sigma_xy_m = 40.0;
+
+  bool degraded = false;
+  for (double t = 0.0; t <= 60.0; t += 0.2)
+    degraded = mon.Update(t, obs);
+
+  EXPECT_FALSE(degraded);
+}
+
+TEST(LocalizationHealthTest, MissingAccuracyFallsBackToRtkMode)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // Receiver reports no accuracy but a valid Float solution -> trusted.
+  ASSERT_FALSE(RunFor(&mon,
+                      0.0,
+                      20.0,
+                      [](double now)
+                      {
+                        LocalizationObservation obs;
+                        obs.gnss_seen = true;
+                        obs.gnss_stamp_s = now;
+                        obs.rtk_mode = RtkMode::kFloat;
+                        obs.gnss_accuracy_m = -1.0;
+                        return obs;
+                      }));
+
+  // Solution lost and still no accuracy -> degrade.
+  const bool degraded = RunFor(&mon,
+                               30.0,
+                               20.0,
+                               [](double now)
+                               {
+                                 LocalizationObservation obs;
+                                 obs.gnss_seen = true;
+                                 obs.gnss_stamp_s = now;
+                                 obs.rtk_mode = RtkMode::kNone;
+                                 obs.gnss_accuracy_m = -1.0;
+                                 return obs;
+                               });
+  EXPECT_TRUE(degraded);
+  EXPECT_EQ(mon.fault(), LocalizationFault::kGnssFixLost);
+}
+
+TEST(LocalizationHealthTest, GoodAccuracyOutranksUnknownRtkMode)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // A receiver that never fills rtk_mode but reports 1.4 cm is healthy.
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               60.0,
+                               [](double now)
+                               {
+                                 LocalizationObservation obs;
+                                 obs.gnss_seen = true;
+                                 obs.gnss_stamp_s = now;
+                                 obs.rtk_mode = RtkMode::kUnknown;
+                                 obs.gnss_accuracy_m = 0.014;
+                                 return obs;
+                               });
+  EXPECT_FALSE(degraded);
+}
+
+// ── Divergence backstop ────────────────────────────────────────────────────
+
+TEST(LocalizationHealthTest, SigmaBackstopCatchesLocalizerDivergence)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // GnssMobileGate-style runaway: receiver perfect, localizer rejecting every
+  // fix, sigma parked far above the pivot ceiling.
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               30.0,
+                               [](double now)
+                               {
+                                 return HealthyFix(now, 8.0);
+                               });
+
+  EXPECT_TRUE(degraded);
+  EXPECT_EQ(mon.fault(), LocalizationFault::kSigmaBackstop);
+}
+
+TEST(LocalizationHealthTest, SigmaBackstopSitsAboveThePivotInflationCeiling)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  // Worst-case deliberate inflation is sqrt(5)*1.05 ~= 2.35 m (adaptive gain
+  // fully engaged). Held indefinitely, that must never reach the backstop.
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               120.0,
+                               [](double now)
+                               {
+                                 return HealthyFix(now, 2.35);
+                               });
+
+  EXPECT_FALSE(degraded);
+}
+
+TEST(LocalizationHealthTest, SigmaBackstopDisabledAtZero)
+{
+  LocalizationHealthCfg cfg;
+  cfg.sigma_backstop_pause_m = 0.0;
+  LocalizationHealthMonitor mon{cfg};
+
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               120.0,
+                               [](double now)
+                               {
+                                 return HealthyFix(now, 40.0);
+                               });
+  EXPECT_FALSE(degraded);
+}
+
+TEST(LocalizationHealthTest, MissingSigmaNeverLatchesTheBackstop)
+{
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+
+  const bool degraded = RunFor(&mon,
+                               0.0,
+                               120.0,
+                               [](double now)
+                               {
+                                 return HealthyFix(now, -1.0);
+                               });
+  EXPECT_FALSE(degraded);
+}
+
+// ── PersistentLatch itself ─────────────────────────────────────────────────
+
+TEST(PersistentLatchTest, RequiresSustainedConditionInBothDirections)
+{
+  PersistentLatch latch;
+
+  EXPECT_FALSE(latch.Update(0.0, /*bad=*/true, /*good=*/false, 3.0, 2.0));
+  EXPECT_FALSE(latch.Update(2.9, true, false, 3.0, 2.0));
+  EXPECT_TRUE(latch.Update(3.0, true, false, 3.0, 2.0));
+
+  EXPECT_TRUE(latch.Update(4.0, false, true, 3.0, 2.0));
+  EXPECT_TRUE(latch.Update(5.9, false, true, 3.0, 2.0));
+  EXPECT_FALSE(latch.Update(6.0, false, true, 3.0, 2.0));
+}
+
+TEST(PersistentLatchTest, InterruptedConditionRestartsTheTimer)
+{
+  PersistentLatch latch;
+
+  EXPECT_FALSE(latch.Update(0.0, true, false, 3.0, 2.0));
+  EXPECT_FALSE(latch.Update(2.0, false, true, 3.0, 2.0));  // resets
+  EXPECT_FALSE(latch.Update(4.0, true, false, 3.0, 2.0));  // starts over
+  EXPECT_FALSE(latch.Update(6.9, true, false, 3.0, 2.0));
+  EXPECT_TRUE(latch.Update(7.0, true, false, 3.0, 2.0));
+}
+
+TEST(PersistentLatchTest, DeadBandHoldsCurrentState)
+{
+  PersistentLatch latch;
+
+  // Neither bad nor good (inside the hysteresis dead-band).
+  for (double t = 0.0; t < 100.0; t += 1.0)
+    EXPECT_FALSE(latch.Update(t, false, false, 3.0, 2.0));
+
+  ASSERT_TRUE(latch.Update(100.0, true, false, 0.0, 2.0));
+  for (double t = 101.0; t < 200.0; t += 1.0)
+    EXPECT_TRUE(latch.Update(t, false, false, 3.0, 2.0));
+}
+
+}  // namespace

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -92,18 +92,39 @@ mowgli:
     # Behavior tree tuning (consumed by behavior_tree_node)
     tick_rate: 10.0
     # Localization-quality gate (LocalizationGuard): pause blade-on mowing
-    # while the fused σ_xy exceeds loc_sigma_pause_m; resume once it falls
-    # below loc_sigma_resume_m (hysteresis so RTK flapping doesn't chatter).
-    # Field incident 2026-08-02: >60 s plain-GPS fallback (σ ≈ 1.5 m) drove
-    # the robot out of the area before BoundaryGuard could see it.
-    loc_sigma_pause_m: 0.15
-    loc_sigma_resume_m: 0.08
-    # Persistence debounce: σ must stay beyond the threshold this long before
-    # the guard flips. Graph covariance spikes to ~0.9 m for a few seconds on
-    # every rejected/missed GPS fix and snaps back — without the debounce the
-    # guard flipped 32× in 15 min and shredded mowing into stutter intervals.
+    # while ABSOLUTE POSITION is untrustworthy. Field incident 2026-08-02:
+    # >60 s plain-GPS fallback (σ ≈ 1.5 m) drove the robot out of the area
+    # before BoundaryGuard could see it.
+    #
+    # The signal is GNSS solution quality from /gps/status, NOT the fused
+    # marginal covariance. fusion_graph deliberately releases the X constraint
+    # during pivots (pivot_wheel_sigma_x = 0.5 m/node) and slip (adaptive
+    # noise gain 10), so its σ_xy reaches >1.8 m while the receiver holds
+    # RTK-Fixed at 1.4 cm. The old σ-keyed gate at 0.15/0.08 m was therefore
+    # only satisfiable while PARKED (σ ≈ 0.05 m) and re-tripped on FTC's
+    # PRE_ROTATE at every strip start — field 2026-08-20: ten degrade/recover
+    # cycles in eight minutes with FollowStrip pinned at 0 %, a livelock.
+    # See mowgli_behavior/localization_health.hpp for the full derivation.
+    #
+    # Pause above this receiver-reported horizontal accuracy, resume below the
+    # tighter one. Defaults sit far above RTK-Fixed (~0.015 m) and ordinary
+    # RTK-Float, but well under the ~1.5 m plain-GPS fallback being caught.
+    loc_gnss_acc_pause_m: 0.30
+    loc_gnss_acc_resume_m: 0.15
+    # /gps/status older than this counts as a dead GNSS feed [s].
+    loc_gnss_stale_s: 5.0
+    # Persistence debounce: the condition must hold this long before the guard
+    # flips, so per-epoch RTK fix flicker does not chatter it.
     loc_sigma_pause_persist_s: 3.0
     loc_sigma_resume_persist_s: 2.0
+    # Divergence backstop on the fused σ_xy — the one hazard /gps/status
+    # cannot see: the localizer rejecting every fix while the receiver stays
+    # healthy (the reverted GnssMobileGate runaway, σ ≈ 2.5 m). MUST stay
+    # above fusion_graph's own inflation ceiling (~2.35 m worst case) or the
+    # 2026-08-20 livelock comes straight back. 0 disables the backstop.
+    loc_sigma_pause_m: 5.0
+    loc_sigma_resume_m: 2.0
+    loc_sigma_backstop_persist_s: 10.0
     bt_debug_logging: false
     # idle_nav2_suspend (default false): when true, the BT PAUSEs the Nav2
     # lifecycle stack while parked on the dock so the costmaps stop looping and

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -246,6 +246,35 @@ def generate_launch_description() -> LaunchDescription:
             # fixed swath angle in degrees. Read by PlanCoverageArea::buildGoal
             # off the BT blackboard into the plan_coverage action goal.
             {"mow_angle_deg": float(robot_params.get("mow_angle_deg", -1.0))},
+            # LocalizationGuard thresholds. These were previously listed in
+            # mowgli_robot.yaml but NEVER forwarded here, so the node silently
+            # ran its compiled defaults and the GUI's reset-to-default had
+            # nothing to act on. The guard keys on GNSS solution quality from
+            # /gps/status — see mowgli_behavior/localization_health.hpp for why
+            # the fused covariance is the wrong signal.
+            {"loc_gnss_acc_pause_m": float(robot_params.get("loc_gnss_acc_pause_m", 0.30))},
+            {"loc_gnss_acc_resume_m": float(robot_params.get("loc_gnss_acc_resume_m", 0.15))},
+            {"loc_gnss_stale_s": float(robot_params.get("loc_gnss_stale_s", 5.0))},
+            {
+                "loc_sigma_pause_persist_s": float(
+                    robot_params.get("loc_sigma_pause_persist_s", 3.0)
+                )
+            },
+            {
+                "loc_sigma_resume_persist_s": float(
+                    robot_params.get("loc_sigma_resume_persist_s", 2.0)
+                )
+            },
+            # Divergence backstop — MUST stay above fusion_graph's own
+            # pivot/slip inflation ceiling (~2.35 m) or the 2026-08-20
+            # livelock returns. 0 disables it.
+            {"loc_sigma_pause_m": float(robot_params.get("loc_sigma_pause_m", 5.0))},
+            {"loc_sigma_resume_m": float(robot_params.get("loc_sigma_resume_m", 2.0))},
+            {
+                "loc_sigma_backstop_persist_s": float(
+                    robot_params.get("loc_sigma_backstop_persist_s", 10.0)
+                )
+            },
             # Battery thresholds — operator-tunable in mowgli_robot.yaml and
             # surfaced on the GUI Settings page. Forwarded here under the C++
             # parameter names the behavior node declares (behavior_tree.yaml


### PR DESCRIPTION
## Problem

Mowing never leaves 0 %. The BT loops `WAITING_FOR_RTK` → stop → recover → `WAITING_FOR_RTK` while the receiver holds RTK-Fixed at 1.4 cm the whole time.

Field 2026-08-20 (`10.69.4.198`, image rev `116fd0df`) — ten cycles in eight minutes, `FollowStrip` pinned at pose 32/14104:

```
355.010  FTCController: state=1 idx=29/451 ang=0.678(deg=38.9)   <- pivot
355.110  Localization degraded (σ_xy 1.38 m > 0.15 m for 3.0 s)
355.204  FollowStrip: area 0 interrupted at pose 32/14104 (0%)
```

Degrade fired at σ 0.57 / 0.74 / 0.81 / 0.92 / 0.99 / 1.07 / 1.38 / 1.86 m; recovery read **exactly 0.05 m every time**. Bimodal on *motion*, not on GPS — live `/gps/status` was `rtk_mode=3`, `horizontal_accuracy_m=0.014`, 5.13 Hz, header-stamp lag 2 ms, `gps_rejects_wrongfix=2` throughout.

## Root cause

A signal mismatch. `LocalizationGuard` (af1f0556, #422) keyed on σ_xy from `/odometry/filtered_map` — but `fusion_graph` **deliberately** releases the X constraint:

- `pivot_wheel_sigma_x = 0.5` m/node above `pivot_gate_dtheta_rad` (~0.3 rad/s) — *"effectively releasing the X constraint so GPS + scan-matching set XY"*
- `adaptive_noise_enabled_gain = 10` on the wheel↔gyro residual

With `node_period_s = 0.04` (25 Hz) and GNSS at 5 Hz there are ~5 GPS-unconstrained nodes per fix, so the head marginal reaches `sqrt(5)·0.5 ≈ 1.1 m` on any pivot and `sqrt(5)·0.092 ≈ 0.21 m` in plain driving — both above the 0.15 m pause threshold. Parked, cadence drops to `stationary_node_period_s = 5 s` and GPS pins every node, so σ settles at ~0.05 m, below the 0.08 m resume threshold.

**The guard was only satisfiable while stopped**, and FTC opens every strip with a PRE_ROTATE pivot. 45a1cf8e then made the guard actually halt the tree, turning a pre-existing false positive into a hard block — its own message records *"σ_xy = 0.83 m while the receiver held RTK-Fixed at 100 %"*.

## Fix

Key the guard on GNSS solution quality from the typed `/gps/status` contract, which reports the plain-GPS fallback directly and does not move when the robot pivots. New pure header `localization_health.hpp` (no ROS, unit-tested standalone — same shape as `mowgli_hardware/dig_detector.hpp`):

- pause above `loc_gnss_acc_pause_m` (0.30 m), resume below `loc_gnss_acc_resume_m` (0.15 m), existing 3 s / 2 s debounce
- `rtk_mode` decides only when the receiver reports no accuracy at all, so a receiver leaving `rtk_mode` UNKNOWN while reporting 1.4 cm stays trusted
- dead `/gps/status` feed (`loc_gnss_stale_s`, 5 s) degrades
- before **any** `/gps/status` the monitor is inert — a guard that cannot observe its input must not block a bladed robot, and BoundaryGuard still covers leaving the area

σ_xy survives as a deliberately generous **divergence backstop** (5 m / 2 m, 10 s persist) for the one hazard `/gps/status` cannot see: the localizer rejecting every fix while the receiver stays healthy (the reverted `GnssMobileGate` runaway, σ ≈ 2.5 m). 5 m sits above fusion_graph's own inflation ceiling (~2.35 m worst case), so no pivot can reach or sustain it.

Also forwards the thresholds from `mowgli_robot.yaml` in `full_system.launch.py` — they were listed in the template but **never passed to the node**, so it silently ran compiled defaults and the GUI's reset-to-default had nothing to act on.

## Test plan

- [x] `test_localization_health` — 16 tests, pins both directions: the recorded 2026-08-20 σ trace must **not** degrade; the 2026-08-02 plain-GPS fallback **must**
- [x] Regression test has teeth — replaying the same trace through the old σ-only shape flips the latch 8×
- [x] Backstop asserted to sit above the pivot inflation ceiling, and to catch an 8 m divergence
- [x] clang-format clean; no line >100 chars
- [ ] CI: full `mowgli_behavior` suite + lint
- [ ] **Field test owed** — confirm mowing gets past 0 % and that a real RTK→plain-GPS fallback still pauses

## Safety

Does not change firmware blade-safety authority. The guard's blade-off and stop nodes still run every tick, and the `AlwaysFailure` terminator from 45a1cf8e is untouched. This change makes the guard **less** trigger-happy, so it warrants the field test above before merging to main.

Refs #459, #445