### PR TITLE
fix(behavior): stop the GUI battery gauge freezing while charging

### DIFF
--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(behavior_tree_node
   src/docking_nodes.cpp
   src/calibration_nodes.cpp
   src/status_nodes.cpp
+  src/status_snapshot.cpp
   src/utility_nodes.cpp
   src/coverage_nodes.cpp
   src/coverage_persistence.cpp
@@ -425,6 +426,7 @@ if(BUILD_TESTING)
     test/test_battery_critical_resume.cpp
     src/condition_nodes.cpp
     src/status_nodes.cpp
+    src/status_snapshot.cpp
     src/coverage_persistence.cpp
   )
 
@@ -472,6 +474,36 @@ if(BUILD_TESTING)
   )
 
   ament_target_dependencies(test_guard_fallthrough
+    rclcpp
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+  )
+
+  # ---- test_high_level_status_snapshot ----
+  # Regression for the frozen GUI gauges: behavior_tree_node's 1 Hz republish
+  # timer used to re-send the CACHED HighLevelStatus verbatim, so every live
+  # field stalled while the tree sat in a transition-free branch (battery pinned
+  # for the whole low-battery charge hold; mowing progress pinned for the whole
+  # FollowStrip). Pins the tree-owned vs live-field split.
+  ament_add_gtest(test_high_level_status_snapshot
+    test/test_high_level_status_snapshot.cpp
+    src/status_snapshot.cpp
+  )
+
+  target_include_directories(test_high_level_status_snapshot PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  ament_target_dependencies(test_high_level_status_snapshot
     rclcpp
     behaviortree_cpp
     mowgli_interfaces

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_snapshot.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_snapshot.hpp
@@ -48,8 +48,7 @@ namespace mowgli_behavior
 /// BTContext::context_mutex across the call, since the fields read here are
 /// written by subscriber callbacks on another thread.
 mowgli_interfaces::msg::HighLevelStatus withLiveStatusFields(
-    const mowgli_interfaces::msg::HighLevelStatus& base,
-    const BTContext& ctx);
+    const mowgli_interfaces::msg::HighLevelStatus& base, const BTContext& ctx);
 
 }  // namespace mowgli_behavior
 

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_snapshot.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_snapshot.hpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+
+#ifndef MOWGLI_BEHAVIOR__STATUS_SNAPSHOT_HPP_
+#define MOWGLI_BEHAVIOR__STATUS_SNAPSHOT_HPP_
+
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_interfaces/msg/high_level_status.hpp"
+
+namespace mowgli_behavior
+{
+
+/// Return a copy of @p base with every context-derived field refreshed from
+/// @p ctx, keeping the tree-owned state identity (state / state_name /
+/// sub_state_name) exactly as cached.
+///
+/// HighLevelStatus mixes two kinds of field. The state identity is only
+/// meaningful at a tree transition, so PublishHighLevelStatus (a SyncActionNode)
+/// is its sole author. Everything else — battery, GPS quality, charging,
+/// emergency, area + swath progress — is live sensor/plan state that the
+/// subscriber callbacks and the coverage nodes keep current in the BTContext
+/// between transitions.
+///
+/// behavior_tree_node's 1 Hz republish timer used to re-send the cached message
+/// verbatim, which froze the live half for as long as the tree sat in a
+/// transition-free branch. On the robot 2026-08-23 the low-battery charge hold
+/// (a single "CHARGING" publish followed by a 30 s retry loop) pinned the GUI
+/// battery gauge at the percent captured at dock contact for the entire charge;
+/// a multi-minute FollowStrip froze the mowing progress the same way. Routing
+/// both the transition publish and the periodic republish through this one
+/// projection keeps the two paths from drifting apart again.
+///
+/// Pure: no locking, no ROS. The caller owns synchronisation — hold
+/// BTContext::context_mutex across the call, since the fields read here are
+/// written by subscriber callbacks on another thread.
+mowgli_interfaces::msg::HighLevelStatus withLiveStatusFields(
+    const mowgli_interfaces::msg::HighLevelStatus& base,
+    const BTContext& ctx);
+
+}  // namespace mowgli_behavior
+
+#endif  // MOWGLI_BEHAVIOR__STATUS_SNAPSHOT_HPP_

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -32,6 +32,7 @@
 #include "mowgli_behavior/coverage_nodes.hpp"
 #include "mowgli_behavior/coverage_persistence.hpp"
 #include "mowgli_behavior/localization_health.hpp"
+#include "mowgli_behavior/status_snapshot.hpp"
 #include "mowgli_interfaces/gnss_status_utils.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
 #include "mowgli_interfaces/msg/emergency.hpp"
@@ -598,6 +599,15 @@ private:
                                                  });
   }
 
+  // Re-publish the last state identity with the LIVE context fields folded in.
+  // Publishing the cached message verbatim froze everything the operator
+  // watches for as long as the tree sat in a transition-free branch: the
+  // low-battery charge hold publishes "CHARGING" once and then loops on a 30 s
+  // wait, so the GUI battery gauge stayed pinned at the percent captured at
+  // dock contact for the whole charge (observed 2026-08-23: 46.03 % while the
+  // pack actually climbed 25.84 V → 26.42 V), and a multi-minute FollowStrip
+  // froze the mowing progress the same way. Only state/state_name/sub_state_name
+  // are genuinely tree-owned; see status_snapshot.hpp.
   void republishHighLevelStatus()
   {
     std::lock_guard<std::mutex> lock(context_->context_mutex);
@@ -605,7 +615,8 @@ private:
     {
       return;
     }
-    context_->high_level_status_pub->publish(context_->last_high_level_status);
+    context_->high_level_status_pub->publish(
+        withLiveStatusFields(context_->last_high_level_status, *context_));
   }
 
   // Publish whether a coverage session can be resumed (a persisted resume cursor

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -16,6 +16,7 @@
 #include "mowgli_behavior/status_nodes.hpp"
 
 #include "mowgli_behavior/coverage_persistence.hpp"
+#include "mowgli_behavior/status_snapshot.hpp"
 
 namespace mowgli_behavior
 {
@@ -85,38 +86,22 @@ BT::NodeStatus PublishHighLevelStatus::tick()
     pending_idle_ticks_ = 0;
   }
 
-  mowgli_interfaces::msg::HighLevelStatus msg;
-  msg.state = published_state;
-  msg.state_name = name_res.value();
+  mowgli_interfaces::msg::HighLevelStatus identity;
+  identity.state = published_state;
+  identity.state_name = name_res.value();
+  identity.sub_state_name = "";
   last_published_state_ = published_state;
   have_published_ = true;
-  msg.sub_state_name = "";
-  msg.current_area = static_cast<int16_t>(ctx->current_area);
-  // Real per-area swath progress. The GUI computes progress as
-  // current_path_index / current_path * 100 (MowerStatus.tsx,
-  // MowgliNextPage.tsx), so current_path is the DENOMINATOR (total swaths in
-  // the current area's plan) and current_path_index the NUMERATOR (completed
-  // swaths). Both are tracked by PlanCoverageArea/FollowStrip in coverage_nodes
-  // (ctx->total_swaths / ctx->completed_swaths). Previously current_path was
-  // hardcoded to -1, which made the GUI ratio divide by a negative and never
-  // render a real percentage.
-  msg.current_path = static_cast<int16_t>(ctx->total_swaths);
-  msg.current_path_index = static_cast<int16_t>(ctx->completed_swaths);
-  msg.total_swaths = static_cast<int16_t>(ctx->total_swaths);
-  msg.completed_swaths = static_cast<int16_t>(ctx->completed_swaths);
-  msg.skipped_swaths = static_cast<int16_t>(ctx->skipped_swaths);
-  // Smooth pose-cursor-based progress for the current area (primary GUI %); the
-  // swath counts above are the coarse secondary "sub-path X/Y" readout.
-  msg.coverage_percent = ctx->coverage_percent;
-  msg.gps_quality_percent = ctx->gps_quality;
-  msg.battery_percent = ctx->battery_percent;
-  msg.is_charging = ctx->latest_power.charger_enabled;
-  msg.emergency = ctx->latest_emergency.active_emergency;
 
   // Cache the message so the behavior_tree_node timer can re-publish it while
   // the tree is parked in a long-running action with no further transitions.
+  // Only the state identity above is authored here; every live field is filled
+  // by the same projection the republish timer uses, so the two paths cannot
+  // drift apart (see status_snapshot.hpp).
+  mowgli_interfaces::msg::HighLevelStatus msg;
   {
     std::lock_guard<std::mutex> lock(ctx->context_mutex);
+    msg = withLiveStatusFields(identity, *ctx);
     ctx->last_high_level_status = msg;
     ctx->has_high_level_status = true;
     ctx->high_level_status_pub->publish(msg);

--- a/ros2/src/mowgli_behavior/src/status_snapshot.cpp
+++ b/ros2/src/mowgli_behavior/src/status_snapshot.cpp
@@ -23,8 +23,7 @@ namespace mowgli_behavior
 {
 
 mowgli_interfaces::msg::HighLevelStatus withLiveStatusFields(
-    const mowgli_interfaces::msg::HighLevelStatus& base,
-    const BTContext& ctx)
+    const mowgli_interfaces::msg::HighLevelStatus& base, const BTContext& ctx)
 {
   mowgli_interfaces::msg::HighLevelStatus msg;
 

--- a/ros2/src/mowgli_behavior/src/status_snapshot.cpp
+++ b/ros2/src/mowgli_behavior/src/status_snapshot.cpp
@@ -1,0 +1,59 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+
+#include "mowgli_behavior/status_snapshot.hpp"
+
+#include <cstdint>
+
+namespace mowgli_behavior
+{
+
+mowgli_interfaces::msg::HighLevelStatus withLiveStatusFields(
+    const mowgli_interfaces::msg::HighLevelStatus& base,
+    const BTContext& ctx)
+{
+  mowgli_interfaces::msg::HighLevelStatus msg;
+
+  // Tree-owned identity: only PublishHighLevelStatus knows which branch is
+  // selected, so carry it through untouched.
+  msg.state = base.state;
+  msg.state_name = base.state_name;
+  msg.sub_state_name = base.sub_state_name;
+
+  msg.current_area = static_cast<int16_t>(ctx.current_area);
+  // The GUI computes progress as current_path_index / current_path
+  // (MowerStatus.tsx, MowgliNextPage.tsx), so current_path is the DENOMINATOR
+  // (total swaths in the current area's plan) and current_path_index the
+  // NUMERATOR (completed swaths). Both are tracked by PlanCoverageArea /
+  // FollowStrip in coverage_nodes.
+  msg.current_path = static_cast<int16_t>(ctx.total_swaths);
+  msg.current_path_index = static_cast<int16_t>(ctx.completed_swaths);
+  msg.total_swaths = static_cast<int16_t>(ctx.total_swaths);
+  msg.completed_swaths = static_cast<int16_t>(ctx.completed_swaths);
+  msg.skipped_swaths = static_cast<int16_t>(ctx.skipped_swaths);
+  // Smooth pose-cursor-based progress for the current area (primary GUI %); the
+  // swath counts above are the coarse secondary "sub-path X/Y" readout.
+  msg.coverage_percent = ctx.coverage_percent;
+  msg.gps_quality_percent = ctx.gps_quality;
+  msg.battery_percent = ctx.battery_percent;
+  msg.is_charging = ctx.latest_power.charger_enabled;
+  msg.emergency = ctx.latest_emergency.active_emergency;
+
+  return msg;
+}
+
+}  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/test/test_high_level_status_snapshot.cpp
+++ b/ros2/src/mowgli_behavior/test/test_high_level_status_snapshot.cpp
@@ -1,0 +1,156 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_high_level_status_snapshot.cpp
+ * @brief Regression test for the frozen GUI battery gauge while charging.
+ *
+ * PublishHighLevelStatus is a SyncActionNode that only fires on tree
+ * transitions, and behavior_tree_node's 1 Hz timer used to re-publish the
+ * cached message VERBATIM. Once the tree parked in the low-battery charge hold
+ * (BatteryDockAndResume: PublishHighLevelStatus "CHARGING" once, then a 30 s
+ * RetryUntilSuccessful loop with no further transitions), the topic kept
+ * emitting the battery percent captured at the moment of docking — observed on
+ * the robot 2026-08-23 frozen at 46.03 % for the whole charge while the pack
+ * actually climbed from 25.84 V to 26.42 V. The same staleness hit the mowing
+ * progress during a multi-minute FollowStrip.
+ *
+ * withLiveStatusFields refreshes every context-derived field from the live
+ * BTContext while keeping the tree-owned state identity (state / state_name /
+ * sub_state_name) from the cached snapshot. These tests pin that split with a
+ * plain BTContext (no ROS, no publisher).
+ */
+
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/status_snapshot.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::withLiveStatusFields;
+using mowgli_interfaces::msg::HighLevelStatus;
+
+namespace
+{
+
+/// The status cached when the tree published "CHARGING" at dock contact.
+HighLevelStatus chargingSnapshot()
+{
+  HighLevelStatus cached;
+  cached.state = HighLevelStatus::HIGH_LEVEL_STATE_IDLE;
+  cached.state_name = "CHARGING";
+  cached.sub_state_name = "";
+  cached.battery_percent = 46.03f;
+  cached.gps_quality_percent = 1.0f;
+  cached.is_charging = true;
+  cached.coverage_percent = 80.57f;
+  return cached;
+}
+
+}  // namespace
+
+// The exact field the operator watches: the pack charges, so the re-published
+// percent must track the live context, not the value latched at dock contact.
+TEST(HighLevelStatusSnapshot, BatteryPercentTracksLiveContext)
+{
+  BTContext ctx;
+  ctx.battery_percent = 60.4f;  // pack has climbed since docking
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_FLOAT_EQ(refreshed.battery_percent, 60.4f);
+}
+
+// The state identity is owned by the tree and is only valid at a transition, so
+// the republish must carry it through from the cache untouched. Refreshing it
+// from a default-constructed context would blank the GUI's state label.
+TEST(HighLevelStatusSnapshot, StateIdentityIsCarriedFromCache)
+{
+  BTContext ctx;
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_EQ(refreshed.state, HighLevelStatus::HIGH_LEVEL_STATE_IDLE);
+  EXPECT_EQ(refreshed.state_name, "CHARGING");
+  EXPECT_EQ(refreshed.sub_state_name, "");
+}
+
+// Charger unplugged / emergency asserted while the tree sits in the charge hold:
+// both are live sensor state and must reach the GUI without a tree transition.
+TEST(HighLevelStatusSnapshot, ChargingAndEmergencyTrackLiveContext)
+{
+  BTContext ctx;
+  ctx.latest_power.charger_enabled = false;
+  ctx.latest_emergency.active_emergency = true;
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_FALSE(refreshed.is_charging);
+  EXPECT_TRUE(refreshed.emergency);
+}
+
+// The other half of the same bug: during a multi-minute FollowStrip the tree
+// never re-ticks PublishHighLevelStatus, so coverage progress and GPS quality
+// were frozen too.
+TEST(HighLevelStatusSnapshot, ProgressAndGpsTrackLiveContext)
+{
+  BTContext ctx;
+  ctx.coverage_percent = 92.5f;
+  ctx.gps_quality = 100.0f;
+  ctx.current_area = 3;
+  ctx.total_swaths = 8;
+  ctx.completed_swaths = 6;
+  ctx.skipped_swaths = 1;
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_FLOAT_EQ(refreshed.coverage_percent, 92.5f);
+  EXPECT_FLOAT_EQ(refreshed.gps_quality_percent, 100.0f);
+  EXPECT_EQ(refreshed.current_area, 3);
+  EXPECT_EQ(refreshed.total_swaths, 8);
+  EXPECT_EQ(refreshed.completed_swaths, 6);
+  EXPECT_EQ(refreshed.skipped_swaths, 1);
+}
+
+// The GUI divides current_path_index by current_path to render the mowing
+// percentage (see the PublishHighLevelStatus comment), so the republish must
+// keep mirroring the swath counts into that pair rather than leaving the
+// denominator at its cached value.
+TEST(HighLevelStatusSnapshot, GuiRatioPairMirrorsSwathCounts)
+{
+  BTContext ctx;
+  ctx.total_swaths = 8;
+  ctx.completed_swaths = 6;
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_EQ(refreshed.current_path, 8);
+  EXPECT_EQ(refreshed.current_path_index, 6);
+}
+
+// A default-constructed context must not fabricate progress: the helper is a
+// pure projection of the context, so an untouched context yields zeros (and the
+// 100 % battery default), never leftovers from the cached snapshot.
+TEST(HighLevelStatusSnapshot, LiveFieldsNeverFallBackToCachedValues)
+{
+  BTContext ctx;
+
+  const HighLevelStatus refreshed = withLiveStatusFields(chargingSnapshot(), ctx);
+
+  EXPECT_FLOAT_EQ(refreshed.coverage_percent, 0.0f);
+  EXPECT_FLOAT_EQ(refreshed.gps_quality_percent, 0.0f);
+  EXPECT_FLOAT_EQ(refreshed.battery_percent, ctx.battery_percent);
+  EXPECT_FALSE(refreshed.is_charging);
+}


### PR DESCRIPTION
## Symptom

Robot at `10.69.4.198` looked like the BT was hung: docked, `CHARGING`, battery gauge pinned at **46.03 %** and never moving. The BT was in fact ticking normally and charging fine — the *gauge* was dead.

Confirmed live on the robot: `high_level_status.battery_percent` was bit-identical (`46.02928161621094`) across a 60 s sample while `/hardware_bridge/power` showed `v_battery` climbing 26.397 → 26.415 V at 1.0 A.

## Root cause

`behavior_tree_node`'s 1 Hz republish timer re-sent the **cached** `HighLevelStatus` verbatim. `PublishHighLevelStatus` is a `SyncActionNode` that only fires on tree transitions, so every live field in that message stalls for as long as the tree sits in a transition-free branch.

The low-battery charge hold is exactly such a branch (`main_tree.xml`, `BatteryDockAndResume`): publish `"CHARGING"` once, then loop on a 30 s `RetryUntilSuccessful` until the pack clears `battery_full_percent` (95 %). So the gauge showed the percent captured at dock contact (25.84 V → 46.03 %) for the entire multi-hour charge.

It gets worse because `gui/web/src/utils/battery.ts:41` **prefers** `highLevelStatus.battery_percent` whenever it is `> 0` and only falls back to `power.v_battery`. The stale value actively shadowed the live voltage the frontend already had.

The same bug froze mowing progress for the whole of a multi-minute `FollowStrip`.

## Fix

Split the message by ownership:

- **Tree-owned** (`state`, `state_name`, `sub_state_name`) — only `PublishHighLevelStatus` knows which branch is selected; carried through from the cache.
- **Live** (battery, GPS quality, charging, emergency, area + swath progress, coverage %) — a pure projection of the current `BTContext`.

Both the transition publish and the periodic republish now go through one shared helper, `withLiveStatusFields()` (`status_snapshot.hpp/.cpp`), so the two paths cannot drift apart again. The transition path additionally reads those context fields under `context_mutex`, which it previously did not.

**No behaviour change to the tree** — the charge hold still waits for `battery_full_percent`, it just reports the truth while it waits.

## Test plan

- [x] New `test_high_level_status_snapshot` (6 tests) — pins the tree-owned vs live split: battery/charging/emergency/coverage/GPS track the live context, state identity comes from the cache, live fields never fall back to cached values. **6/6 pass.**
- [x] `test_battery_critical_resume` (links the modified `status_nodes.cpp`) — **3/3 still pass.**
- [x] `behavior_tree_node` executable builds clean.
- [ ] On-robot: watch the gauge climb during a charge hold instead of sitting at the dock-contact value.

Built and run locally in `ros:kilted-ros-base`.

## Not addressed here

Two other things found while diagnosing, both pre-existing and worth separate issues:

1. **Two nodes share the name `/behavior_tree_node`** — `full_system.launch.py:217` sets `name="behavior_tree_node"`, which renames *every* node in the process, including the `_bt_helper_node` created at `behavior_tree_node.cpp:79`. `ros2 param get/set /behavior_tree_node …` hits whichever answers first, so runtime param tuning from the GUI is a coin flip.
2. **Pack health** — battery went 72.8 % → below 20 % in 10.7 min of mowing, then recovered to 25.84 V at rest immediately. Classic high-internal-resistance SLA sag. No software fix.