### PR TITLE
fix(fusion_graph): floor the DR slip veto above encoder quantization

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -192,6 +192,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_yaw_gates fusion_graph_core)
 
+  ament_add_gtest(test_dr_slip_veto
+    test/test_dr_slip_veto.cpp
+  )
+  target_link_libraries(test_dr_slip_veto fusion_graph_core)
+
   ament_add_gtest(test_rtk_wrongfix_gate
     test/test_rtk_wrongfix_gate.cpp
   )

--- a/ros2/src/fusion_graph/include/fusion_graph/dr_slip_veto.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/dr_slip_veto.hpp
@@ -1,0 +1,79 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Dead-reckoning slip veto, factored out of OnImu so it is unit-testable
+// without ROS. See fusion_graph_node.hpp for the design rationale: when the
+// wheel encoders claim a yaw rate the chassis gyro does not corroborate, the
+// wheels are skating and their forward velocity is a fiction that must not
+// accumulate into dr_x_/dr_y_.
+//
+// The subtlety this header exists to document: `wheel_wz` is not a continuous
+// measurement. /wheel_odom derives it from a tick DIFFERENCE over one
+// aggregation window (odometry_publisher.cpp),
+//
+//     wheel_wz = (d_right_m - d_left_m) / wheel_track / dt
+//
+// so its resolution is one encoder tick of left/right asymmetry:
+//
+//     1 LSB = (1 / ticks_per_meter) / wheel_track / dt
+//           = (1 / 280.44) / 0.325 / 0.066 = 0.166 rad/s   (typical 66 ms window)
+//           = (1 / 280.44) / 0.325 / 0.050 = 0.219 rad/s   (shortest 50 ms window)
+//
+// Any threshold at or below ~0.22 rad/s therefore cannot distinguish "one tick
+// of encoder rounding" from "the wheels are skating". Issue #488: with the
+// original 0.15 rad/s threshold the veto fired on 32-45 % of windows during a
+// slow STRAIGHT reverse (gyro ~0, ±1 tick asymmetry is the norm at 3 ticks per
+// wheel per window), zeroing that fraction of the translation. odom→base_footprint
+// then under-reported travel by ~25-30 %, and Nav2's BackUp — which measures
+// odom-frame displacement — drove 2.1 m for a 1.50 m command.
+//
+// The failure this veto was written for (2026-05-27, odom→base reaching 74 m on
+// a 10 m² lawn) is a skating pivot, where wheel_wz is order 1-3 rad/s. A
+// threshold above the 2-LSB floor keeps that caught with a wide margin.
+
+#pragma once
+
+#include <cmath>
+
+namespace fusion_graph
+{
+
+// Shipped thresholds. Defined here rather than at the member declaration so
+// the unit test can assert them against this robot's quantization floor
+// without pulling in ROS/GTSAM (see test_dr_slip_veto.cpp).
+//
+// kDrSlipWheelMinDefaultRadPerS clears 2 LSB at the shortest /wheel_odom
+// aggregation window on this drivetrain (2 x 0.219 = 0.439 rad/s); the skating
+// pivot the veto exists for runs 1-3 rad/s. The gyro rate needs no such floor —
+// it is a continuous 91 Hz measurement, not a tick difference.
+inline constexpr double kDrSlipWheelMinDefaultRadPerS = 0.44;
+inline constexpr double kDrSlipGyroMaxDefaultRadPerS = 0.15;
+
+// Quantization floor of the wheel-derived yaw rate: the |wheel_wz| produced by
+// a single encoder tick of left/right asymmetry over one aggregation window.
+// Below this, |wheel_wz| carries no information about chassis rotation.
+inline double WheelYawRateQuantumRadPerS(double ticks_per_meter,
+                                         double wheel_track_m,
+                                         double window_s)
+{
+  if (ticks_per_meter <= 0.0 || wheel_track_m <= 0.0 || window_s <= 0.0)
+    return 0.0;
+  return (1.0 / ticks_per_meter) / wheel_track_m / window_s;
+}
+
+// True when the wheels claim a yaw rate the gyro does not corroborate, i.e. the
+// chassis is being skated rather than driven and wheel_vx is phantom.
+//
+// All three conditions must hold: the wheels and the gyro must disagree, the
+// gyro must read near-still (a coordinated turn is never vetoed), and the
+// wheels must claim a rate large enough to be real rather than quantization.
+inline bool DrSlipVetoed(double wheel_wz,
+                         double gyro_wz,
+                         double wheel_min_rad_per_s,
+                         double gyro_max_rad_per_s)
+{
+  return std::abs(wheel_wz - gyro_wz) > wheel_min_rad_per_s &&
+         std::abs(gyro_wz) < gyro_max_rad_per_s && std::abs(wheel_wz) > wheel_min_rad_per_s;
+}
+
+}  // namespace fusion_graph

--- a/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
@@ -35,6 +35,7 @@
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 
+#include "fusion_graph/dr_slip_veto.hpp"
 #include "fusion_graph/graph_manager.hpp"
 #include "fusion_graph/pose_extrapolator.hpp"
 #include "fusion_graph/scan_matcher.hpp"
@@ -185,8 +186,24 @@ private:
   //   dr_slip_wheel_min_rad_per_s: wheel must claim a real yaw rate
   // The disagreement itself is |wheel_wz_ - gz|, gated by the two
   // above so a normal coordinated turn (both agree) is never vetoed.
-  double dr_slip_gyro_max_rad_per_s_ = 0.15;
-  double dr_slip_wheel_min_rad_per_s_ = 0.15;
+  //
+  // dr_slip_wheel_min_rad_per_s MUST stay above the quantization floor of
+  // wheel_wz_ — see dr_slip_veto.hpp for the derivation. /wheel_odom derives
+  // the wheel yaw rate from a tick DIFFERENCE over one 50-67 ms aggregation
+  // window, so one tick of left/right asymmetry already reads 0.166-0.219
+  // rad/s. The original 0.15 sat BELOW that floor: during a slow straight
+  // drive the gyro reads ~0 and a single tick of encoder rounding was
+  // indistinguishable from a skating pivot, so the veto fired on 32-45 % of
+  // windows and zeroed that fraction of the translation. odom→base_footprint
+  // under-reported travel by ~25-30 %, and Nav2's BackUp — which measures
+  // odom-frame displacement — drove 2.1 m for a 1.50 m undock command
+  // (issue #488). 0.44 rad/s clears the 2-LSB floor; the skating pivot this
+  // veto exists for runs 1-3 rad/s, so the margin costs no sensitivity.
+  // Both are ROS parameters (dr_slip_gyro_max_rad_per_s /
+  // dr_slip_wheel_min_rad_per_s) so a robot with a different
+  // ticks_per_meter, wheel_track or aggregation window can re-floor them.
+  double dr_slip_gyro_max_rad_per_s_ = kDrSlipGyroMaxDefaultRadPerS;
+  double dr_slip_wheel_min_rad_per_s_ = kDrSlipWheelMinDefaultRadPerS;
 
   // GPS antenna radial offset from base_link, hypot(lever_arm_x,
   // lever_arm_y). Used by the RTK wrong-fix gate in OnGnss to

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -99,6 +99,15 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
   // the docked pose 11.5 cm + 53° over a dwell — field 2026-06-10). σ small so
   // the dock prior dominates xy; yaw σ from dock_pose_yaw_sigma_rad.
   dock_reanchor_sigma_xy_m_ = declare_parameter<double>("dock_reanchor_sigma_xy_m", 0.03);
+  // Dead-reckoning slip veto thresholds (see header + dr_slip_veto.hpp).
+  // dr_slip_wheel_min_rad_per_s MUST stay above the 1-tick quantization floor
+  // of the wheel-derived yaw rate, or the veto fires on encoder rounding
+  // during ordinary straight driving (issue #488).
+  dr_slip_gyro_max_rad_per_s_ =
+      declare_parameter<double>("dr_slip_gyro_max_rad_per_s", dr_slip_gyro_max_rad_per_s_);
+  dr_slip_wheel_min_rad_per_s_ =
+      declare_parameter<double>("dr_slip_wheel_min_rad_per_s", dr_slip_wheel_min_rad_per_s_);
+
   // Dock-approach pose stabilisation (see header). During the final graceful
   // approach, drop COG yaw + reject RTK-float epochs so the dock controller
   // gets a stable target instead of a flickering pose.

--- a/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
@@ -16,6 +16,7 @@
 #include <tf2/exceptions.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include "fusion_graph/dr_slip_veto.hpp"
 #include "fusion_graph/fusion_graph_node.hpp"
 #include "fusion_graph/fusion_graph_node_util.hpp"
 #include "fusion_graph/rtk_wrongfix_gate.hpp"
@@ -71,9 +72,8 @@ void FusionGraphNode::OnImu(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       // this sample; yaw still integrates from the gyro, which is the
       // honest source during a slipping pivot. Without this the odom
       // frame accumulates the fictitious forward motion unbounded.
-      const bool dr_slip = std::abs(wheel_wz_ - gz) > dr_slip_wheel_min_rad_per_s_ &&
-                           std::abs(gz) < dr_slip_gyro_max_rad_per_s_ &&
-                           std::abs(wheel_wz_) > dr_slip_wheel_min_rad_per_s_;
+      const bool dr_slip =
+          DrSlipVetoed(wheel_wz_, gz, dr_slip_wheel_min_rad_per_s_, dr_slip_gyro_max_rad_per_s_);
       const double vx_eff = dr_slip ? 0.0 : wheel_vx_;
       {
         // tf_state_mu_: dr_* is read concurrently by TfBroadcastLoop.

--- a/ros2/src/fusion_graph/test/test_dr_slip_veto.cpp
+++ b/ros2/src/fusion_graph/test/test_dr_slip_veto.cpp
@@ -1,0 +1,106 @@
+// Dead-reckoning slip veto vs. encoder quantization (issue #488).
+//
+// The veto drops wheel-derived translation when the wheels claim a yaw rate
+// the gyro does not corroborate. Its threshold must sit ABOVE the resolution
+// of the wheel yaw rate, which /wheel_odom derives from a tick DIFFERENCE
+// over one aggregation window. Below that floor the veto cannot tell one tick
+// of encoder rounding from a skating pivot, and fires during ordinary
+// straight driving — which is what made odom→base_footprint under-report
+// travel by ~25-30 % and Nav2's BackUp drive 2.1 m for a 1.50 m command.
+
+#include "fusion_graph/dr_slip_veto.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+// This robot, from mowgli_robot.yaml + odometry_publisher.cpp.
+constexpr double kTicksPerMeter = 280.4408894780635;
+constexpr double kWheelTrack = 0.325;
+// /wheel_odom publishes once the accumulated firmware dt reaches kAggregateMs
+// = 50; the observed field windows are 65-67 ms. The SHORTEST window gives the
+// LARGEST quantum, so it is the one the threshold must clear.
+constexpr double kShortestWindowS = 0.050;
+constexpr double kTypicalWindowS = 0.066;
+
+// Shipped defaults — read from the header, never re-typed here, so this test
+// tracks the real value if someone edits it.
+constexpr double kWheelMin = fg::kDrSlipWheelMinDefaultRadPerS;
+constexpr double kGyroMax = fg::kDrSlipGyroMaxDefaultRadPerS;
+
+double Quantum(double window_s)
+{
+  return fg::WheelYawRateQuantumRadPerS(kTicksPerMeter, kWheelTrack, window_s);
+}
+}  // namespace
+
+TEST(DrSlipVeto, QuantumMatchesHandDerivation)
+{
+  // (1 / 280.44) / 0.325 / dt
+  EXPECT_NEAR(Quantum(kTypicalWindowS), 0.1662, 1e-3);
+  EXPECT_NEAR(Quantum(kShortestWindowS), 0.2194, 1e-3);
+}
+
+TEST(DrSlipVeto, QuantumIsZeroForDegenerateGeometry)
+{
+  EXPECT_EQ(fg::WheelYawRateQuantumRadPerS(0.0, kWheelTrack, kTypicalWindowS), 0.0);
+  EXPECT_EQ(fg::WheelYawRateQuantumRadPerS(kTicksPerMeter, 0.0, kTypicalWindowS), 0.0);
+  EXPECT_EQ(fg::WheelYawRateQuantumRadPerS(kTicksPerMeter, kWheelTrack, 0.0), 0.0);
+}
+
+// The regression guard. A future edit that lowers the threshold back under the
+// quantization floor re-opens issue #488, so pin the invariant, not the value.
+TEST(DrSlipVeto, ThresholdClearsTwoTicksOfEncoderAsymmetry)
+{
+  EXPECT_GT(kWheelMin, 2.0 * Quantum(kShortestWindowS));
+}
+
+// Slow STRAIGHT reverse, gyro ~0, one tick of left/right asymmetry: this is
+// encoder rounding, not slip. Must NOT be vetoed at any observed window length.
+TEST(DrSlipVeto, OneTickAsymmetryDuringStraightDriveIsNotSlip)
+{
+  for (double window : {kShortestWindowS, kTypicalWindowS})
+  {
+    const double wz = Quantum(window);
+    EXPECT_FALSE(fg::DrSlipVetoed(wz, 0.0, kWheelMin, kGyroMax)) << "window " << window;
+    EXPECT_FALSE(fg::DrSlipVetoed(-wz, 0.0, kWheelMin, kGyroMax)) << "window " << window;
+  }
+}
+
+TEST(DrSlipVeto, TwoTickAsymmetryDuringStraightDriveIsNotSlip)
+{
+  const double wz = 2.0 * Quantum(kTypicalWindowS);  // 0.332 rad/s, observed in the field logs
+  EXPECT_FALSE(fg::DrSlipVetoed(wz, 0.0, kWheelMin, kGyroMax));
+}
+
+// The failure this veto exists for: wheels claim a pivot, gyro says still.
+TEST(DrSlipVeto, SkatingPivotIsVetoed)
+{
+  for (double wheel_wz : {1.0, 2.0, 3.0})
+  {
+    EXPECT_TRUE(fg::DrSlipVetoed(wheel_wz, 0.0, kWheelMin, kGyroMax)) << wheel_wz;
+    EXPECT_TRUE(fg::DrSlipVetoed(-wheel_wz, 0.0, kWheelMin, kGyroMax)) << wheel_wz;
+  }
+}
+
+// A real coordinated turn: both sensors agree. Never vetoed, however fast.
+TEST(DrSlipVeto, CoordinatedTurnIsNotVetoed)
+{
+  EXPECT_FALSE(fg::DrSlipVetoed(1.0, 1.0, kWheelMin, kGyroMax));
+  EXPECT_FALSE(fg::DrSlipVetoed(2.0, 1.95, kWheelMin, kGyroMax));
+}
+
+// Gyro moving disqualifies the veto even when the wheels disagree — the gyro
+// gate exists so a turn where the wheels merely mis-scale is not called slip.
+TEST(DrSlipVeto, MovingGyroDisqualifiesVeto)
+{
+  EXPECT_FALSE(fg::DrSlipVetoed(2.0, 0.5, kWheelMin, kGyroMax));
+}
+
+// Sanity: the veto still catches a slow skate, just above the new floor.
+TEST(DrSlipVeto, SlowSkateJustAboveThresholdIsVetoed)
+{
+  EXPECT_TRUE(fg::DrSlipVetoed(kWheelMin + 0.01, 0.0, kWheelMin, kGyroMax));
+  EXPECT_FALSE(fg::DrSlipVetoed(kWheelMin - 0.01, 0.0, kWheelMin, kGyroMax));
+}


### PR DESCRIPTION
## Why

Investigation of #488. The undock `BackUp` overshoot is real motion, and the cause is in the
localizer, not in `BackUp`. Full data and derivation: https://github.com/mowglinext/mowglinext/issues/488#issuecomment-5396243029

The dead-reckoning slip veto (`fusion_graph_node_callbacks_a.cpp`) drops wheel translation when
the wheels claim a yaw rate the gyro does not corroborate. Its threshold was **0.15 rad/s** —
below the resolution of the signal it tests.

`/wheel_odom` derives the wheel yaw rate from a tick **difference** over one 50–67 ms
aggregation window (`odometry_publisher.cpp`, `kAggregateMs = 50`):

```
wheel_wz = (d_right_m - d_left_m) / wheel_track / dt
```

so one encoder tick of left/right asymmetry already reads

```
(1 / 280.4409) / 0.325 / 0.066 = 0.166 rad/s     typical 66 ms window
(1 / 280.4409) / 0.325 / 0.050 = 0.219 rad/s     shortest 50 ms window
```

1 LSB = 0.166–0.219 rad/s; the gate tripped at 0.15. During a slow straight drive the gyro reads
~0 and each wheel logs ~3 ticks per window, so ±1 tick of rounding is the norm — and was
indistinguishable from a skating pivot.

## Evidence

Four undocks are now available (sessions 1a, 1b, 2, 3 — all commanded 1.50 m at 0.15 m/s),
encoder travel integrated from `cum L`/`cum R` between `BackUp: reversing` and `BackUp: complete`:

| run | duration | encoder travel | fused `dist` | measured speed | implied odom shortfall |
|-----|---------:|---------------:|-------------:|---------------:|-----------------------:|
| S1a | 13.20 s | 2.130 m | 2.171 m | 0.161 m/s | 29.6 % |
| S1b | 12.60 s | 1.996 m | 1.641 m | 0.158 m/s | 24.8 % |
| S2  | 13.16 s | 2.099 m | 1.987 m | 0.159 m/s | 28.5 % |
| S3  | 12.05 s | 1.885 m | 1.869 m | 0.156 m/s | 20.4 % |

`behavior_server` logged `backup completed successfully` in all four (not a timeout —
`time_allowance` is 30 s), and it measures displacement in the **odom** frame
(`global_frame: odom`, `nav2_params_base.yaml:598`), which `fusion_graph_node` publishes. So it
genuinely saw 1.50 m while the wheels turned ~2.0 m, every time.

What the four runs settle, comparing coefficient of variation across them:

| model | quantity it predicts constant | CV |
|-------|------------------------------|---:|
| terminates on a proportionally-short distance | total travel | **4.7 %** |
| fixed extra time (TF lag) | deficit in seconds | 17.2 % |
| fixed extra distance | deficit in metres | 18.2 % |

BackUp stops at a repeatable **total** (2.03 m mean), not after a fixed extra amount. That
favours a proportional scale error in the odom-frame measurement over a fixed lag.

What the four runs do **not** settle: all four ran at the same speed (CV 1.1 %), so duration and
distance are proportional and the data **cannot** separate "terminates on a scaled distance"
from "runs for a fixed extra time" — CV 4.7 % vs 3.7 % is not a discriminator at n=4. See the
test plan for the experiment that does separate them.

### Honest limits on the veto attribution

The quantization arithmetic above is exact and independent of the logs — the gate provably
cannot distinguish 1 tick from a skate at 0.15 rad/s. What the logs do **not** establish is that
the veto is the sole or exact cause of the shortfall. Estimating each run's veto rate from the
logged `acc_dL`/`acc_dR` windows:

| run | veto-predicted loss | implied shortfall |
|-----|--------------------:|------------------:|
| S3  | 49.5 % | 20.4 % |
| S1a | 44.9 % | 29.6 % |
| S2  | 32.8 % | 28.5 % |
| S1b | 31.5 % | 24.8 % |

The per-run rank correlation **does not hold** (S3 has the highest predicted loss and the lowest
observed shortfall), and the mean predicted loss (39.7 %) systematically exceeds the mean
observed (25.8 %). Two known reasons: only every 10th window is logged (~20 of ~190 per run,
binomial SE ±11 pts), and the estimator assumes `gz = 0`, which inflates the rate — real gyro
noise sometimes pulls `|wheel_wz - gz|` back under threshold and un-vetoes a window.

So: the veto is a mechanism of the right kind and more than sufficient magnitude, and it is a
defect worth fixing on its own arithmetic. It is **not** proven to be the whole of the 25-30 %.

## What changed

- **`dr_slip_wheel_min_rad_per_s` 0.15 → 0.44 rad/s**, clear of the 2-LSB floor. The skating
  pivot this veto exists for (2026-05-27, `odom→base` reaching 74 m on a 10 m² lawn) runs
  1–3 rad/s, so the margin costs no sensitivity.
- **Gyro gate unchanged at 0.15** — it is a continuous 91 Hz measurement, not a tick difference,
  and has no quantization floor.
- Predicate extracted into a pure ROS-free header `dr_slip_veto.hpp` so the invariant is
  testable; threshold defaults live there as the single source of truth (the test reads them
  rather than re-typing them).
- Both thresholds declared as ROS parameters, so a robot with a different `ticks_per_meter`,
  `wheel_track` or aggregation window can re-floor them without a rebuild.

Behaviour is otherwise identical — same three conditions, same operands.

## Test plan

`test_dr_slip_veto` pins the **invariant**, not the number:

- [x] quantum matches the hand derivation (0.166 / 0.219 rad/s)
- [x] threshold clears two ticks of encoder asymmetry
- [x] one- and two-tick asymmetry during a straight drive is **not** vetoed
- [x] a 1–3 rad/s skating pivot **is** vetoed
- [x] a coordinated turn (both sensors agree) is never vetoed
- [x] moving gyro disqualifies the veto
- [x] degenerate geometry returns a 0 quantum

Verified **RED at the old 0.15** (3 failures: threshold guard + both quantization cases) and
**GREEN at 0.44** (9/9), compiled standalone against gtest 1.17. Not built under colcon locally
— CI builds `feat/*`.

- [ ] **Field test owed.** Next undock should travel ~1.5 m rather than ~2.0 m.

Two follow-up measurements, both cheap, that the four logged runs cannot substitute for:

- [ ] **Separate distance-termination from time-overrun:** issue one BackUp at a *different*
      commanded speed (e.g. 0.30 m/s). All four logged runs were at 0.15 m/s, which is exactly
      why they cannot discriminate. Scaled-distance termination → travel stays ~2.0 m and
      duration halves; fixed-time overrun → duration stays ~12.8 s and travel doubles.
- [ ] **Measure the odom shortfall directly:** record `/odometry/filtered` and `/wheel_odom`
      across one BackUp and compare `hypot(Δx, Δy)` against `∫|vx| dt`. Counting `dr_slip == true`
      samples over the same window pins the veto's actual contribution, which the 10x-decimated
      logs cannot.

## Scope / safety

Localizer change — flagging as behaviour-affecting per the project safety rule. It does **not**
touch blade control, the firmware safety authority, or any wheel-independent check.

`map→base` is unaffected either way (`fusion_graph` derives `map→odom` by composition, so the
error cancelled there), and FTC is unaffected via `controller_server.odom_topic: /wheel_odom`,
which does not pass through the veto. The change makes the odom frame report the distance the
robot actually travelled, which is what every odom-frame consumer already assumed.

Invariant 16's rule that the **dig detector** must never trust a wheel-derived signal is
untouched — this is `fusion_graph`'s DR veto, a different gate, and it still reads the gyro as
its cross-check.

## Not addressed here

The other half of #488. `CalibrateHeadingFromUndock`'s `dist` comes from raw
`/gps/absolute_pose`, not the fused pose (`calibration_nodes.cpp:118` ←
`behavior_tree_node.cpp:277`). Across the four runs the start point — physically the same dock
every time — scattered by 0.237 m and the end point by 0.324 m. `dist` is a difference of two
raw-GNSS endpoints and inherits both errors: its spread is 0.530 m against the encoder's 0.245 m,
and its per-run agreement with the encoder is erratic (0.016 / 0.041 / 0.112 / 0.355 m) rather
than biased. That is a separate measurement question and deserves its own change.

Refs #488

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
