### PR TITLE
fix(fusion_graph): scale wheel between-factor translation sigma by distance (#491)

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -177,6 +177,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_adaptive_noise fusion_graph_core)
 
+  ament_add_gtest(test_wheel_sigma_scaling
+    test/test_wheel_sigma_scaling.cpp
+  )
+  target_link_libraries(test_wheel_sigma_scaling fusion_graph_core)
+
   ament_add_gtest(test_pose_extrapolator
     test/test_pose_extrapolator.cpp
   )

--- a/ros2/src/fusion_graph/config/fusion_graph.yaml
+++ b/ros2/src/fusion_graph/config/fusion_graph.yaml
@@ -38,11 +38,24 @@ fusion_graph_node:
     odom_rebase_dist_m: 6.0
 
     # ── Wheel between-factor noise ─────────────────────────────────────
-    # Per-node sigmas in body frame. wheel_sigma_y << wheel_sigma_x is
-    # the non-holonomic constraint: the robot doesn't slide sideways.
-    wheel_sigma_x: 0.05         # m
-    wheel_sigma_y: 0.005        # m — tight non-holo
-    wheel_sigma_theta: 0.01     # rad — used only when no gyro this tick
+    # Translational noise is a RANDOM WALK scaled by the distance each node
+    # actually covered (issue #491), not a fixed per-node sigma:
+    #
+    #   sigma = k * sqrt(step_m + wheel_creep_speed_mps * dt)
+    #
+    # so variance grows with distance travelled and the accumulated
+    # uncertainty is invariant to node_period_s. Units are m/sqrt(m): at 1 m
+    # of travel per node these reproduce the old per-node 0.05 / 0.005 m.
+    # wheel_sigma_y << wheel_sigma_x remains the non-holonomic constraint
+    # (the robot doesn't slide sideways) — both scale by the same sqrt(d),
+    # so the 10:1 ratio holds at every step size.
+    wheel_sigma_x_per_sqrt_m: 0.05    # m/sqrt(m) — along-track
+    wheel_sigma_y_per_sqrt_m: 0.005   # m/sqrt(m) — tight non-holo
+    # Floor on the noise distance, as a creep SPEED rather than a constant
+    # sigma: motion the encoders may have missed (towed, lifted, both wheels
+    # skating). Stating it as a distance keeps it cadence-invariant.
+    wheel_creep_speed_mps: 0.04
+    wheel_sigma_theta: 0.01     # rad per node — used only when no gyro this tick
 
     # ── Gyro yaw between-factor noise ──────────────────────────────────
     # Used when at least one IMU sample arrived between nodes. Much
@@ -201,7 +214,8 @@ fusion_graph_node:
     gyro_bias_prior_sigma_rad_per_s: 0.05
 
     # ── Adaptive process noise on wheel σ_x ────────────────────────────
-    # Inflates wheel_sigma_x when the |dtheta_wheel - dtheta_gyro|
+    # Inflates the wheel between-factor's sigma_x when the
+    # |dtheta_wheel - dtheta_gyro|
     # residual EMA exceeds the floor. Slip on wet grass / slope causes
     # encoders to over-report distance — without inflation the
     # iSAM2 wheel between-factor pins the trajectory to that bogus

--- a/ros2/src/fusion_graph/include/fusion_graph/graph_params.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/graph_params.hpp
@@ -23,6 +23,12 @@ namespace fusion_graph
 // default is 50 Hz, some setups 10 Hz). At 25 Hz the factor is 1.0 (no change).
 inline constexpr double kTunedNodePeriodS = 0.04;
 
+// Absolute lower bound (m) on the wheel between-factor's translational sigmas.
+// The distance-scaled model below already carries a creep floor, so this only
+// guards the degenerate case where BOTH the step and dt are zero — a zero
+// sigma would make the GTSAM noise model singular.
+inline constexpr double kMinWheelSigmaM = 1.0e-4;
+
 struct GraphParams
 {
   // Node creation cadence — one Pose2 per node_period_s of wall-clock.
@@ -31,10 +37,42 @@ struct GraphParams
   // kTunedNodePeriodS so their rad/s meaning is cadence-invariant.
   double node_period_s = 0.1;
 
-  // Wheel between-factor noise (sigmas, body-frame). Tight vy enforces
-  // non-holonomic motion.
-  double wheel_sigma_x = 0.05;  // m per node @ 10 Hz
-  double wheel_sigma_y = 0.005;  // m per node — non-holo
+  // Wheel between-factor TRANSLATIONAL noise (body-frame), as random-walk
+  // coefficients — NOT per-node sigmas. Changed 2026-08-24 (issue #491); see
+  // the long rationale block in CreateNodeLocked. Summary:
+  //
+  //   σ = k · √(step_m + wheel_creep_speed_mps · dt)      [Var = k² · d]
+  //
+  // Variance (not sigma) is proportional to the distance the step covered, so
+  // N hops of d/N metres sum to exactly the variance of one hop of d metres —
+  // the accumulated uncertainty tracks distance travelled and is invariant to
+  // node_period_s. This is the noise-model counterpart of the kTunedNodePeriodS
+  // tick_scale applied to the per-tick gates.
+  //
+  // Units are m/√m. At 1 m of travel per node these reproduce the old fixed
+  // per-node values (0.05 / 0.005 m), so the numbers are unchanged in
+  // magnitude — only their meaning (and hence their effect at the deployed
+  // 8 mm-per-hop step) changes. wheel_sigma_y ≪ wheel_sigma_x still holds at
+  // every step size: both scale by the same √d, so the 10:1 non-holonomic
+  // asymmetry ("the robot doesn't slide sideways") is preserved.
+  double wheel_sigma_x_per_sqrt_m = 0.05;  // m/√m — along-track random walk
+  double wheel_sigma_y_per_sqrt_m = 0.005;  // m/√m — non-holo, 10x tighter
+
+  // Floor on the noise distance, expressed as a CREEP SPEED rather than a
+  // constant sigma: even when the encoders report a zero step we allow for
+  // wheel_creep_speed_mps · dt metres of motion they may have missed (towed,
+  // lifted, both wheels skating). Stating the floor as a distance keeps it
+  // cadence-invariant — a constant per-node sigma floor would reintroduce the
+  // √N-per-hop accumulation this model exists to remove. 0.04 m/s is well
+  // under the 0.2 m/s mowing speed, so it never dominates while driving; while
+  // parked (node cadence drops to stationary_node_period_s = 5 s) it yields
+  // σ_x = 0.05·√0.2 ≈ 0.022 m per node, loose enough that GNSS still anchors.
+  double wheel_creep_speed_mps = 0.04;
+
+  // Yaw stays a PER-NODE sigma: unlike translation, the wheel-derived yaw
+  // error is dominated by per-tick encoder quantisation and differential slip,
+  // not by a distance-driven random walk, and the gyro (gyro_sigma_theta)
+  // supersedes it on every tick where an IMU sample arrived.
   double wheel_sigma_theta = 0.01;  // rad per node
 
   // Gyro yaw between-factor noise (overrides wheel_sigma_theta when used).

--- a/ros2/src/fusion_graph/src/fusion_graph_node.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node.cpp
@@ -29,8 +29,10 @@ FusionGraphNode::FusionGraphNode(const rclcpp::NodeOptions& opts)
   // ── Parameters ────────────────────────────────────────────────────
   GraphParams gp;
   gp.node_period_s = declare_parameter<double>("node_period_s", 0.1);
-  gp.wheel_sigma_x = declare_parameter<double>("wheel_sigma_x", 0.05);
-  gp.wheel_sigma_y = declare_parameter<double>("wheel_sigma_y", 0.005);
+  // Random-walk coefficients (m/√m), not per-node sigmas — issue #491.
+  gp.wheel_sigma_x_per_sqrt_m = declare_parameter<double>("wheel_sigma_x_per_sqrt_m", 0.05);
+  gp.wheel_sigma_y_per_sqrt_m = declare_parameter<double>("wheel_sigma_y_per_sqrt_m", 0.005);
+  gp.wheel_creep_speed_mps = declare_parameter<double>("wheel_creep_speed_mps", 0.04);
   gp.wheel_sigma_theta = declare_parameter<double>("wheel_sigma_theta", 0.01);
   gp.gyro_sigma_theta = declare_parameter<double>("gyro_sigma_theta", 0.005);
   gp.gps_sigma_floor = declare_parameter<double>("gps_sigma_floor", 0.003);

--- a/ros2/src/fusion_graph/src/graph_manager_node.cpp
+++ b/ros2/src/fusion_graph/src/graph_manager_node.cpp
@@ -237,15 +237,76 @@ std::optional<TickOutput> GraphManager::CreateNodeLocked(double now_s)
   // stationary logic that drove dtheta — reuse it here so both halves
   // of the BetweenFactor stay consistent.
   //
+  // ── Translational sigmas: distance-scaled random walk (issue #491) ──
+  //
+  // σ_x / σ_y are NOT fixed per-node constants. A per-node sigma makes the
+  // accumulated uncertainty a function of how many nodes we happened to
+  // create, not of how far the robot actually drove. Measured 2026-08-24 on
+  // RTK-Fixed: the published major-axis σ read p50 0.574 m / max 1.391 m
+  // while the GNSS receiver reported 0.014 m and FTC's cross-track error was
+  // 0.008-0.016 m. At node_period_s = 0.04 and 0.2 m/s each hop covers 8 mm
+  // yet the old fixed σ_x claimed 50-92 mm for it (~10x the step), so the
+  // marginal on the newest node grew as σ·√N — 0.092·√40 = 0.58 m for the
+  // ~40 hops between the last GNSS-anchored node and the head, matching the
+  // observation. It was also cadence-dependent: the same physical motion
+  // accumulated √2.5x more uncertainty at 25 Hz than at 10 Hz.
+  //
+  // Fix: make VARIANCE (not sigma) proportional to the distance the step
+  // covered — σ = k·√d, Var = k²·d — so N hops of d/N metres sum to exactly
+  // the variance of one hop of d metres. That is cadence-invariant by
+  // construction, and is the noise-model counterpart of the tick_scale
+  // applied to the per-tick GATES above (same reasoning: a quantity tuned
+  // per-tick must be rescaled when the tick length changes). Sigma-
+  // proportional scaling (σ = k·d, as the issue sketched) would have been
+  // wrong in the opposite direction: it accumulates as k·d/√N, i.e. tighter
+  // the faster you tick. Precedent for the √ form is a few lines below —
+  // the gyro-bias random walk already uses σ = σ_rw·√dt.
+  //
+  // The noise distance uses the RAW accumulator, not the slip-vetoed
+  // (dx_eff, dy_eff). What the encoders CLAIMED bounds how wrong they can
+  // be; when the veto zeroes the delta the factor's meaning becomes "we
+  // believe we did not move, ± the distance the wheels claimed", which is
+  // exactly the uncertainty we want. Scoring the vetoed zero would instead
+  // pin the pose to "stationary" at the moment we know least.
+  const double claimed_step_m = std::hypot(accum_.dx, accum_.dy);
+  const double accum_dt = (accum_.dt_total > 0.0) ? accum_.dt_total : params_.node_period_s;
+  const double noise_dist_m = claimed_step_m + params_.wheel_creep_speed_mps * accum_dt;
+  const double sigma_x_travel =
+      std::max(kMinWheelSigmaM, params_.wheel_sigma_x_per_sqrt_m * std::sqrt(noise_dist_m));
+  const double sigma_y_travel =
+      std::max(kMinWheelSigmaM, params_.wheel_sigma_y_per_sqrt_m * std::sqrt(noise_dist_m));
+
+  // ── Fault releases: pivot gate + adaptive inflation ────────────────
+  //
+  // These two stay PER-NODE ABSOLUTE sigmas and are applied as a lower BOUND
+  // on the travel-scaled value, rather than being scaled by distance
+  // themselves. That is deliberate: they do not model a distance-driven
+  // random walk, they model a wheel FAULT — a measurement that is wrong in a
+  // way unrelated to how far the encoders say we went — and their job is to
+  // RELEASE the X constraint so GPS / scan-matching set XY.
+  //
+  // Scaling them per-distance would defeat them precisely in the case they
+  // exist for. During a pivot the encoders report ~0.8 mm of phantom
+  // translation per tick at 25 Hz, so a per-distance pivot sigma would
+  // collapse to ~1.4 mm and pin the pose to the phantom motion — the exact
+  // 0.2-0.4 m per-spin drift pivot_wheel_sigma_x was added to stop. Likewise
+  // the adaptive term is driven by a yaw residual measuring rotation the
+  // wheels invented; the linear error that implies is not bounded by the
+  // (often vetoed, hence zero) reported step.
+  //
+  // Because these fire only on a detected fault, keeping them per-node does
+  // not reintroduce the √N growth in normal driving: net_residual is 0 and
+  // the pivot gate is shut, so the release is 0 and the travel term wins.
+  //
   // sigma_x gates on the per-tick gyro yaw delta: during fast pivots
   // the wheels report phantom forward velocity (see GraphParams
   // comment) so swap to a loose sigma and let GPS / scan-matching
   // constrain XY. Gating on the gyro (not wheel-derived) dtheta
   // avoids feedback from the same encoder that's misreporting.
-  double wheel_sigma_x_eff =
+  double wheel_sigma_x_release =
       std::abs(accum_.dtheta_gyro) > params_.pivot_gate_dtheta_rad * tick_scale
           ? params_.pivot_wheel_sigma_x
-          : params_.wheel_sigma_x;
+          : 0.0;
 
   // Adaptive σ_x inflation from wheel↔gyro residual EMA. Skipped
   // entirely when adaptive_noise_enabled_gain == 0 (the parameter
@@ -262,21 +323,24 @@ std::optional<TickOutput> GraphManager::CreateNodeLocked(double now_s)
     // residual = larger inflation.
     const double residual = std::abs(accum_.dtheta_wheel - accum_.dtheta_gyro);
 
-    // EMA in continuous time: α = dt / (τ + dt). dt_total here is the
-    // wall time we've been accumulating wheel/gyro samples; safe
-    // approximation of node_period_s when the inputs are arriving on
-    // schedule. Falls back to one full step when dt_total is 0 (rare —
-    // happens on the very first tick before any wheel sample).
-    const double dt = (accum_.dt_total > 0.0) ? accum_.dt_total : params_.node_period_s;
+    // EMA in continuous time: α = dt / (τ + dt). accum_dt (computed with
+    // the travel sigmas above) is the wall time we've been accumulating
+    // wheel/gyro samples; safe approximation of node_period_s when the
+    // inputs are arriving on schedule, and it already falls back to one
+    // full step when dt_total is 0 (rare — happens on the very first tick
+    // before any wheel sample).
     const double tau = std::max(params_.adaptive_noise_ema_tau_s, 1.0e-3);
-    const double alpha = dt / (tau + dt);
+    const double alpha = accum_dt / (tau + accum_dt);
     residual_ema_ = (1.0 - alpha) * residual_ema_ + alpha * residual;
 
     // Floor: anything below this is sensor jitter, not slip.
     const double net_residual =
         std::max(0.0, residual_ema_ - params_.adaptive_noise_residual_floor_rad);
-    wheel_sigma_x_eff += params_.adaptive_noise_enabled_gain * net_residual;
+    wheel_sigma_x_release += params_.adaptive_noise_enabled_gain * net_residual;
   }
+
+  // Travel-scaled random walk, floored by whichever fault release is active.
+  const double wheel_sigma_x_eff = std::max(sigma_x_travel, wheel_sigma_x_release);
   last_wheel_sigma_x_eff_ = wheel_sigma_x_eff;
 
   // When IMU preintegration is active, the GyroPreintFactor below
@@ -290,7 +354,7 @@ std::optional<TickOutput> GraphManager::CreateNodeLocked(double now_s)
 
   auto between_noise = MakeDiagonal({
       wheel_sigma_x_eff,
-      params_.wheel_sigma_y,
+      sigma_y_travel,
       sigma_theta,
   });
   new_factors_.add(gtsam::BetweenFactor<gtsam::Pose2>(k_prev, k_curr, between, between_noise));

--- a/ros2/src/fusion_graph/test/test_adaptive_noise.cpp
+++ b/ros2/src/fusion_graph/test/test_adaptive_noise.cpp
@@ -8,14 +8,25 @@
 // the bogus delta until a downstream sensor (GPS / ICP) corrects.
 //
 // The mechanism observed: |dtheta_wheel - dtheta_gyro| is a per-tick
-// proxy for slip. We EMA-smooth it and add `gain * net_residual` (in
-// metres per radian) on top of the configured σ_x baseline.
+// proxy for slip. We EMA-smooth it and use `gain * net_residual` (in
+// metres per radian) as a per-node FLOOR under the baseline σ_x.
 //
-// Tests pin three behaviours:
-//   1. Matched wheel + gyro (no slip)         → σ_x stays at baseline.
+// Updated 2026-08-24 (issue #491): the σ_x baseline is no longer a fixed
+// per-node constant — it is a distance-scaled random walk,
+// σ = k·√(step_m + creep·dt). The adaptive term deliberately stayed a
+// per-node absolute release (it models a wheel FAULT, not a distance-driven
+// random walk), so it is now applied as max(travel, release) instead of
+// baseline + release. The "baseline" the tests below compare against is
+// therefore ExpectedTravelSigmaX() rather than a literal 0.05.
+//
+// Tests pin four behaviours:
+//   1. Matched wheel + gyro (no slip)         → σ_x stays at the travel
+//                                                baseline.
 //   2. Sustained wheel↔gyro disagreement (slip) → σ_x inflates.
 //   3. Slip event followed by quiet           → EMA decays back, σ_x
-//                                                returns near baseline.
+//                                                returns to the travel
+//                                                baseline.
+//   4. gain = 0                               → no inflation at all.
 
 #include <cmath>
 #include <cstdio>
@@ -33,8 +44,8 @@ fg::GraphParams MakeParams()
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_thresh_xy_m = 1.0e-3;
@@ -46,7 +57,31 @@ fg::GraphParams MakeParams()
   gp.adaptive_noise_enabled_gain = 10.0;
   gp.adaptive_noise_ema_tau_s = 0.5;
   gp.adaptive_noise_residual_floor_rad = 0.005;
+  gp.wheel_creep_speed_mps = 0.04;
   return gp;
+}
+
+// The no-fault σ_x for a node that advanced `step_m` metres over `dt`
+// seconds. Mirrors the model in CreateNodeLocked so a params change here
+// stays in step with the code under test.
+double ExpectedTravelSigmaX(double step_m, double dt)
+{
+  const auto gp = MakeParams();
+  return gp.wheel_sigma_x_per_sqrt_m * std::sqrt(step_m + gp.wheel_creep_speed_mps * dt);
+}
+
+// These tests tick at 0.1 s against node_period_s = 0.1, a comparison that
+// drifts in binary float, so a node absorbs ONE OR TWO wheel samples. With
+// σ_x now scaled by the step, that makes the exact value ambiguous — assert
+// the band the travel model allows instead. The old per-node constant
+// (0.05 m) sits an order of magnitude above the whole band either way, so the
+// regression this pins is not weakened.
+void ExpectTravelBaseline(double sigma_x_eff, double step_per_sample_m, double dt_per_sample)
+{
+  const double lo = ExpectedTravelSigmaX(step_per_sample_m, dt_per_sample);
+  const double hi = ExpectedTravelSigmaX(2.0 * step_per_sample_m, 2.0 * dt_per_sample);
+  EXPECT_GE(sigma_x_eff, lo - 1.0e-9);
+  EXPECT_LE(sigma_x_eff, hi + 1.0e-9);
 }
 
 }  // namespace
@@ -79,9 +114,10 @@ TEST(AdaptiveNoise, NoSlipKeepsBaselineSigma)
 
   // Residual EMA must stay under the floor (no inflation kicks in).
   EXPECT_LT(stats.residual_ema_rad, 0.005);
-  // σ_x_eff must equal the configured wheel_sigma_x within a small
-  // numeric epsilon — adaptive gain × (residual − floor) must be 0.
-  EXPECT_NEAR(stats.wheel_sigma_x_eff, 0.05, 1.0e-6);
+  // σ_x_eff must sit on the travel-scaled baseline — adaptive gain ×
+  // (residual − floor) is 0, so the release floor is 0 and
+  // max(travel, 0) == travel.
+  ExpectTravelBaseline(stats.wheel_sigma_x_eff, kVx * kDt, kDt);
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -122,7 +158,8 @@ TEST(AdaptiveNoise, SlipInflatesSigma)
   EXPECT_GT(stats.residual_ema_rad, 0.020);
   EXPECT_LT(stats.residual_ema_rad, 0.070);
 
-  // σ_x_eff = baseline + gain × (residual − floor) ≈ 0.05 + 10 × 0.05 ≈ 0.55 m
+  // σ_x_eff = max(travel, gain × (residual − floor)) ≈ 10 × 0.05 ≈ 0.5 m —
+  // the release dominates the ~3 mm travel term by two orders of magnitude.
   // Wide bounds — this just checks "inflated meaningfully".
   EXPECT_GT(stats.wheel_sigma_x_eff, 0.15);
   EXPECT_LT(stats.wheel_sigma_x_eff, 0.65);
@@ -165,10 +202,10 @@ TEST(AdaptiveNoise, EmaDecaysAfterSlipEnds)
               recovered.residual_ema_rad,
               recovered.wheel_sigma_x_eff);
 
-  // 10 τ of zero residual collapses the EMA to << floor; σ_x returns
-  // to the configured baseline (0.05).
+  // 10 τ of zero residual collapses the EMA to << floor; σ_x returns to the
+  // travel baseline for a zero-length step (creep floor only).
   EXPECT_LT(recovered.residual_ema_rad, 0.001);
-  EXPECT_NEAR(recovered.wheel_sigma_x_eff, 0.05, 1.0e-6);
+  ExpectTravelBaseline(recovered.wheel_sigma_x_eff, 0.0, kDt);
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -195,7 +232,9 @@ TEST(AdaptiveNoise, GainZeroDisablesAdaptation)
               stats.residual_ema_rad,
               stats.wheel_sigma_x_eff);
 
-  // EMA still tracks (it's a passive measurement), but σ_x_eff
-  // must equal the baseline — the gain=0 short-circuits inflation.
-  EXPECT_NEAR(stats.wheel_sigma_x_eff, 0.05, 1.0e-6);
+  // EMA still tracks (it's a passive measurement), but σ_x_eff must sit on
+  // the travel baseline — gain=0 short-circuits inflation. The wheels claim
+  // rotation only (vx = 0), so the step is zero and only the creep floor
+  // contributes.
+  ExpectTravelBaseline(stats.wheel_sigma_x_eff, 0.0, kDt);
 }

--- a/ros2/src/fusion_graph/test/test_gnss_timestamp.cpp
+++ b/ros2/src/fusion_graph/test/test_gnss_timestamp.cpp
@@ -23,8 +23,8 @@ fg::GraphParams MakeParams()
   gp.stationary_node_period_s = 0.0;
   gp.stationary_motion_thresh_m = 0.0;
   gp.stationary_motion_thresh_theta = 0.0;
-  gp.wheel_sigma_x = 0.01;
-  gp.wheel_sigma_y = 0.01;
+  gp.wheel_sigma_x_per_sqrt_m = 0.01;
+  gp.wheel_sigma_y_per_sqrt_m = 0.01;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.01;
   gp.adaptive_noise_enabled_gain = 0.0;

--- a/ros2/src/fusion_graph/test/test_graph_window.cpp
+++ b/ros2/src/fusion_graph/test/test_graph_window.cpp
@@ -29,8 +29,8 @@ fg::GraphParams MakeParams(uint64_t window)
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_thresh_xy_m = 1.0e-3;

--- a/ros2/src/fusion_graph/test/test_gyro_bias.cpp
+++ b/ros2/src/fusion_graph/test/test_gyro_bias.cpp
@@ -26,8 +26,8 @@ fg::GraphParams MakeParams()
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_thresh_xy_m = 1.0e-3;

--- a/ros2/src/fusion_graph/test/test_keyframe_map.cpp
+++ b/ros2/src/fusion_graph/test/test_keyframe_map.cpp
@@ -129,8 +129,8 @@ fg::GraphParams TickParams()
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_node_period_s = 0.0;  // a node every tick

--- a/ros2/src/fusion_graph/test/test_loop_closure_robust.cpp
+++ b/ros2/src/fusion_graph/test/test_loop_closure_robust.cpp
@@ -25,8 +25,8 @@ fg::GraphParams MakeParams()
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_node_period_s = 0.0;

--- a/ros2/src/fusion_graph/test/test_slip_pivot.cpp
+++ b/ros2/src/fusion_graph/test/test_slip_pivot.cpp
@@ -35,8 +35,8 @@ fg::GraphParams MakeParams()
   // still fed at kDt=0.1 s per tick — node_period only gates the MINIMUM node
   // spacing, so one node is created per Tick as before).
   gp.node_period_s = fg::kTunedNodePeriodS;  // 0.04
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_thresh_xy_m = 1.0e-3;

--- a/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
+++ b/ros2/src/fusion_graph/test/test_stationary_yaw.cpp
@@ -53,8 +53,8 @@ fg::GraphParams MakeParams()
 {
   fg::GraphParams gp;
   gp.node_period_s = 0.1;
-  gp.wheel_sigma_x = 0.05;
-  gp.wheel_sigma_y = 0.005;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
   gp.wheel_sigma_theta = 0.01;
   gp.gyro_sigma_theta = 0.005;
   gp.stationary_thresh_xy_m = 1.0e-3;

--- a/ros2/src/fusion_graph/test/test_wheel_sigma_scaling.cpp
+++ b/ros2/src/fusion_graph/test/test_wheel_sigma_scaling.cpp
@@ -1,0 +1,289 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Regression tests for the wheel between-factor's TRANSLATIONAL noise model
+// (issue #491).
+//
+// Bug: σ_x was a fixed PER-NODE constant with no reference to the distance the
+// step covered. At node_period_s = 0.04 (25 Hz) and 0.2 m/s each hop covers
+// 8 mm while the factor claimed 50-92 mm of along-track uncertainty for it, so
+// the marginal on the newest node grew as σ·√N per HOP rather than with
+// distance travelled. Measured 2026-08-24 on RTK-Fixed: published major-axis σ
+// p50 0.574 m / p90 0.957 / max 1.391 against a GNSS horizontal accuracy of
+// 0.014 m and an FTC cross-track error of 0.008-0.016 m. It was also
+// cadence-dependent — the same physical motion accumulated √2.5x more
+// uncertainty at 25 Hz than at 10 Hz.
+//
+// Fix: VARIANCE proportional to the distance the step covered,
+//
+//   σ = wheel_sigma_x_per_sqrt_m · √(step_m + wheel_creep_speed_mps · dt)
+//
+// so N hops of d/N metres sum to exactly the variance of one hop of d metres.
+//
+// The tests below observe the per-node σ_x through GraphManager::Stats()
+// (wheel_sigma_x_eff, the sigma actually handed to the BetweenFactor) and sum
+// its square across the nodes a run produced — that sum is the dead-reckoned
+// variance the marginal accumulates between two GNSS-anchored nodes, which is
+// the quantity the bug was about.
+
+#include <cmath>
+#include <cstdio>
+
+#include "fusion_graph/graph_manager.hpp"
+#include <gtest/gtest.h>
+
+namespace fg = fusion_graph;
+
+namespace
+{
+
+// Wheel/gyro samples arrive at 100 Hz; node cadence is what the tests vary.
+constexpr double kSampleDt = 0.01;  // s — one wheel/gyro sample
+constexpr int kSamples = 160;  // 1.6 s of driving
+constexpr double kSpeed = 0.20;  // m/s — mowing speed
+constexpr double kTotalDist = kSpeed * kSampleDt * kSamples;  // 0.32 m
+constexpr double kTotalTime = kSampleDt * kSamples;  // 1.6 s
+
+// Node period that fires exactly every `samples` wheel samples. The 1 ns
+// shave absorbs binary-float error in kSampleDt * n (0.01 * 10 evaluates just
+// BELOW 0.1), which would otherwise slip a node by one sample and leave the
+// cadences covering slightly different distances.
+constexpr double NodePeriodForSamples(int samples)
+{
+  return kSampleDt * samples - 1.0e-9;
+}
+
+fg::GraphParams MakeParams(double node_period_s)
+{
+  fg::GraphParams gp;
+  gp.node_period_s = node_period_s;
+  gp.wheel_sigma_x_per_sqrt_m = 0.05;
+  gp.wheel_sigma_y_per_sqrt_m = 0.005;
+  gp.wheel_creep_speed_mps = 0.04;
+  gp.wheel_sigma_theta = 0.01;
+  gp.gyro_sigma_theta = 0.005;
+  gp.stationary_thresh_xy_m = 1.0e-3;
+  gp.stationary_thresh_theta = 2.0e-3;
+  gp.stationary_sigma_theta = 1.0e-3;
+  // Disable the stationary node throttle so cadence is purely node_period_s.
+  gp.stationary_node_period_s = 0.0;
+  gp.stationary_motion_thresh_m = 0.0;
+  gp.stationary_motion_thresh_theta = 0.0;
+  // No slip in these runs, but keep the gain live so the tests also prove the
+  // adaptive term contributes nothing when the wheels and gyro agree.
+  gp.adaptive_noise_enabled_gain = 10.0;
+  gp.adaptive_noise_ema_tau_s = 0.5;
+  gp.adaptive_noise_residual_floor_rad = 0.005;
+  return gp;
+}
+
+struct RunResult
+{
+  int nodes = 0;
+  double sum_var = 0.0;  // Σ σ_x², the accumulated dead-reckoning variance
+  double last_sigma_x = 0.0;
+
+  double sigma() const
+  {
+    return std::sqrt(sum_var);
+  }
+};
+
+// Drive straight at `speed` for `samples` × kSampleDt seconds, feeding matched
+// wheel + gyro samples, and accumulate σ_x² over every node the manager
+// created. Node cadence comes from the params, so the SAME physical motion can
+// be replayed at different cadences.
+RunResult DriveStraight(const fg::GraphParams& gp, int samples, double speed)
+{
+  fg::GraphManager gm(gp);
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  RunResult r;
+  for (int i = 0; i < samples; ++i)
+  {
+    gm.AddWheelTwist(speed, 0.0, 0.0, kSampleDt);
+    gm.AddGyroDelta(0.0, kSampleDt);
+    if (gm.Tick(kSampleDt * (i + 1)).has_value())
+    {
+      const double sigma_x = gm.Stats().wheel_sigma_x_eff;
+      r.sum_var += sigma_x * sigma_x;
+      r.last_sigma_x = sigma_x;
+      ++r.nodes;
+    }
+  }
+  return r;
+}
+
+}  // namespace
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. THE key property: N hops of d/N metres must accumulate exactly the
+//    same uncertainty as one hop of d metres. This is what "per-distance"
+//    means, and it is precisely what the per-node model got wrong.
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, ManySmallHopsEqualOneBigHop)
+{
+  // Identical wheel/gyro input, identical elapsed time, identical distance —
+  // only the node cadence differs: 160 hops of 2 mm vs 1 hop of 0.32 m.
+  const auto fine = DriveStraight(MakeParams(NodePeriodForSamples(1)), kSamples, kSpeed);
+  const auto coarse = DriveStraight(MakeParams(NodePeriodForSamples(kSamples)), kSamples, kSpeed);
+
+  std::printf("[WheelSigmaScaling] %d hops → σ=%.6f m | %d hop → σ=%.6f m\n",
+              fine.nodes,
+              fine.sigma(),
+              coarse.nodes,
+              coarse.sigma());
+
+  ASSERT_EQ(fine.nodes, kSamples);
+  ASSERT_EQ(coarse.nodes, 1);
+
+  // Accumulated σ must match to numerical precision, not merely "closely".
+  EXPECT_NEAR(fine.sigma(), coarse.sigma(), 1.0e-9);
+
+  // And it must equal the closed form σ = k·√(d + creep·t).
+  const double expected = 0.05 * std::sqrt(kTotalDist + 0.04 * kTotalTime);
+  EXPECT_NEAR(fine.sigma(), expected, 1.0e-9);
+
+  // Guard against the trivially-passing implementation where BOTH collapse to
+  // the per-node floor: the per-hop σ must be much smaller than the total.
+  EXPECT_LT(fine.last_sigma_x, 0.25 * fine.sigma());
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. Cadence invariance. The 10 Hz / 25 Hz / 50 Hz configurations must
+//    report the same uncertainty for the same physical drive — the same
+//    property tick_scale gives the per-tick GATES, applied to the noise
+//    model. Under the old per-node σ, 25 Hz accumulated √2.5x more than
+//    10 Hz for identical motion.
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, AccumulatedSigmaIsCadenceInvariant)
+{
+  const auto at_50hz = DriveStraight(MakeParams(NodePeriodForSamples(2)), kSamples, kSpeed);
+  const auto at_25hz = DriveStraight(MakeParams(NodePeriodForSamples(4)), kSamples, kSpeed);
+  const auto at_10hz = DriveStraight(MakeParams(NodePeriodForSamples(10)), kSamples, kSpeed);
+
+  std::printf(
+      "[WheelSigmaScaling] 50Hz %d nodes σ=%.6f | 25Hz %d nodes σ=%.6f "
+      "| 10Hz %d nodes σ=%.6f\n",
+      at_50hz.nodes,
+      at_50hz.sigma(),
+      at_25hz.nodes,
+      at_25hz.sigma(),
+      at_10hz.nodes,
+      at_10hz.sigma());
+
+  // Different node counts...
+  EXPECT_GT(at_25hz.nodes, at_10hz.nodes);
+  // ...same accumulated uncertainty.
+  EXPECT_NEAR(at_25hz.sigma(), at_10hz.sigma(), 1.0e-9);
+  EXPECT_NEAR(at_50hz.sigma(), at_25hz.sigma(), 1.0e-9);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. Uncertainty must grow with DISTANCE: twice the drive, √2 the sigma
+//    (a random walk, not a straight line and not a constant).
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, SigmaGrowsAsSqrtOfDistance)
+{
+  const auto one_leg = DriveStraight(MakeParams(NodePeriodForSamples(1)), kSamples, kSpeed);
+  const auto two_legs = DriveStraight(MakeParams(NodePeriodForSamples(1)), 2 * kSamples, kSpeed);
+
+  std::printf("[WheelSigmaScaling] %.2f m → σ=%.6f | %.2f m → σ=%.6f (ratio %.4f)\n",
+              kTotalDist,
+              one_leg.sigma(),
+              2.0 * kTotalDist,
+              two_legs.sigma(),
+              two_legs.sigma() / one_leg.sigma());
+
+  EXPECT_NEAR(two_legs.sigma() / one_leg.sigma(), std::sqrt(2.0), 1.0e-9);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. The reported number is now physically plausible. This is the
+//    user-visible symptom in #491: on RTK-Fixed the published σ read
+//    0.574 m (p50) where the receiver reported 0.014 m and FTC held
+//    8-16 mm of cross-track error. Between two GNSS-anchored nodes the
+//    wheel chain must contribute centimetres, not half a metre.
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, DeployedMowingRegimeIsCentimetreScale)
+{
+  const auto run = DriveStraight(MakeParams(NodePeriodForSamples(4)), kSamples, kSpeed);
+
+  std::printf("[WheelSigmaScaling] deployed regime (25 Hz): %d hops over %.2f m → σ=%.4f m\n",
+              run.nodes,
+              kTotalDist,
+              run.sigma());
+
+  // The old per-node model produced 0.05·√40 = 0.32 m over these same 40
+  // hops (0.58 m once the adaptive term had inflated σ_x to the
+  // field-observed 0.092).
+  EXPECT_LT(run.sigma(), 0.10);
+  // ...but not so tight that the wheel chain out-votes an RTK-Fixed fix
+  // (σ ≈ 0.014 m) over the same window.
+  EXPECT_GT(run.sigma(), 0.014);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 5. A zero-length step must still yield a usable, non-singular sigma.
+//    The floor is a creep DISTANCE (wheel_creep_speed_mps · dt), not a
+//    constant sigma, so it too stays cadence-invariant.
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, ZeroStepUsesCreepFloorAndStaysNonSingular)
+{
+  const auto parked = DriveStraight(MakeParams(NodePeriodForSamples(1)), kSamples, 0.0);
+
+  std::printf("[WheelSigmaScaling] parked: %d nodes, per-node σ=%.6f m, total σ=%.6f m\n",
+              parked.nodes,
+              parked.last_sigma_x,
+              parked.sigma());
+
+  ASSERT_GT(parked.nodes, 0);
+  // Strictly positive — a zero sigma would make the GTSAM noise model
+  // singular.
+  EXPECT_GT(parked.last_sigma_x, 0.0);
+  EXPECT_GE(parked.last_sigma_x, fg::kMinWheelSigmaM);
+  // Exactly the creep floor for one node.
+  EXPECT_NEAR(parked.last_sigma_x, 0.05 * std::sqrt(0.04 * kSampleDt), 1.0e-9);
+  // And the accumulated parked uncertainty is still time-invariant across
+  // cadences: k·√(creep·t).
+  EXPECT_NEAR(parked.sigma(), 0.05 * std::sqrt(0.04 * kTotalTime), 1.0e-9);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 6. The pivot release must survive the change. It is deliberately a
+//    PER-NODE absolute sigma applied as a floor, not a distance-scaled
+//    term: during a pivot the encoders report ~0.8 mm of phantom
+//    translation per tick, so a distance-scaled pivot sigma would
+//    collapse to ~1.4 mm and pin the pose to the phantom motion — the
+//    exact 0.2-0.4 m per-spin drift pivot_wheel_sigma_x exists to stop.
+// ─────────────────────────────────────────────────────────────────────
+TEST(WheelSigmaScaling, PivotReleaseStillOverridesTheTravelTerm)
+{
+  auto gp = MakeParams(NodePeriodForSamples(1));
+  gp.pivot_gate_dtheta_rad = 0.012;
+  gp.pivot_wheel_sigma_x = 0.5;
+
+  fg::GraphManager gm(gp);
+  gm.Initialize(gtsam::Pose2(0.0, 0.0, 0.0), 0.0);
+
+  // In-place spin at 1 rad/s with the diff-drive's phantom forward vx.
+  // Per-tick gyro dθ = 0.01 rad, well over the cadence-scaled 0.003 rad gate.
+  constexpr double kPhantomVx = 0.021;  // m/s, measured 2026-05-14
+  constexpr double kSpinWz = 1.0;  // rad/s
+  for (int i = 0; i < kSamples; ++i)
+  {
+    gm.AddWheelTwist(kPhantomVx, 0.0, kSpinWz, kSampleDt);
+    gm.AddGyroDelta(kSpinWz, kSampleDt);
+    gm.Tick(kSampleDt * (i + 1));
+  }
+
+  const double sigma_x = gm.Stats().wheel_sigma_x_eff;
+  std::printf("[WheelSigmaScaling] pivot: σ_x_eff=%.4f m (travel term would be %.6f)\n",
+              sigma_x,
+              0.05 * std::sqrt(kPhantomVx * kSampleDt + 0.04 * kSampleDt));
+
+  // The travel term for an 0.84 mm phantom step is ~1.3 mm; the release must
+  // win.
+  EXPECT_GE(sigma_x, gp.pivot_wheel_sigma_x);
+  EXPECT_LT(0.05 * std::sqrt(kPhantomVx * kSampleDt + 0.04 * kSampleDt), 0.01);
+}

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
@@ -40,6 +40,14 @@
 // drops to stationary_node_period_s = 5 s and GPS pins every node, so σ
 // settles at ~0.05 m, below the old 0.08 m resume threshold.
 //
+// UPDATE 2026-08-24 (issue #491): the "plain driving" half of that arithmetic
+// has since been fixed — the wheel between-factor's translational sigma is now
+// a distance-scaled random walk instead of a per-node constant, so the same
+// window contributes centimetres rather than decimetres. The PIVOT half is
+// unchanged and deliberate: pivot_wheel_sigma_x stays a per-node absolute
+// release, so the marginal still balloons on every PRE_ROTATE. This guard must
+// therefore keep off the fused covariance regardless.
+//
 // The guard was therefore ONLY satisfiable while stopped, and FTC opens every
 // strip with a PRE_ROTATE pivot. Field 2026-08-20 (robot on RTK-Fixed at
 // hacc 0.014 m throughout): degrade at σ 0.57/0.74/0.81/0.92/0.99/1.07/1.38/

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -800,7 +800,9 @@ The legacy EKF (`ekf_map_node`) and `fusion_graph_node` are **mutually exclusive
 |---|---|---|
 | `node_period_s` | 0.1 | Graph node creation cadence (10 Hz). |
 | `stationary_node_period_s` | 5.0 | Throttled node period when motion is below the stationary threshold — bounds graph growth on the dock. |
-| `wheel_sigma_x / sigma_y / sigma_theta` | 0.05 / 0.005 / 0.01 | Body-frame between-factor noise. `sigma_y` ≪ `sigma_x` enforces non-holonomic motion. |
+| `wheel_sigma_x_per_sqrt_m / wheel_sigma_y_per_sqrt_m` | 0.05 / 0.005 | Body-frame between-factor **translational** noise, in m/√m. The sigma applied to a node is `k · √(step_m + wheel_creep_speed_mps · dt)` — variance grows with the distance the step covered, so the accumulated uncertainty tracks distance travelled and is invariant to `node_period_s` (issue #491). `sigma_y` ≪ `sigma_x` still enforces non-holonomic motion: both scale by the same `√d`. At 1 m of travel per node these reproduce the old fixed per-node 0.05 / 0.005 m. |
+| `wheel_creep_speed_mps` | 0.04 | Floor on the noise distance above, as a creep *speed*: motion the encoders may have missed (towed, lifted, both wheels skating). Expressed as a distance so the floor stays cadence-invariant. |
+| `wheel_sigma_theta` | 0.01 | Yaw between-factor noise, still a **per-node** sigma — used only when no gyro sample arrived for the tick. |
 | `gyro_sigma_theta` | 0.005 | Yaw between-factor noise from `/imu/data`. |
 | `gps_sigma_floor` | 0.003 | Lower bound for the GPS XY noise (3 mm) — prevents over-trusting RTK-Fixed reports with under-estimated covariance. |
 | `cov_update_every_n` | 10 | Skip-rate for the marginal covariance recompute (the diagonals on `/odometry/filtered_map`). |


### PR DESCRIPTION
Closes #491.

## The bug

The wheel `BetweenFactor`'s translational sigmas were fixed **per-node constants** with no reference to the distance the step covered:

```cpp
auto between_noise = MakeDiagonal({wheel_sigma_x_eff, params_.wheel_sigma_y, sigma_theta});
```

At `node_period_s` 0.04 (25 Hz) and 0.2 m/s each hop covers **8 mm** while `sigma_x` claimed **50-92 mm** for it, so the marginal on the newest node grew as `sigma*sqrt(N)` per **hop** rather than with distance travelled.

Measured 2026-08-24, RTK-Fixed throughout:

| | |
|---|---|
| published major-axis sigma | p50 **0.574 m** / p90 0.957 / max 1.391 |
| GNSS `horizontal_accuracy_m` | 0.014 m |
| FTC cross-track error, same moment | 0.008-0.016 m |

`0.092*sqrt(40) = 0.58` for the ~40 hops between the GNSS-anchored node and the head — matching the observation. It was also cadence-dependent: the same physical motion accumulated `sqrt(2.5)x` more uncertainty at 25 Hz than at 10 Hz.

## The fix

Make **variance** (not sigma) proportional to the distance the step covered:

```
sigma = k * sqrt(step_m + wheel_creep_speed_mps * dt)      [Var = k^2 * d]
```

so **N hops of `d/N` metres sum to exactly the variance of one hop of `d` metres** — cadence-invariant by construction. This is the noise-model counterpart of the existing `tick_scale` / `kTunedNodePeriodS` rescaling of the per-tick *gates*, and the reasoning is deliberately cross-referenced in the code.

Note the issue's sketch (`sigma_x = max(floor, k*|dx|)`, i.e. sigma-proportional) would have failed in the **opposite** direction — it accumulates as `k*d/sqrt(N)`, i.e. tighter the faster you tick. The `sqrt` form already has precedent a few lines below in the same function: the gyro-bias random walk uses `sigma = sigma_rw*sqrt(dt)`.

The floor is expressed as an **unobservable-creep distance** (`wheel_creep_speed_mps * dt`), not a constant sigma, for the same reason — a constant per-node sigma floor would reintroduce exactly the per-hop accumulation being removed. It also has a physical reading: motion the encoders may have missed (towed, lifted, both wheels skating). `kMinWheelSigmaM = 1e-4` guards only the degenerate `step == 0 && dt == 0` case against a singular GTSAM noise model.

### sigma_y is scaled too

Scoping the fix to `sigma_x` alone would have left `sigma_y` (0.005 per node) dominating the accumulated ellipse *and* would have collapsed `sigma_x ≈ sigma_y` at the deployed 8 mm step — violating Architecture Invariant 1 (`sigma_y << sigma_x`). Both now scale by the same `sqrt(d)`, so the 10:1 non-holonomic asymmetry holds at every step size.

### Why the pivot gate and adaptive inflation stay per-node

`pivot_wheel_sigma_x` and `adaptive_noise_enabled_gain * net_residual` remain **per-node absolute sigmas**, now applied as a lower **bound** on the travel-scaled value instead of as base/addend.

They do not model a distance-driven random walk — they model a wheel **fault**: a measurement wrong in a way unrelated to how far the encoders say we went. Their job is to *release* the X constraint so GPS / scan-matching set XY. Scaling them per-distance would defeat them precisely in the case they exist for: during a pivot the encoders report ~0.8 mm of phantom translation per tick, so a per-distance pivot sigma would collapse to ~1.4 mm and **pin the pose to the phantom motion** — the exact 0.2-0.4 m per-spin drift `pivot_wheel_sigma_x` was added to stop. Likewise the adaptive term is driven by a yaw residual measuring rotation the wheels *invented*; the linear error that implies is not bounded by the (often slip-vetoed, hence zero) reported step.

Because they fire only on a detected fault, keeping them per-node does not reintroduce `sqrt(N)` growth in normal driving: `net_residual` is 0 and the pivot gate is shut, so the release is 0 and the travel term wins.

One related detail: the noise distance uses the **raw** accumulator, not the slip-vetoed `(dx_eff, dy_eff)`. What the encoders *claimed* bounds how wrong they can be; scoring the vetoed zero would pin the pose to "stationary" at the moment we know least.

## Parameters

Defaults live in the in-package template (`fusion_graph/config/fusion_graph.yaml` + `declare_parameter` defaults), per Invariant 15. Nothing in the sparse installed `mowgli_robot.yaml` or any launch file set these, so no migration is needed.

| old | new | default |
|---|---|---|
| `wheel_sigma_x` (m/node) | `wheel_sigma_x_per_sqrt_m` (m/sqrt(m)) | 0.05 |
| `wheel_sigma_y` (m/node) | `wheel_sigma_y_per_sqrt_m` (m/sqrt(m)) | 0.005 |
| — | `wheel_creep_speed_mps` (m/s) | 0.04 |

Renamed rather than reinterpreted because the **units** changed — a silently-reinterpreted `wheel_sigma_x` in someone's config would have been a trap. At 1 m of travel per node the new coefficients reproduce the old per-node values exactly, so the numbers are unchanged in magnitude; only their meaning (and hence their effect at the deployed 8 mm step) changes. `wheel_sigma_theta` stays a per-node sigma (yaw error is per-tick quantisation/slip, and the gyro supersedes it whenever an IMU sample arrived).

## Effect

Deployed mowing regime (25 Hz, 0.2 m/s, 40 hops = 0.32 m between GNSS anchors):

| | old | new |
|---|---|---|
| wheel-chain contribution to sigma | 0.32 m (0.58 m once adaptively inflated) | **0.031 m** |

Comfortably above the RTK-Fixed 0.014 m (so GNSS still anchors, the wheel chain does not out-vote it) and in the same order as the observed 8-16 mm tracking error, instead of ~40x the receiver's own number.

## Tests

New `test_wheel_sigma_scaling.cpp` (registered in `CMakeLists.txt`), 6 cases:

- `ManySmallHopsEqualOneBigHop` — **the key one**: 160 hops of 2 mm accumulate exactly the sigma of 1 hop of 0.32 m (identical input, identical elapsed time, only node cadence differs), matched to 1e-9 and against the closed form. Includes a guard against a trivially-passing "everything collapses to the floor" implementation.
- `AccumulatedSigmaIsCadenceInvariant` — 50 / 25 / 10 Hz produce different node counts and the same accumulated sigma.
- `SigmaGrowsAsSqrtOfDistance` — twice the drive, sqrt(2) the sigma (a random walk, not a straight line and not a constant).
- `DeployedMowingRegimeIsCentimetreScale` — the #491 symptom: the 40-hop window must contribute centimetres, and must not be so tight it out-votes an RTK-Fixed fix.
- `ZeroStepUsesCreepFloorAndStaysNonSingular` — zero-length step stays strictly positive, equals the creep floor, and the parked accumulation is time-invariant across cadences.
- `PivotReleaseStillOverridesTheTravelTerm` — pins the per-node pivot decision above.

`test_adaptive_noise.cpp` asserted the old per-node baseline (`sigma_x_eff == 0.05`) in three places; those now compare against the travel-scaled baseline. Because those tests tick at 0.1 s against `node_period_s = 0.1` — a comparison that drifts in binary float, so a node absorbs one *or two* wheel samples — the assertion is a band rather than a point value; the old 0.05 sits an order of magnitude above the whole band, so the regression it pins is not weakened. The slip / decay / gain-zero behaviours are otherwise unchanged.

The other 7 test files only needed the field rename. `test_gnss_timestamp` drives 1 m per node, which is exactly the calibration point where old and new coincide.

## Safety

This changes localization **noise modelling** on a robot with blades.

- **The estimate was already fine** — the robot localises and tracks to centimetres. This PR only fixes the reported *uncertainty*. No attempt was made to "improve" the estimate.
- That said, a noise model change is not estimate-neutral by construction: loosening the wheel factor's grip in the common case means the GNSS unary (the trusted absolute source) carries more weight, and tightening `sigma_y` enforces the non-holonomic constraint harder. Both directions are intended, neither is proven on hardware.
- **NOT field-verified.** Nothing here has run on the robot. It wants a live mow with `/fusion_graph/diagnostics` (`cov_xx`/`cov_yy`) recorded against `/gps/fix` `horizontal_accuracy_m` and FTC cross-track error before it is trusted.
- The dig-detector trust gate (Invariant 16) currently keys on `/gps/status`, not this covariance (#489), so it is unaffected either way. `behavior_tree_node.cpp`'s `fused_sigma_xy_m` backstop (5.0 m) and the GUI onboarding readiness checks will now see honest numbers; `localization_health.hpp`'s explanatory comment has been updated to record that the pivot half of its arithmetic is unchanged and deliberate, so that guard must still keep off the fused covariance.

Also updated: the `wiki/Configuration.md` fusion_graph parameter table.

---

## Rebased onto `dev` @ 84374739 (after #492) — headline number re-verified, unchanged

Rebased cleanly: **#492 did not touch `graph_params.hpp`** (it added `dr_slip_veto.hpp` and put its two ROS params on `FusionGraphNode` in `fusion_graph_node.hpp`), so the expected conflict did not materialise. The two overlapping files, `CMakeLists.txt` and `fusion_graph_node.cpp`, auto-merged; both changesets verified present afterwards (`test_dr_slip_veto` + `test_wheel_sigma_scaling` both registered; `dr_slip_*` + `wheel_sigma_*_per_sqrt_m` declares both live).

### The noise-model input is untouched by #492 — confirmed, not assumed

The two slip vetoes are on **different code paths**, which I traced rather than inferred:

| | veto | acts on | changed by #492 |
|---|---|---|---|
| DR veto | `DrSlipVetoed()` in `OnImu` | `dr_x_` / `dr_y_` — the `odom→base_footprint` dead-reckoning + TF extrapolation | **yes** (0.15 → 0.44 rad/s) |
| graph veto | `slip_detected` in `CreateNodeLocked` | `dx_eff` / `dy_eff` on the wheel `BetweenFactor` | no |

`OnWheelOdom` calls `graph_->AddWheelTwist(msg->twist.twist.linear.x, ...)` with the **raw** `/wheel_odom` twist. The DR veto is applied later and separately, in `OnImu`, to `dr_x_/dr_y_` only. So `accum_.dx` — the input to this PR's noise model — never passed through the DR veto, before or after #492. Independently, this PR's noise distance also deliberately uses the raw `accum_.dx/dy` rather than the graph veto's `dx_eff/dy_eff`, so it is insulated from that one too.

### Hop count between GNSS anchors: unchanged

The ~40 unconstrained hops are set by node cadence (25 Hz) and how far back `FindNodeAtOrBefore` places the GNSS anchor. The DR veto gates neither node creation nor GNSS acceptance — and the two accumulators the RTK wrong-fix gate uses (`wheel_dist_since_last_gps_m_`, `abs_dtheta_since_last_gps_rad_`) are fed from the raw wheel speed and the raw gyro respectively, not from `vx_eff`. Nothing in that chain moved.

### Headline number: **0.031 m, unchanged**

`0.05 * sqrt(0.32 + 0.04*1.6) = 0.031 m` stands as written. Both inputs are unaffected: 0.32 m of *claimed* travel (raw wheel vx × 40 hops) and 1.6 s.

One qualification worth stating rather than leaving implicit. The 25-30 % translation shortfall was measured on `odom→base_footprint` (i.e. `dr_x_`), not on `/wheel_odom` itself, and — per the investigation's own later revision — its **cause is not established**: the per-run correlation between veto-predicted loss and observed shortfall was inverted by a fourth data point, so #492 is justified by the quantization arithmetic alone. If the shortfall turns out to live in `/wheel_odom` (a `ticks_per_meter` calibration error) rather than in the DR veto, then `accum_.dx` under-reports too — but that would not change the number above, because the model consumes the *claimed* step and 0.031 m is the sigma for 0.32 m claimed either way. It would instead mean `wheel_sigma_x_per_sqrt_m` is sized against a systematically short odometer, which argues for a *larger* coefficient once `ticks_per_meter` is settled. That is a calibration question, not a scaling-law question, and it is one more reason the field validation below is not optional.

### Out-of-scope observation for a follow-up (not changed here)

#492's quantization argument appears to apply to the **graph** slip veto too, and this PR does not address it. One encoder tick of left/right asymmetry produces a fixed wheel-derived `dtheta_wheel` quantum of `(1/280.44)/0.325 = 0.01097 rad`, independent of `dt` (the `dt` in `wz = d_asym/track/dt` cancels against `dtheta = wz*dt`). At the deployed 25 Hz, `tick_scale == 1.0`, so the graph veto's thresholds are `slip_residual_thresh_rad = 0.0100` and `slip_wheel_min_rad = 0.0050` — **both below that 0.01097 rad quantum**, with `slip_gyro_max_rad` satisfied whenever the gyro is near still. That is the same "±1 tick on a straight slow run trips all three conditions" signature as #488.

Note the direction: because the quantum is `dt`-independent while `tick_scale` scales the thresholds *with* `dt`, higher cadence makes it worse — at 10 Hz the thresholds (0.025 / 0.0125) clear the quantum comfortably, which is consistent with them having been tuned at a slower cadence. This is arithmetic only; I have not measured how often the graph veto actually fires, and it is a separate change from this PR. It does mean the raw-accumulator choice above is load-bearing rather than merely tidy: had the noise distance used `dx_eff`, a spuriously-firing graph veto would collapse sigma toward the creep floor at exactly the hops where the measurement was being discarded.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
