### PR TITLE
test(map): stop test_obstacle_tracker timing out in CI

### DIFF
--- a/ros2/src/mowgli_map/test/test_obstacle_tracker.cpp
+++ b/ros2/src/mowgli_map/test/test_obstacle_tracker.cpp
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <cmath>
+#include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -34,16 +36,38 @@ protected:
     {
       rclcpp::init(0, nullptr);
     }
-  }
-
-  void SetUp() override
-  {
+    // ONE node for the whole suite. This fixture used to build and destroy a
+    // full rclcpp::Node in every SetUp/TearDown — 17 create/destroy cycles per
+    // run — and the middleware teardown intermittently deadlocked, hanging the
+    // binary until ctest killed it (`test_obstacle_tracker (Timeout)`, red on
+    // dev and on unrelated PRs). The methods under test are pure algorithms
+    // that only need *a* node for its clock and parameters, not a fresh one,
+    // so the node is built once and the mutable state it carries is reset
+    // between tests instead (see SetUp).
     node_ = std::make_shared<mowgli_map::ObstacleTrackerNode>();
   }
 
-  void TearDown() override
+  static void TearDownTestSuite()
   {
     node_.reset();
+    if (rclcpp::ok())
+    {
+      rclcpp::shutdown();
+    }
+  }
+
+  /// Reset every piece of node state a test can mutate, so sharing one node
+  /// across the suite stays equivalent to the old fresh-node-per-test setup.
+  void SetUp() override
+  {
+    {
+      std::lock_guard<std::mutex> lock(node_->mutex_);
+      node_->tracked_.clear();
+      node_->next_id_ = 1;
+    }
+    std::lock_guard<std::mutex> lock(node_->keepout_mutex_);
+    node_->keepout_mask_ = nav_msgs::msg::OccupancyGrid{};
+    node_->have_keepout_mask_ = false;
   }
 
   // Expose private methods via delegation
@@ -126,8 +150,10 @@ protected:
     return obs;
   }
 
-  std::shared_ptr<mowgli_map::ObstacleTrackerNode> node_;
+  static std::shared_ptr<mowgli_map::ObstacleTrackerNode> node_;
 };
+
+std::shared_ptr<mowgli_map::ObstacleTrackerNode> ObstacleTrackerAlgorithmTest::node_;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // boundary_hull tests


### PR DESCRIPTION
`test_obstacle_tracker (Timeout)` is red on **dev itself** and on unrelated PRs (e.g. #481, which only touches `mowgli_bringup`'s URDF). That makes "merge when green" impossible to apply, so this clears the gate before other fixes land.

### Cause

The fixture built and destroyed a full `rclcpp::Node` in every `SetUp`/`TearDown` — 17 create/destroy cycles per run. Middleware teardown intermittently deadlocks, hanging the binary until ctest kills it.

Evidence from the dev run: the first 7 tests pass in single-digit ms each, then `InflateHull_Square` prints `[ RUN ]` and the node's construction log line, and nothing further appears until the timeout. `inflate_hull` itself contains no loop and cannot hang — the stall is in the node lifecycle around it, which is also why it reproduces intermittently (PR #482 passed on the same base).

### Change

- build the node once in `SetUpTestSuite` instead of per test
- reset the mutable state tests can touch in `SetUp` — `tracked_`, `next_id_`, `keepout_mask_`, `have_keepout_mask_` — so per-test isolation is unchanged
- add `TearDownTestSuite` to shut `rclcpp` down cleanly (there was no `shutdown` at all before)

No production code is touched and no assertion changes.

### Verification

- `Build & Test (ROS2 kilted)` green on this branch
- all 17 `ObstacleTrackerAlgorithmTest` cases still run and pass

### Caveat

The hang is intermittent and I could not reproduce it locally, so this is a removal of the *mechanism* (17 node lifecycles to 1) rather than a fix verified against a live repro. If the timeout ever returns, the remaining suspect is the single construction in `SetUpTestSuite`.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ