### PR TITLE
fix(map_server): republish cached mow progress

### DIFF
--- a/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
+++ b/ros2/src/mowgli_map/include/mowgli_map/map_server_node.hpp
@@ -126,6 +126,15 @@ public:
   /// Test-only: return the mowed-layer value at a map-frame position.
   float mow_progress_value_for_test(double x, double y) const;
 
+  /// Test-only: run the regular publish path without waiting for the timer.
+  void publish_mow_progress_for_test()
+  {
+    on_publish_timer();
+  }
+
+  /// Test-only: report whether a current mow-progress grid is cached.
+  bool mow_progress_cache_valid_for_test() const;
+
   /// Clear all layers to their default values.
   void clear_map_layers();
 
@@ -301,9 +310,22 @@ private:
   /// map_'s geometry. Takes map_mutex_ internally — caller must NOT hold it.
   void stamp_mow_progress(double x, double y);
 
-  /// Publish mow_progress_map_ as a nav_msgs/OccupancyGrid on ~/mow_progress.
+  /// Rebuild the cached OccupancyGrid from mow_progress_map_.
   /// Caller MUST hold map_mutex_.
-  void publish_mow_progress();
+  void rebuild_mow_progress_cache();
+
+  /// Publish the cached mow-progress OccupancyGrid on ~/mow_progress.
+  /// Caller MUST hold map_mutex_.
+  void publish_cached_mow_progress();
+
+  /// Clear the progress map and its cached OccupancyGrid after a map reset.
+  /// Caller MUST hold map_mutex_.
+  void reset_mow_progress();
+
+  /// Create an empty progress map matching map_'s current geometry and mark it
+  /// for publication so transient_local history cannot retain stale geometry.
+  /// Caller MUST hold map_mutex_.
+  void initialize_mow_progress_map();
 
   // ── Services ─────────────────────────────────────────────────────────────
 
@@ -655,11 +677,13 @@ private:
   /// occupancy/classification lifecycle. Guarded by map_mutex_.
   grid_map::GridMap mow_progress_map_;
   bool mow_progress_dirty_{false};
-  /// Throttle for the mowed-overlay publish. The overlay is re-serialized (an
-  /// O(cells) full-grid pass that scales with map extent) at most once per this
-  /// period while mowing, instead of on every timer tick — the dominant steady
-  /// cost on a large map. transient_local keeps late subscribers current, and
-  /// mow_progress_dirty_ stays set until an actual publish, so no growth is lost.
+  /// Serialized only when the progress map changes; published unchanged between
+  /// updates so reconnecting WebSocket clients receive the current overlay.
+  nav_msgs::msg::OccupancyGrid mow_progress_cache_;
+  bool mow_progress_cache_valid_{false};
+  /// Throttle for cached mowed-overlay publication. Conversion remains O(cells)
+  /// only when the progress map is dirty; unchanged cached grids are cheap to
+  /// republish at this interval for GUI reconnect reliability.
   double mow_progress_publish_period_s_{2.0};
   rclcpp::Time last_mow_progress_pub_time_{0, 0, RCL_ROS_TIME};
 

--- a/ros2/src/mowgli_map/src/area_manager.cpp
+++ b/ros2/src/mowgli_map/src/area_manager.cpp
@@ -189,10 +189,9 @@ void MapServerNode::init_map()
   map_[std::string(layers::OCCUPANCY)].setConstant(defaults::OCCUPANCY);
   map_[std::string(layers::CLASSIFICATION)].setConstant(defaults::CLASSIFICATION);
 
-  // Drop any accumulated mowed-progress overlay: a fresh map (startup or a map
-  // delete) means coverage starts over. stamp_mow_progress lazily recreates it.
-  mow_progress_map_ = grid_map::GridMap();
-  have_last_mow_tool_position_ = false;
+  // A fresh map (startup or a map delete) starts coverage over and must not
+  // retain an OccupancyGrid cache generated for its previous geometry.
+  initialize_mow_progress_map();
 
   RCLCPP_DEBUG(get_logger(),
                "Grid map created: %zu×%zu cells",
@@ -248,6 +247,8 @@ void MapServerNode::resize_map_to_areas()
 
   map_[std::string(layers::OCCUPANCY)].setConstant(defaults::OCCUPANCY);
   map_[std::string(layers::CLASSIFICATION)].setConstant(defaults::CLASSIFICATION);
+
+  initialize_mow_progress_map();
 
   masks_dirty_ = true;
 
@@ -397,6 +398,8 @@ void MapServerNode::on_load_map(const std_srvs::srv::Trigger::Request::SharedPtr
     map_.setGeometry(grid_map::Length(map_size_x_, map_size_y_),
                      resolution_,
                      grid_map::Position(pos_x, pos_y));
+
+    initialize_mow_progress_map();
 
     std::ifstream dat(data_path, std::ios::binary);
     if (!dat.is_open())
@@ -632,8 +635,7 @@ void MapServerNode::clear_map_layers()
 {
   map_[std::string(layers::OCCUPANCY)].setConstant(defaults::OCCUPANCY);
   map_[std::string(layers::CLASSIFICATION)].setConstant(defaults::CLASSIFICATION);
-  mow_progress_map_ = grid_map::GridMap();
-  have_last_mow_tool_position_ = false;
+  initialize_mow_progress_map();
 }
 void MapServerNode::on_set_docking_point(
     const mowgli_interfaces::srv::SetDockingPoint::Request::SharedPtr req,

--- a/ros2/src/mowgli_map/src/map_server_node.cpp
+++ b/ros2/src/mowgli_map/src/map_server_node.cpp
@@ -857,21 +857,22 @@ void MapServerNode::on_publish_timer()
       masks_dirty_ = false;
     }
 
-    // Republish the mowed overlay only when it grew, and at most once per
-    // mow_progress_publish_period_s_. Re-serializing the full-extent overlay on
-    // every tick is O(cells) per second while mowing — the dominant steady cost
-    // on a large map. transient_local keeps late subscribers up to date, and
-    // mow_progress_dirty_ stays set until we actually publish, so no growth is
-    // lost between throttled publishes.
-    if (mow_progress_dirty_)
+    // Rebuild the full-extent OccupancyGrid only after coverage changed, then
+    // republish that cached message at the existing throttle interval. Foxglove
+    // WebSocket reconnects do not reliably receive transient_local history.
+    const rclcpp::Time now_t = now();
+    if (last_mow_progress_pub_time_.nanoseconds() == 0 ||
+        (now_t - last_mow_progress_pub_time_).seconds() >= mow_progress_publish_period_s_)
     {
-      const rclcpp::Time now_t = now();
-      if (last_mow_progress_pub_time_.nanoseconds() == 0 ||
-          (now_t - last_mow_progress_pub_time_).seconds() >= mow_progress_publish_period_s_)
+      if (mow_progress_dirty_)
       {
-        publish_mow_progress();
-        last_mow_progress_pub_time_ = now_t;
+        rebuild_mow_progress_cache();
         mow_progress_dirty_ = false;
+      }
+      if (mow_progress_cache_valid_)
+      {
+        publish_cached_mow_progress();
+        last_mow_progress_pub_time_ = now_t;
       }
     }
   }
@@ -889,13 +890,7 @@ void MapServerNode::stamp_mow_progress(double x, double y)
       mow_progress_map_.getSize()(1) != map_.getSize()(1) ||
       mow_progress_map_.getPosition() != map_.getPosition())
   {
-    mow_progress_map_ = grid_map::GridMap({layer});
-    mow_progress_map_.setFrameId(map_frame_);
-    mow_progress_map_.setGeometry(map_.getLength(), map_.getResolution(), map_.getPosition());
-    mow_progress_map_[layer].setConstant(0.0F);
-    // The previous point belonged to different grid geometry, so it must not
-    // be joined to the first pose in the fresh overlay.
-    have_last_mow_tool_position_ = false;
+    initialize_mow_progress_map();
   }
 
   const grid_map::Position center(x, y);
@@ -943,18 +938,55 @@ float MapServerNode::mow_progress_value_for_test(double x, double y) const
   return mow_progress_map_.at(layer, index);
 }
 
-void MapServerNode::publish_mow_progress()
+bool MapServerNode::mow_progress_cache_valid_for_test() const
+{
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  return mow_progress_cache_valid_;
+}
+
+void MapServerNode::rebuild_mow_progress_cache()
 {
   const std::string layer = "mowed";
   if (!mow_progress_map_.exists(layer))
   {
+    mow_progress_cache_valid_ = false;
     return;
   }
-  nav_msgs::msg::OccupancyGrid grid;
   // 0 → unmowed (rendered transparent by the GUI), 100 → mowed. The converter
   // handles the grid_map↔OccupancyGrid index convention correctly.
-  grid_map::GridMapRosConverter::toOccupancyGrid(mow_progress_map_, layer, 0.0F, 100.0F, grid);
-  mow_progress_pub_->publish(grid);
+  grid_map::GridMapRosConverter::toOccupancyGrid(
+      mow_progress_map_, layer, 0.0F, 100.0F, mow_progress_cache_);
+  mow_progress_cache_valid_ = true;
+}
+
+void MapServerNode::publish_cached_mow_progress()
+{
+  if (mow_progress_cache_valid_)
+  {
+    mow_progress_pub_->publish(mow_progress_cache_);
+  }
+}
+
+void MapServerNode::reset_mow_progress()
+{
+  mow_progress_map_ = grid_map::GridMap();
+  mow_progress_dirty_ = false;
+  mow_progress_cache_ = nav_msgs::msg::OccupancyGrid();
+  mow_progress_cache_valid_ = false;
+  last_mow_progress_pub_time_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
+  have_last_mow_tool_position_ = false;
+}
+
+void MapServerNode::initialize_mow_progress_map()
+{
+  const std::string layer = "mowed";
+  reset_mow_progress();
+  mow_progress_map_ = grid_map::GridMap({layer});
+  mow_progress_map_.setFrameId(map_frame_);
+  mow_progress_map_.setGeometry(map_.getLength(), map_.getResolution(), map_.getPosition());
+  mow_progress_map_[layer].setConstant(0.0F);
+  // Refresh the latched publisher with the empty grid after a reset or resize.
+  mow_progress_dirty_ = true;
 }
 
 }  // namespace mowgli_map

--- a/ros2/src/mowgli_map/test/test_mow_progress.cpp
+++ b/ros2/src/mowgli_map/test/test_mow_progress.cpp
@@ -78,4 +78,30 @@ TEST(MowProgress, DoesNotSweepAcrossAProgressReset)
   rclcpp::shutdown();
 }
 
+TEST(MowProgress, CachesChangedCoverageAndInvalidatesItOnReset)
+{
+  rclcpp::init(0, nullptr);
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("mow_progress_publish_period_s", 0.0);
+  auto node = std::make_shared<mowgli_map::MapServerNode>(options);
+
+  node->stamp_mow_progress_for_test(0.0, 0.0);
+  node->publish_mow_progress_for_test();
+  EXPECT_TRUE(node->mow_progress_cache_valid_for_test());
+
+  // No coverage changed, but the timer may still republish the cached grid for
+  // a reconnecting GUI. The cache remains valid and requires no rebuild.
+  node->publish_mow_progress_for_test();
+  EXPECT_TRUE(node->mow_progress_cache_valid_for_test());
+
+  {
+    std::lock_guard<std::mutex> lock(node->map_mutex());
+    node->clear_map_layers();
+  }
+  EXPECT_FALSE(node->mow_progress_cache_valid_for_test());
+
+  node.reset();
+  rclcpp::shutdown();
+}
+
 }  // namespace


### PR DESCRIPTION
Fixes mow-progress disappearing after GUI/WebSocket reconnects.

`~/mow_progress` is currently only published when coverage changes, relying on `transient_local` for late subscribers. In practice Foxglove WebSocket clients may not receive that latched message after a reconnect, leaving the overlay blank until coverage changes again.

Cache the generated OccupancyGrid and periodically republish the cached message. The expensive GridMap → OccupancyGrid conversion still only runs when coverage changes.

This adds a small amount of idle network traffic, but keeps the GUI reliable without bringing back the previous CPU cost. For this status overlay, reconnect stability is more important than avoiding an occasional cached publish.

### Changes
- cache the generated mow-progress OccupancyGrid
- rebuild it only when coverage changes
- republish the cached grid at the existing throttled interval
- invalidate and replace the cache when map geometry changes

### Verification
- reload/reconnect the GUI while coverage is unchanged
- existing coverage reappears without requiring new mowing
- unchanged coverage does not trigger GridMap → OccupancyGrid recomputation