### PR TITLE
fix(fusion_graph): publish the pose covariance in the map frame

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -147,6 +147,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_factors fusion_graph_core)
 
+  ament_add_gtest(test_covariance_frame
+    test/test_covariance_frame.cpp
+  )
+  target_link_libraries(test_covariance_frame fusion_graph_core)
+
   ament_add_gtest(test_persistence
     test/test_persistence.cpp
   )

--- a/ros2/src/fusion_graph/include/fusion_graph/covariance_frame.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/covariance_frame.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Body → map frame conversion for the Pose2 marginal covariance. Pure, so it
+// is unit-testable without ROS/GTSAM (see test_covariance_frame.cpp).
+//
+// ── Why this exists ─────────────────────────────────────────────────────────
+// GTSAM's `marginalCovariance(PoseKey)` returns the marginal in the pose's
+// LOCAL tangent coordinates — i.e. the robot's body frame, where x is
+// along-track and y is cross-track. `nav_msgs/Odometry.pose.covariance` is
+// defined in the message's `header.frame_id`, which for /odometry/filtered_map
+// is `map`. Copying one into the other publishes a body-frame matrix labelled
+// map-frame.
+//
+// The wheel between-factor is deliberately non-holonomic (σ_x >> σ_y, 0.05 vs
+// 0.005 by default), so the body-frame marginal is strongly anisotropic and
+// the mislabelling is not a rounding detail: measured live on 2026-08-24 with
+// the robot holding a ~132° heading for 22 s, the published matrix showed
+// var_xx ≈ 100 × var_yy with var_xy pinned at 0.0000. A genuine map-frame
+// ellipse at that heading would carry a large negative var_xy; the absence of
+// any cross term regardless of heading is the signature of the raw body-frame
+// matrix going out unrotated.
+//
+// ── What this does NOT fix ──────────────────────────────────────────────────
+// Rotation is a similarity transform, so it does not change the eigenvalues:
+// the ~0.09 m along-track sigma is still there afterwards, just distributed
+// across map x and y according to heading. Any consumer wanting a single
+// "how well do we know where we are" number needs the MAJOR AXIS
+// (`MaxPositionSigma` below), which is frame-invariant — reading
+// `sqrt(max(var_xx, var_yy))` off the rotated matrix yields a
+// heading-dependent value that swings between the minor and major axis as the
+// robot turns.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+#include <Eigen/Core>
+
+namespace fusion_graph
+{
+
+/// Rotate a Pose2 tangent-space covariance from the pose's body frame into the
+/// map frame. Tangent ordering is GTSAM's: (x, y, theta).
+///
+/// The Jacobian is block-diagonal — R(yaw) on the translation block, identity
+/// on heading — so heading variance is preserved exactly and the
+/// position/heading cross terms rotate with the position block.
+///
+/// @param cov_body  3x3 marginal in body coordinates
+/// @param yaw       map-frame heading of the pose the marginal belongs to [rad]
+inline Eigen::Matrix3d BodyToMapCovariance(const Eigen::Matrix3d& cov_body, double yaw)
+{
+  const double c = std::cos(yaw);
+  const double s = std::sin(yaw);
+
+  Eigen::Matrix3d j = Eigen::Matrix3d::Identity();
+  j(0, 0) = c;
+  j(0, 1) = -s;
+  j(1, 0) = s;
+  j(1, 1) = c;
+
+  return j * cov_body * j.transpose();
+}
+
+/// Largest 1-sigma position uncertainty [m] — the major axis of the xy
+/// covariance ellipse. Frame-invariant, so it reads the same before and after
+/// BodyToMapCovariance, which is exactly what makes it the right quantity for
+/// a trust gate.
+///
+/// Closed-form largest eigenvalue of the symmetric 2x2 block; the radicand is
+/// clamped at zero so floating-point noise on a near-degenerate block cannot
+/// produce NaN.
+inline double MaxPositionSigma(const Eigen::Matrix3d& cov)
+{
+  const double vxx = cov(0, 0);
+  const double vyy = cov(1, 1);
+  const double vxy = 0.5 * (cov(0, 1) + cov(1, 0));
+
+  const double mean = 0.5 * (vxx + vyy);
+  const double diff = 0.5 * (vxx - vyy);
+  const double radicand = std::max(0.0, diff * diff + vxy * vxy);
+  const double lambda_max = mean + std::sqrt(radicand);
+
+  return std::sqrt(std::max(0.0, lambda_max));
+}
+
+}  // namespace fusion_graph

--- a/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_publish.cpp
@@ -17,6 +17,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include "fusion_graph/anchor_slew.hpp"
+#include "fusion_graph/covariance_frame.hpp"
 #include "fusion_graph/fusion_graph_node.hpp"
 #include "fusion_graph/fusion_graph_node_util.hpp"
 
@@ -171,18 +172,27 @@ void FusionGraphNode::PublishOutputs(const TickOutput& out)
   odom.pose.pose.position.z = 0.0;
   odom.pose.pose.orientation = QuatFromYaw(extrapolated_map_base.theta());
 
-  // Pose covariance is 6x6 row-major: x, y, z, roll, pitch, yaw.
+  // Pose covariance is 6x6 row-major: x, y, z, roll, pitch, yaw, and — like
+  // every other field in this message — it is expressed in header.frame_id
+  // (map). GTSAM hands back the marginal in the pose's LOCAL tangent frame,
+  // so it must be rotated by the pose's heading before it goes out; the wheel
+  // between-factor is non-holonomic (sigma_x >> sigma_y), which makes the
+  // body-frame matrix strongly anisotropic and the difference material.
+  // See covariance_frame.hpp.
+  const Eigen::Matrix3d cov_map =
+      BodyToMapCovariance(out.covariance, extrapolated_map_base.theta());
+
   for (auto& v : odom.pose.covariance)
     v = 0.0;
-  odom.pose.covariance[0] = out.covariance(0, 0);
-  odom.pose.covariance[1] = out.covariance(0, 1);
-  odom.pose.covariance[5] = out.covariance(0, 2);
-  odom.pose.covariance[6] = out.covariance(1, 0);
-  odom.pose.covariance[7] = out.covariance(1, 1);
-  odom.pose.covariance[11] = out.covariance(1, 2);
-  odom.pose.covariance[30] = out.covariance(2, 0);
-  odom.pose.covariance[31] = out.covariance(2, 1);
-  odom.pose.covariance[35] = out.covariance(2, 2);
+  odom.pose.covariance[0] = cov_map(0, 0);
+  odom.pose.covariance[1] = cov_map(0, 1);
+  odom.pose.covariance[5] = cov_map(0, 2);
+  odom.pose.covariance[6] = cov_map(1, 0);
+  odom.pose.covariance[7] = cov_map(1, 1);
+  odom.pose.covariance[11] = cov_map(1, 2);
+  odom.pose.covariance[30] = cov_map(2, 0);
+  odom.pose.covariance[31] = cov_map(2, 1);
+  odom.pose.covariance[35] = cov_map(2, 2);
   // Z, roll, pitch — clamped, give them tiny variance so consumers
   // don't choke on zero.
   odom.pose.covariance[14] = 1e-9;

--- a/ros2/src/fusion_graph/test/test_covariance_frame.cpp
+++ b/ros2/src/fusion_graph/test/test_covariance_frame.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Pins the body → map rotation of the Pose2 marginal covariance, and the
+// frame-invariance of MaxPositionSigma. See covariance_frame.hpp.
+
+#include <cmath>
+
+#include "fusion_graph/covariance_frame.hpp"
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+using fusion_graph::BodyToMapCovariance;
+using fusion_graph::MaxPositionSigma;
+
+namespace
+{
+
+/// The non-holonomic wheel between-factor shape this robot actually runs:
+/// wheel_sigma_x 0.05 along-track, wheel_sigma_y 0.005 cross-track.
+Eigen::Matrix3d NonHolonomicBodyCov()
+{
+  Eigen::Matrix3d c = Eigen::Matrix3d::Zero();
+  c(0, 0) = 0.05 * 0.05;  // along-track variance
+  c(1, 1) = 0.005 * 0.005;  // cross-track variance
+  c(2, 2) = 0.0008;  // yaw variance
+  return c;
+}
+
+}  // namespace
+
+TEST(CovarianceFrame, ZeroYawIsIdentity)
+{
+  const Eigen::Matrix3d body = NonHolonomicBodyCov();
+  const Eigen::Matrix3d map = BodyToMapCovariance(body, 0.0);
+
+  EXPECT_TRUE(map.isApprox(body, 1e-12));
+}
+
+TEST(CovarianceFrame, QuarterTurnSwapsAlongAndCrossTrack)
+{
+  const Eigen::Matrix3d body = NonHolonomicBodyCov();
+  const Eigen::Matrix3d map = BodyToMapCovariance(body, M_PI / 2.0);
+
+  // Heading due north: along-track uncertainty now lies on map Y.
+  EXPECT_NEAR(map(0, 0), body(1, 1), 1e-12);
+  EXPECT_NEAR(map(1, 1), body(0, 0), 1e-12);
+  EXPECT_NEAR(map(0, 1), 0.0, 1e-12);
+}
+
+// The regression this whole change exists for. Live on 2026-08-24 the robot
+// held ~132° for 22 s and the published matrix carried var_xy == 0.0000 with
+// var_xx ~100x var_yy — the signature of an unrotated body-frame matrix. A
+// correctly rotated one MUST show a substantial cross term at that heading.
+TEST(CovarianceFrame, ObliqueHeadingProducesCrossTerm)
+{
+  const Eigen::Matrix3d body = NonHolonomicBodyCov();
+  const double yaw = 132.0 * M_PI / 180.0;
+  const Eigen::Matrix3d map = BodyToMapCovariance(body, yaw);
+
+  // cos(132°)sin(132°) < 0, and the along-track term dominates, so the cross
+  // term is clearly negative — not the 0.0000 we observed on the robot.
+  EXPECT_LT(map(0, 1), -1e-4);
+  EXPECT_NEAR(map(0, 1), map(1, 0), 1e-12);
+}
+
+TEST(CovarianceFrame, RotationPreservesTraceAndYaw)
+{
+  const Eigen::Matrix3d body = NonHolonomicBodyCov();
+
+  for (double deg = 0.0; deg < 360.0; deg += 17.0)
+  {
+    const Eigen::Matrix3d map = BodyToMapCovariance(body, deg * M_PI / 180.0);
+
+    // Similarity transform: xy trace and the heading block are untouched.
+    EXPECT_NEAR(map(0, 0) + map(1, 1), body(0, 0) + body(1, 1), 1e-12);
+    EXPECT_NEAR(map(2, 2), body(2, 2), 1e-12);
+    // Still symmetric.
+    EXPECT_NEAR(map(0, 1), map(1, 0), 1e-12);
+  }
+}
+
+TEST(CovarianceFrame, PositionHeadingCrossTermsRotate)
+{
+  Eigen::Matrix3d body = NonHolonomicBodyCov();
+  body(0, 2) = 0.002;  // along-track / yaw coupling
+  body(2, 0) = 0.002;
+
+  const Eigen::Matrix3d map = BodyToMapCovariance(body, M_PI / 2.0);
+
+  // A quarter turn moves the along-track/yaw coupling onto map Y.
+  EXPECT_NEAR(map(0, 2), 0.0, 1e-12);
+  EXPECT_NEAR(map(1, 2), 0.002, 1e-12);
+  EXPECT_NEAR(map(2, 1), map(1, 2), 1e-12);
+}
+
+// MaxPositionSigma is the quantity a trust gate wants: it must read the same
+// no matter which way the robot is pointing. sqrt(max(var_xx, var_yy)) does
+// NOT have that property once the matrix is correctly rotated.
+TEST(CovarianceFrame, MaxPositionSigmaIsFrameInvariant)
+{
+  const Eigen::Matrix3d body = NonHolonomicBodyCov();
+  const double expected = 0.05;  // the along-track sigma is the major axis
+
+  for (double deg = 0.0; deg < 360.0; deg += 13.0)
+  {
+    const Eigen::Matrix3d map = BodyToMapCovariance(body, deg * M_PI / 180.0);
+    EXPECT_NEAR(MaxPositionSigma(map), expected, 1e-9) << "heading " << deg << " deg";
+  }
+}
+
+TEST(CovarianceFrame, MaxPositionSigmaHandlesIsotropicAndDegenerate)
+{
+  Eigen::Matrix3d iso = Eigen::Matrix3d::Zero();
+  iso(0, 0) = 0.04;
+  iso(1, 1) = 0.04;
+  EXPECT_NEAR(MaxPositionSigma(iso), 0.2, 1e-12);
+
+  // All-zero block must yield 0, not NaN.
+  EXPECT_NEAR(MaxPositionSigma(Eigen::Matrix3d::Zero()), 0.0, 1e-12);
+}


### PR DESCRIPTION
`marginalCovariance()` returns the `Pose2` marginal in the pose's **local tangent frame** — x along-track, y cross-track. `nav_msgs/Odometry.pose.covariance` is defined in `header.frame_id`, which for `/odometry/filtered_map` is `map`. The raw body-frame matrix was copied straight into it (`fusion_graph_node_publish.cpp:177-185`).

### Why it matters here

The wheel between-factor is deliberately non-holonomic — `wheel_sigma_x` 0.05 against `wheel_sigma_y` 0.005 — so the body-frame marginal is strongly anisotropic and the mislabelling is material, not cosmetic.

Measured live on the robot 2026-08-24, 619 samples while it held a ~132° heading for 22 s:

```
var_xy  = 0.0000        every sample, at every heading
var_xx ~= 100 x var_yy
```

A genuine map-frame ellipse at 132° carries a large negative cross term. Its absence regardless of heading is the signature of an unrotated body-frame matrix.

### Change

- rotate the marginal by the published pose's heading before it goes out (`C_map = J C_body Jᵀ`, `J` block-diagonal: `R(yaw)` on translation, identity on heading)
- new pure header `covariance_frame.hpp` + `test_covariance_frame.cpp` (7 cases)
- `MaxPositionSigma()` — major axis of the xy ellipse

### What this does NOT fix

Rotation is a similarity transform: it preserves eigenvalues. The ~0.09 m along-track sigma is still there afterwards, just distributed across map x and y by heading. So this does **not** on its own fix the anti-dig gate in `hardware_bridge_node.cpp:2599` — in fact `sqrt(max(var_xx, var_yy))` becomes *heading-dependent* once the matrix is correctly rotated, swinging between the minor and major axis as the robot turns. That is why `MaxPositionSigma()` is added here: it is frame-invariant and is the quantity a trust gate actually wants. Rewiring the gate is a separate PR.

`/fusion_graph/diagnostics` `cov_xx`/`cov_yy` are unchanged and remain graph-internal body-frame telemetry (the GUI onboarding readiness check reads them).

### Consumers of the corrected field

- `hardware_bridge_node.cpp:2599` — anti-dig trust gate
- `behavior_tree_node.cpp:251` — `loc_obs_.fused_sigma_xy_m` (backstop is 5.0 m, so no behaviour change expected)

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ