### PR TITLE
fix(nav2): stop FTC skipping a whole headland ring in setPlan

### DIFF
--- a/ros2/src/mowgli_nav2_plugins/CMakeLists.txt
+++ b/ros2/src/mowgli_nav2_plugins/CMakeLists.txt
@@ -139,6 +139,15 @@ if(BUILD_TESTING)
     tf2_geometry_msgs
   )
 
+  ament_add_gtest(test_ftc_start_index
+    test/test_ftc_start_index.cpp
+  )
+
+  target_include_directories(test_ftc_start_index
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+
   ament_add_gtest(test_ftc_stall
     test/test_ftc_stall.cpp
   )

--- a/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_controller.hpp
+++ b/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_controller.hpp
@@ -405,6 +405,10 @@ private:
 
     // Options
     bool forward_only{true};
+    /// Legacy: snap to the nearest plan point in setPlan instead of starting at
+    /// index 0. OFF by default — on a CLOSED headland ring (start == end) the
+    /// snap is ambiguous and could skip the whole ring. See setPlan.
+    bool snap_to_nearest_on_set_plan{false};
     bool debug_pid{false};
     bool debug_obstacle{false};
 

--- a/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_start_index.hpp
+++ b/ros2/src/mowgli_nav2_plugins/include/mowgli_nav2_plugins/ftc_start_index.hpp
@@ -1,0 +1,80 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Which index of a freshly dispatched plan FTC should begin tracking from.
+// Pure, so it is unit-testable without ROS/nav2 (see test_ftc_start_index.cpp)
+// — same shape as ftc_stall.hpp.
+//
+// ── Why this exists ─────────────────────────────────────────────────────────
+// setPlan used to run an UNBOUNDED nearest-point search over the whole plan and
+// start tracking wherever it landed. Coverage headland rings are CLOSED —
+// start == end to the millimetre — so index 0 and index N-1 describe the SAME
+// POINT and the search is genuinely ambiguous; floating-point noise picks the
+// winner. When the last index won, FTC drove a few poses, reported the goal
+// reached, and FollowStrip recorded the whole ring as MOWED. Observed on the
+// robot on both 2026-08-24 runs:
+//
+//     new path with 436 poses, start=(1.95,9.50), end=(1.95,9.50)
+//     setPlan with 436 points, starting at idx=432   -> 99 % of the ring skipped
+//     setPlan with 805 points, starting at idx=372   -> 46 % skipped
+//
+// Both were then logged "reached 99-100 % of path - treating as MOWED", so the
+// un-mowed ground was recorded as done and skipped_swaths still read 0. Nothing
+// ever came back for it.
+//
+// Resume is not this function's job. FollowStrip owns it: it trims the path at
+// its resume cursor BEFORE dispatch, and decides whether to transit blade-off
+// first by measuring to poses.front() — index 0 (coverage_nodes.cpp:444, :644).
+// Snapping to some other index here silently disagreed with that decision.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace mowgli_nav2_plugins
+{
+
+/// Index to begin tracking from.
+///
+/// Default (`snap_to_nearest == false`) is always 0: the caller has already
+/// placed the robot at the plan start, or asked Nav2 to.
+///
+/// The legacy nearest-point behaviour is kept behind the flag for sites that
+/// need it, with one correction — ties break toward the EARLIER index, so a
+/// closed ring starts at its beginning rather than its end. `>` rather than
+/// `>=` on the comparison is the whole fix for the ambiguity.
+///
+/// @param snap_to_nearest  enable the legacy nearest-point search
+/// @param plan             plan points as (x, y) in the robot's frame
+/// @param rx,ry            robot position in the same frame
+inline std::size_t ChooseStartIndex(bool snap_to_nearest,
+                                    const std::vector<std::pair<double, double>>& plan,
+                                    double rx,
+                                    double ry)
+{
+  if (!snap_to_nearest || plan.empty())
+  {
+    return 0;
+  }
+
+  std::size_t best = 0;
+  double best_dist_sq = -1.0;
+  for (std::size_t i = 0; i < plan.size(); ++i)
+  {
+    const double dx = plan[i].first - rx;
+    const double dy = plan[i].second - ry;
+    const double d = dx * dx + dy * dy;
+    // Strictly-less keeps the FIRST of any equidistant run, so a closed ring
+    // resolves to its start rather than its end.
+    if (best_dist_sq < 0.0 || d < best_dist_sq)
+    {
+      best_dist_sq = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+}  // namespace mowgli_nav2_plugins

--- a/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
+++ b/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <nav2_core/controller_exceptions.hpp>
@@ -29,6 +30,7 @@
 #include <tf2_ros/transform_listener.hpp>
 
 #include "mowgli_nav2_plugins/ftc_stall.hpp"
+#include "mowgli_nav2_plugins/ftc_start_index.hpp"
 #include "mowgli_nav2_plugins/obstacle_deviation.hpp"
 
 namespace mowgli_nav2_plugins
@@ -209,6 +211,9 @@ void FTCController::declareParameters(const rclcpp_lifecycle::LifecycleNode::Sha
 
   // Options
   config_.forward_only = declare_bool("forward_only", true);
+  // Legacy nearest-point snap in setPlan. OFF by default: on closed headland
+  // rings it could skip the entire ring (see setPlan).
+  config_.snap_to_nearest_on_set_plan = declare_bool("snap_to_nearest_on_set_plan", false);
   config_.debug_pid = declare_bool("debug_pid", false);
   config_.debug_obstacle = declare_bool("debug_obstacle", false);
 
@@ -628,8 +633,40 @@ void FTCController::setPlan(const nav_msgs::msg::Path& path)
   current_index_ = 0;
   current_progress_ = 0.0;
 
-  // Find the nearest path point to the robot's current position so we don't
-  // start from index 0 when the robot is far from the path start.
+  // Start at the BEGINNING of a freshly dispatched plan.
+  //
+  // This used to run an UNBOUNDED nearest-point search over the whole plan and
+  // begin tracking wherever that landed. On coverage headland rings — which are
+  // CLOSED, start == end to the millimetre — index 0 and index N-1 are the SAME
+  // POINT, so the search is genuinely ambiguous and floating-point noise decides
+  // which end wins. When the last index won, FTC drove three poses, reported the
+  // goal reached, and FollowStrip recorded the ring as MOWED. Observed on the
+  // robot on both 2026-08-24 runs:
+  //
+  //     new path with 436 poses, start=(1.95,9.50), end=(1.95,9.50)
+  //     setPlan with 436 points, starting at idx=432   -> 99 % of the ring skipped
+  //     setPlan with 805 points, starting at idx=372   -> 46 % skipped
+  //
+  // and both were then logged "reached 99-100 % of path - treating as MOWED".
+  // Un-mowed ground marked done, with skipped_swaths still reading 0.
+  //
+  // Resume is not this function's job and never was: FollowStrip already owns it
+  // by trimming the path at its resume cursor BEFORE dispatch, and it decides
+  // whether to transit blade-off first by measuring to poses.front() — index 0.
+  // Snapping to a different index here silently disagreed with that decision.
+  // Starting at 0 makes the two consistent again.
+  //
+  // snap_to_nearest_on_set_plan restores the old behaviour if a site needs it.
+  if (!config_.snap_to_nearest_on_set_plan)
+  {
+    RCLCPP_INFO(logger_,
+                "FTCController: setPlan with %zu points, starting at idx=0.",
+                global_plan_.size());
+    last_time_ = clock_->now();
+    current_movement_speed_ = config_.speed_slow;
+    return;
+  }
+
   try
   {
     const auto base_to_map = tf_buffer_->lookupTransform("map",
@@ -638,19 +675,18 @@ void FTCController::setPlan(const nav_msgs::msg::Path& path)
                                                          tf2::durationFromSec(0.5));
     const double rx = base_to_map.transform.translation.x;
     const double ry = base_to_map.transform.translation.y;
-    double best_dist = std::numeric_limits<double>::max();
-    for (uint32_t i = 0; i < global_plan_.size(); ++i)
+
+    std::vector<std::pair<double, double>> xy;
+    xy.reserve(global_plan_.size());
+    for (const auto& p : global_plan_)
     {
-      const double dx = global_plan_[i].pose.position.x - rx;
-      const double dy = global_plan_[i].pose.position.y - ry;
-      const double d = dx * dx + dy * dy;
-      if (d < best_dist)
-      {
-        best_dist = d;
-        current_index_ = i;
-      }
+      xy.emplace_back(p.pose.position.x, p.pose.position.y);
     }
-    best_dist = std::sqrt(best_dist);
+    current_index_ = static_cast<uint32_t>(ChooseStartIndex(true, xy, rx, ry));
+
+    const double bdx = global_plan_[current_index_].pose.position.x - rx;
+    const double bdy = global_plan_[current_index_].pose.position.y - ry;
+    const double best_dist = std::hypot(bdx, bdy);
     RCLCPP_INFO(logger_,
                 "FTCController: setPlan with %zu points, starting at idx=%u (%.2fm from robot at "
                 "%.2f,%.2f).",

--- a/ros2/src/mowgli_nav2_plugins/test/test_ftc_start_index.cpp
+++ b/ros2/src/mowgli_nav2_plugins/test/test_ftc_start_index.cpp
@@ -1,0 +1,77 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Pins that a freshly dispatched plan is tracked from its start, and that a
+// CLOSED headland ring can never resolve to its end index.
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "mowgli_nav2_plugins/ftc_start_index.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_nav2_plugins::ChooseStartIndex;
+
+namespace
+{
+
+/// A closed headland ring: start == end, exactly as the coverage server emits.
+/// Modelled on the real one — 436 poses, start=end=(1.95, 9.50).
+std::vector<std::pair<double, double>> ClosedRing(std::size_t n = 436)
+{
+  std::vector<std::pair<double, double>> ring;
+  ring.reserve(n);
+  const double cx = 1.95, cy = 8.50, r = 1.0;
+  for (std::size_t i = 0; i < n; ++i)
+  {
+    // Sweep a full turn so the last point lands back on the first.
+    const double a = 2.0 * M_PI * static_cast<double>(i) / static_cast<double>(n - 1);
+    ring.emplace_back(cx + r * std::sin(a), cy + r * std::cos(a));
+  }
+  return ring;
+}
+
+}  // namespace
+
+TEST(FtcStartIndex, FreshPlanAlwaysStartsAtZero)
+{
+  const auto ring = ClosedRing();
+  // Robot sitting on the ring's start/end point — the exact 2026-08-24 case.
+  EXPECT_EQ(ChooseStartIndex(false, ring, ring.front().first, ring.front().second), 0u);
+  // ...and even parked deep inside the ring, a dispatched plan starts at 0.
+  EXPECT_EQ(ChooseStartIndex(false, ring, ring[300].first, ring[300].second), 0u);
+}
+
+// The regression. Both 2026-08-24 runs snapped to the ring's END index
+// (432 and 433 of 436) and skipped the entire ring while reporting it MOWED.
+TEST(FtcStartIndex, ClosedRingNeverResolvesToItsEndIndex)
+{
+  const auto ring = ClosedRing();
+  ASSERT_NEAR(ring.front().first, ring.back().first, 1e-9) << "fixture must be closed";
+  ASSERT_NEAR(ring.front().second, ring.back().second, 1e-9) << "fixture must be closed";
+
+  // Even with the legacy snap enabled, the tie must break toward the start.
+  const std::size_t idx = ChooseStartIndex(true, ring, ring.front().first, ring.front().second);
+  EXPECT_EQ(idx, 0u) << "a closed ring must start at its beginning, not its end";
+  EXPECT_LT(idx, ring.size() - 2) << "must never skip essentially the whole ring";
+}
+
+TEST(FtcStartIndex, LegacySnapStillFindsAGenuineMidPathPoint)
+{
+  // An open path — legacy behaviour is unambiguous here and must be preserved.
+  std::vector<std::pair<double, double>> line;
+  for (int i = 0; i < 100; ++i)
+  {
+    line.emplace_back(static_cast<double>(i) * 0.1, 0.0);
+  }
+  EXPECT_EQ(ChooseStartIndex(true, line, 5.0, 0.01), 50u);
+  EXPECT_EQ(ChooseStartIndex(false, line, 5.0, 0.01), 0u) << "default ignores the snap";
+}
+
+TEST(FtcStartIndex, EmptyPlanIsSafe)
+{
+  const std::vector<std::pair<double, double>> empty;
+  EXPECT_EQ(ChooseStartIndex(true, empty, 1.0, 2.0), 0u);
+  EXPECT_EQ(ChooseStartIndex(false, empty, 1.0, 2.0), 0u);
+}


### PR DESCRIPTION
Found during the 2026-08-24 validation mow. FTC was silently marking un-mowed ground as **mowed** — worse than skipping it, because `skipped_swaths` stays 0 and nothing ever comes back for it.

### Root cause

`setPlan` ran an unbounded nearest-point search over the whole plan and began tracking wherever it landed. Coverage headland rings are **closed** — start == end to the millimetre:

```
PathProgressGoalChecker: new path with 452 poses, start=(2.07,9.54), end=(2.07,9.54)
PathProgressGoalChecker: new path with 436 poses, start=(1.95,9.50), end=(1.95,9.50)
```

So index 0 and index N-1 describe the **same point**, the search is genuinely ambiguous, and floating-point noise picks the winner. When the last index won:

```
setPlan with 436 points, starting at idx=432   -> 99 % of the ring skipped
setPlan with 805 points, starting at idx=372   -> 46 % skipped
```

Both were then logged `reached 99-100% of path - treating as MOWED`.

**Reproducible, not random** — it happened on both 2026-08-24 runs (idx 433 and idx 432 of 436). That determinism makes this a strong candidate for **#445**, whose reporter says *"It skips exactly the blank spots between the mowed lines. Every run it skips exactly that part."*

### Change

A freshly dispatched plan now starts at index 0.

Resume was never this function's job. `FollowStrip` owns it: it trims the path at its resume cursor **before** dispatch, and decides whether to transit blade-off first by measuring to `poses.front()` — index 0 (`coverage_nodes.cpp:444`, `:644`). Snapping to a different index here silently disagreed with that decision. The two are now consistent, and the blade-off transit to a distant path start already exists on the BT side, so no new motion logic is introduced.

Legacy behaviour stays behind `snap_to_nearest_on_set_plan` (default `false`), with the tie now breaking toward the **earlier** index so a closed ring can never resolve to its end.

Selection logic is extracted to a pure `ftc_start_index.hpp` so both paths share one implementation.

### Tests

- `FreshPlanAlwaysStartsAtZero` — including the robot parked deep inside the ring
- `ClosedRingNeverResolvesToItsEndIndex` — the 2026-08-24 case, on a fixture asserted closed
- `LegacySnapStillFindsAGenuineMidPathPoint` — open paths unchanged
- `EmptyPlanIsSafe`

### Risk

This changes where the coverage controller begins every path. The intended effect is that FTC drives the segment it was handed, from the beginning. If the robot is far from a path start, the BT transits blade-off first (existing behaviour); if it somehow does not, FTC will drive there with the blade on rather than skipping the segment — noisier, but it cuts grass instead of pretending to.

**Not field-verified.** Wants a monitored run watching every `setPlan ... starting at idx=` line.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ