### PR TITLE
fix(coverage): make blade_link transform static

### DIFF
--- a/ros2/src/mowgli_bringup/test/test_urdf_xacro.py
+++ b/ros2/src/mowgli_bringup/test/test_urdf_xacro.py
@@ -26,3 +26,24 @@ def test_chassis_mass_argument_sets_base_link_inertial_mass() -> None:
     mass = base_link.find("./inertial/mass")
     assert mass is not None
     assert float(mass.attrib["value"]) == configured_mass
+
+
+def test_blade_link_is_attached_by_a_fixed_joint() -> None:
+    """Coverage must always be able to resolve the cutting-tool TF."""
+    result = subprocess.run(
+        ["xacro", str(_XACRO_FILE)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    robot = ET.fromstring(result.stdout)
+    blade_joint = robot.find("./joint[@name='blade_joint']")
+    assert blade_joint is not None
+    assert blade_joint.attrib["type"] == "fixed"
+    parent = blade_joint.find("./parent")
+    child = blade_joint.find("./child")
+    assert parent is not None
+    assert child is not None
+    assert parent.attrib["link"] == "base_link"
+    assert child.attrib["link"] == "blade_link"

--- a/ros2/src/mowgli_bringup/urdf/mowgli.urdf.xacro
+++ b/ros2/src/mowgli_bringup/urdf/mowgli.urdf.xacro
@@ -290,12 +290,11 @@
                             h="${blade_height}"/>
   </link>
 
-  <joint name="blade_joint" type="continuous">
+  <joint name="blade_joint" type="fixed">
     <parent link="base_link"/>
     <child  link="blade_link"/>
     <!-- Blade disc centred under chassis -->
     <origin xyz="${chassis_cx} 0 ${-wheel_radius + 0.05}" rpy="0 0 0"/>
-    <axis xyz="0 0 1"/>
   </joint>
 
   <!-- ================================================================


### PR DESCRIPTION
Fixes a regression introduced by #458.

Coverage stamping now uses `blade_link`, but `blade_joint` was declared as a `continuous` joint. No joint state is published for the blade rotation, so `robot_state_publisher` could not reliably provide the `base_link -> blade_link` transform required by the coverage map server.

This changes `blade_joint` to a fixed joint so `base_link -> blade_link` is always available as a static TF.

This regression also made it into today's release. Sorry I missed the TF implication when implementing #458 and without this fix the coverage will not be recorded at all.

### Changes
- change `blade_joint` from `continuous` to `fixed`
- remove the now-unused joint axis
- add a focused xacro regression test

### Verification
- `base_link -> blade_link` resolves without requiring a blade joint state
- `map -> blade_link` can therefore be composed while the robot moves
- coverage stamping can continue using the actual cutting-tool position

### Runtime verification
```bash
ros2 run tf2_ros tf2_echo base_link blade_link
ros2 run tf2_ros tf2_echo map blade_link
```