### PR TITLE
fix(behavior): stop one occupied start pose forfeiting the whole area (#487)

### DIFF
--- a/gui/web/src/components/BTStateGraph.tsx
+++ b/gui/web/src/components/BTStateGraph.tsx
@@ -80,6 +80,9 @@ const STATE_ALIASES: Record<string, string> = {
   'COVERAGE_FAILED_DOCKING': 'RETURNING_HOME',
   'PLANNING': 'MOWING',
   'DYNAMIC_OBSTACLE_CLEARED': 'OBSTACLE_BACKOFF',
+  // #487: coverage refused because the robot's OWN pose is a lethal/keepout
+  // cell. Same family as an obstacle wedge from the operator's point of view.
+  'START_POSE_BLOCKED': 'OBSTACLE_BACKOFF',
   'PREFLIGHT_CHECK': 'UNDOCKING',
   'CALIBRATING_HEADING': 'TRANSIT',
   'BOUNDARY_EMERGENCY_STOP': 'EMERGENCY',

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -253,6 +253,44 @@ if(BUILD_TESTING)
     action_msgs
   )
 
+  # ---- test_start_occupied_retry ----
+  # Regression for issue #487: one occupied start pose forfeited a whole field.
+  # Covers the pure transit-failure classifier (nav2 error_code + error_msg
+  # fallback), the consume-once IsCoverageStartBlocked condition, and a
+  # STRUCTURAL check that main_tree.xml still carries the non-motion recovery
+  # branch (clear costmaps + retry) and still commands no escape motion.
+  ament_add_gtest(test_start_occupied_retry
+    test/test_start_occupied_retry.cpp
+    src/condition_nodes.cpp
+  )
+
+  target_include_directories(test_start_occupied_retry PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
+  # The structural half reads the real tree from the source tree.
+  target_compile_definitions(test_start_occupied_retry PRIVATE
+    MOWGLI_MAIN_TREE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/trees/main_tree.xml"
+  )
+
+  ament_target_dependencies(test_start_occupied_retry
+    rclcpp
+    rclcpp_action
+    behaviortree_cpp
+    mowgli_interfaces
+    nav2_msgs
+    nav_msgs
+    geometry_msgs
+    std_msgs
+    std_srvs
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    rcl_interfaces
+    action_msgs
+  )
+
   # Round-trip + staleness coverage for the disk-backed resume state (issue #334:
   # coverage must resume after a full process/container restart, not just an
   # in-RAM BT halt).

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -140,6 +140,40 @@ struct BTContext
   static constexpr float kAreaProgressEpsilonPct = 0.5f;
 
   // -----------------------------------------------------------------------
+  // Start-pose-blocked passes (issue #487)
+  // -----------------------------------------------------------------------
+  /// Set by FollowStrip when a whole pass ended with EVERY sub-path skipped
+  /// because Nav2's planner refused to plan from the ROBOT'S OWN pose
+  /// (ComputePathToPose START_OCCUPIED) and ZERO swaths were mowed. That is a
+  /// property of where the robot is STANDING, not of the field: the area is
+  /// perfectly mowable from one metre away. Observed 2026-08-24 — the robot
+  /// undocked into the inflated keepout of a 0.25 m obstacle circle and
+  /// forfeited a whole field at 0 % coverage.
+  ///
+  /// Two consumers, deliberately split:
+  ///   * IsCoverageStartBlocked (condition node) CONSUMES this bool, so the
+  ///     coverage subtree can run a non-motion recovery (stop, clear costmaps,
+  ///     wait) and re-tick FollowStrip;
+  ///   * GetNextUnmowedArea reads `start_blocked_area` to keep the pass from
+  ///     burning the no-progress retirement budget (see below).
+  /// Cleared by EndSession.
+  bool coverage_start_blocked{false};
+  /// Area index whose most recent FollowStrip pass ended start-pose-blocked.
+  /// Consumed (reset) by the next GetNextUnmowedArea dispatch of that area.
+  std::optional<uint32_t> start_blocked_area;
+  /// Per-area count of dispatches that were EXEMPTED from the no-progress
+  /// retirement counter because the previous pass was start-pose-blocked.
+  /// Bounded by kMaxStartBlockedAttempts so a robot that is genuinely parked on
+  /// a lethal cell forever still retires the area and docks — the exemption buys
+  /// a real second chance, it does not create an infinite loop. Cleared by
+  /// EndSession.
+  std::map<uint32_t, uint32_t> area_start_blocked_count;
+  /// Maximum start-pose-blocked dispatches exempted from area_attempt_count per
+  /// area. Worst case an area gets kMaxStartBlockedAttempts + kMaxAreaAttempts
+  /// dispatches before retirement.
+  static constexpr uint32_t kMaxStartBlockedAttempts = 3;
+
+  // -----------------------------------------------------------------------
   // Swath-completion model (replaces the mow_progress cell grid)
   // -----------------------------------------------------------------------
   /// Indices of swaths already mowed for each area, in the deterministic F2C

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/condition_nodes.hpp
@@ -782,4 +782,47 @@ public:
   BT::NodeStatus tick() override;
 };
 
+// ---------------------------------------------------------------------------
+// IsCoverageStartBlocked
+// ---------------------------------------------------------------------------
+
+/// Returns SUCCESS when the FollowStrip pass that just failed did so because
+/// the ROBOT'S OWN POSE is a cell nav2 refuses to plan from (every blade-off
+/// sub-path transit came back START_OCCUPIED and zero swaths were mowed).
+/// FAILURE otherwise.
+///
+/// Field problem this solves (issue #487, 2026-08-24): the robot undocked into
+/// the inflated keepout around a 0.25 m obstacle circle. SmacPlanner2D has no
+/// start tolerance, so all 26 plan calls answered "Start occupied", FollowStrip
+/// skipped all four sub-paths in a row, and the whole field was declared
+/// unmowable at 0 % coverage. The area was perfectly mowable — a second attempt
+/// 13 minutes later completed it at 100 %.
+///
+/// CONSUMING condition: it clears ctx->coverage_start_blocked on read, so the
+/// recovery branch fires exactly once per blocked pass and a later, unrelated
+/// FollowStrip failure cannot re-trigger it. (ctx->start_blocked_area is a
+/// SEPARATE field with a separate consumer — GetNextUnmowedArea — so this read
+/// does not disturb the retirement-budget exemption.)
+///
+/// Deliberately does NOT command any motion. After an undock the robot REVERSED
+/// into the blocked spot, so a reverse escape drives deeper, while mid-mow it
+/// arrived driving forward and a reverse retraces known-good ground. Choosing
+/// between those on a machine with blades is a maintainer decision, not
+/// something this node guesses — see issue #487.
+class IsCoverageStartBlocked : public BT::ConditionNode
+{
+public:
+  IsCoverageStartBlocked(const std::string& name, const BT::NodeConfig& config)
+      : BT::ConditionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {};
+  }
+
+  BT::NodeStatus tick() override;
+};
+
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/coverage_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/coverage_nodes.hpp
@@ -19,6 +19,7 @@
 #include <future>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -28,6 +29,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "mowgli_behavior/bt_context.hpp"
 #include "mowgli_behavior/detour_resume.hpp"
+#include "mowgli_behavior/transit_failure.hpp"
 #include "mowgli_interfaces/action/plan_coverage.hpp"
 #include "mowgli_interfaces/coverage_geometry.hpp"
 #include "mowgli_interfaces/srv/get_mowing_area.hpp"
@@ -223,6 +225,36 @@ private:
   // so the GUI %-readout climbs smoothly rather than jumping per sub-path.
   float livePercent() const;
 
+  // --- Transit-failure classification (issue #487) ---------------------------
+  /// Result of the blade-off NavigateToPose transit that just finished, plus
+  /// the raw nav2 fields it was derived from (kept for the log line).
+  struct TransitOutcome
+  {
+    TransitFailure kind = TransitFailure::kUnknown;
+    uint16_t error_code = 0;
+    std::string error_msg;
+  };
+  /// Latest NavigateToPose result, filled by the result_callback registered at
+  /// dispatch. Held behind a shared_ptr so the callback never touches a
+  /// destroyed FollowStrip, and behind a mutex so a future Reentrant callback
+  /// group cannot race the BT tick (today they are serialized — see
+  /// bt_context.hpp).
+  struct TransitResultSlot
+  {
+    std::mutex mutex;
+    bool ready = false;
+    uint16_t error_code = 0;
+    std::string error_msg;
+  };
+  /// Arm a fresh result slot for a transit about to be dispatched.
+  void resetTransitResult();
+  /// Classify the transit whose STATUS already reported abort/cancel. The nav2
+  /// result arrives on its own callback, slightly after the status topic, so
+  /// this returns nullopt while still waiting (bounded by
+  /// kTransitResultWaitSec, after which it classifies as UNKNOWN and the caller
+  /// proceeds exactly as it did before this change).
+  std::optional<TransitOutcome> classifyFinishedTransit();
+
   rclcpp_action::Client<Nav2FollowPath>::SharedPtr follow_client_;
   rclcpp_action::Client<Nav2Navigate>::SharedPtr nav_client_;
   rclcpp::Client<mowgli_interfaces::srv::MowerControl>::SharedPtr blade_client_;
@@ -246,6 +278,15 @@ private:
   // the swath is skipped rather than mowed cross-country.
   bool transit_pending_ = false;
   std::chrono::steady_clock::time_point transit_wait_start_;
+  // Result slot for the in-flight transit + the bounded wait that lets it
+  // arrive after the status topic reports the abort (issue #487).
+  std::shared_ptr<TransitResultSlot> transit_result_;
+  bool transit_abort_seen_ = false;
+  std::chrono::steady_clock::time_point transit_abort_time_;
+  // Max wait for the NavigateToPose RESULT after get_status() says the goal
+  // terminated. Past this the failure is logged as UNKNOWN and the swath is
+  // skipped — i.e. exactly the pre-#487 behaviour, never a hang.
+  static constexpr double kTransitResultWaitSec = 2.0;
 
   // The drivable units being executed: the hole-free continuous SUB-PATHS
   // (ctx->current_strip_subpaths, issue #333), or a single continuous path when
@@ -254,6 +295,15 @@ private:
   std::vector<nav_msgs::msg::Path> swaths_;
   std::size_t swath_idx_ = 0;
   std::size_t swaths_skipped_ = 0;
+  // Of swaths_skipped_, how many were skipped because the blade-off transit was
+  // refused with START_OCCUPIED — i.e. because of where the ROBOT stands, not
+  // anything about the swath. Paired with swaths_mowed_this_pass_ to recognise
+  // the "zero progress and every failure was our own pose" case that must not
+  // retire the area (issue #487).
+  std::size_t swaths_skipped_start_occupied_ = 0;
+  // Sub-paths recorded MOWED during THIS pass. Distinct from
+  // ctx->area_completed_swaths[area].size(), which is cumulative across passes.
+  std::size_t swaths_mowed_this_pass_ = 0;
   bool swath_goal_sent_ = false;
   // Absolute start index of each swaths_ unit within the CONCATENATION of all
   // units (== full_path). swath_base_[k] = sum of the ORIGINAL (untrimmed) pose

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/transit_failure.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/transit_failure.hpp
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cctype>
 #include <cstdint>
 #include <string>
 
@@ -42,6 +40,15 @@ namespace mowgli_behavior
 //     undocked into the inflated keepout around a 0.25 m obstacle circle and
 //     SmacPlanner2D answered "Start occupied" to all 26 planning calls.
 //
+// CLASSIFICATION IS ERROR-CODE-ONLY. The nav2 result's error_msg is NEVER
+// parsed. Matching the planner's wording would break silently on any nav2
+// upgrade that rewords the exception, and a wrong "start blocked" verdict
+// suppresses the "area not mowable" path — so an honest kUnknown (which skips
+// the swath exactly as the code did before #487) is preferred over a fragile
+// text match. classifyTransitFailure() still ACCEPTS the message so call sites
+// can pass the whole result through one place and so a regression test can
+// assert it is ignored; it does not read it.
+//
 // Where the code comes from (verified against the nav2 version in use, Kilted):
 //   * nav2_msgs/action/NavigateToPose.action has `uint16 error_code` +
 //     `string error_msg` in its RESULT (only NONE/UNKNOWN/
@@ -56,19 +63,23 @@ namespace mowgli_behavior
 //     ComputePathToPose::Result::START_OCCUPIED (205) reaches the
 //     NavigateToPose result verbatim.
 //
-// The message fallback exists because that propagation is configuration-
-// dependent (a robot whose bt_navigator drops "compute_path" from
-// error_code_name_prefixes, or a tree that omits error_code_id, reports
-// UNKNOWN). nav2_smac_planner throws nav2_core::StartOccupied("Start occupied")
-// and planner_server puts that text in error_msg either way, so matching it is
-// a strictly additional signal — never the only one.
+// DEPLOYMENT CAVEAT (documented, deliberately not papered over): that
+// propagation is configuration-dependent. A bt_navigator whose
+// `error_code_name_prefixes` omits "compute_path", or a navigate_to_pose tree
+// whose ComputePathToPose omits `error_code_id`, reports UNKNOWN instead of 205.
+// On such a robot every START_OCCUPIED refusal classifies as kUnknown, the
+// start-blocked recovery never fires, and FollowStrip behaves exactly as it did
+// before #487 — the swath is skipped and the area can still be declared
+// unmowable. The fix there is to restore the error-code plumbing, not to guess
+// from the message text.
 // ---------------------------------------------------------------------------
 
 /// What made a blade-off NavigateToPose transit fail.
 enum class TransitFailure : uint8_t
 {
-  /// No result was available to classify (result never arrived, or the goal was
-  /// rejected before it ever ran).
+  /// No usable error code: the result never arrived, the goal was rejected
+  /// before it ever ran, or nav2 reported its UNKNOWN placeholder because the
+  /// sub-action's code did not propagate (see the deployment caveat above).
   kUnknown = 0,
   /// The planner refused because the ROBOT'S CURRENT CELL is lethal. Retrying
   /// from the same pose is futile — every goal fails identically.
@@ -82,7 +93,7 @@ enum class TransitFailure : uint8_t
   kTimeout,
   /// TF was unavailable/late.
   kTfError,
-  /// A real error code that is none of the above.
+  /// A real, defined error code that is none of the above.
   kOther,
 };
 
@@ -110,35 +121,14 @@ inline const char* transitFailureName(TransitFailure kind)
   }
 }
 
-namespace detail
-{
-
-/// ASCII-lowercase copy — the planner's message casing is not part of any API
-/// contract, so the substring fallback must not depend on it.
-inline std::string asciiLower(const std::string& s)
-{
-  std::string out = s;
-  std::transform(out.begin(),
-                 out.end(),
-                 out.begin(),
-                 [](unsigned char c)
-                 {
-                   return static_cast<char>(std::tolower(c));
-                 });
-  return out;
-}
-
-}  // namespace detail
-
-/// Classify a NavigateToPose result. `error_code` / `error_msg` are the fields
-/// of nav2_msgs::action::NavigateToPose::Result. Pure — unit-testable without
-/// ROS running.
+/// Classify a NavigateToPose result from its `error_code` ALONE. Pure —
+/// unit-testable without ROS running.
 ///
-/// The numeric code wins when it is one nav2 actually defines; the message text
-/// is only consulted when the code carries no information (0 = NONE, or the
-/// NavigateToPose-level UNKNOWN placeholder), which is exactly the case where
-/// the sub-action code failed to propagate.
-inline TransitFailure classifyTransitFailure(uint16_t error_code, const std::string& error_msg)
+/// `error_msg` is accepted but NEVER read (see the error-code-only rationale
+/// above). NONE and either action's UNKNOWN placeholder map to kUnknown; any
+/// other defined-but-unmapped code maps to kOther.
+inline TransitFailure classifyTransitFailure(uint16_t error_code,
+                                             const std::string& /*error_msg*/ = std::string{})
 {
   using ComputePath = nav2_msgs::action::ComputePathToPose::Result;
   using Navigate = nav2_msgs::action::NavigateToPose::Result;
@@ -155,6 +145,9 @@ inline TransitFailure classifyTransitFailure(uint16_t error_code, const std::str
       return TransitFailure::kTimeout;
     case ComputePath::TF_ERROR:
       return TransitFailure::kTfError;
+    case ComputePath::NONE:  // == Navigate::NONE == 0
+    case ComputePath::UNKNOWN:
+      return TransitFailure::kUnknown;
     default:
       break;
   }
@@ -166,24 +159,7 @@ inline TransitFailure classifyTransitFailure(uint16_t error_code, const std::str
   {
     return TransitFailure::kTfError;
   }
-
-  // No usable code — fall back to the planner's own words. Only the
-  // start-occupied phrase is matched: it is the one condition whose handling
-  // differs, and nav2_smac_planner's exception text ("Start occupied") is
-  // stable across the supported versions.
-  const bool code_is_uninformative = (error_code == ComputePath::NONE) ||
-                                     (error_code == Navigate::UNKNOWN) ||
-                                     (error_code == ComputePath::UNKNOWN);
-  if (code_is_uninformative && !error_msg.empty())
-  {
-    const std::string lowered = detail::asciiLower(error_msg);
-    if (lowered.find("start occupied") != std::string::npos)
-    {
-      return TransitFailure::kStartOccupied;
-    }
-  }
-
-  if (error_code == ComputePath::NONE)
+  if (error_code == Navigate::UNKNOWN)
   {
     return TransitFailure::kUnknown;
   }

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/transit_failure.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/transit_failure.hpp
@@ -1,0 +1,202 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+#include "nav2_msgs/action/compute_path_to_pose.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+
+namespace mowgli_behavior
+{
+
+// ---------------------------------------------------------------------------
+// Transit-failure classification (issue #487)
+//
+// Every blade-off NavigateToPose transit that aborts used to be treated
+// identically by FollowStrip: "transit failed — skipping". That collapsed two
+// completely different conditions into one:
+//
+//   * the GOAL is unreachable (obstacle in the way, no valid path, timeout) —
+//     the swath genuinely cannot be mowed on this pass, skipping is right;
+//   * the ROBOT'S OWN POSE is a lethal cell (START_OCCUPIED) — no plan can ever
+//     be produced from where it stands, so EVERY sub-path start fails in a row
+//     and the whole area is forfeited even though the field is perfectly
+//     mowable. Observed 2026-08-24 (attempt 1 cut zero grass): the robot
+//     undocked into the inflated keepout around a 0.25 m obstacle circle and
+//     SmacPlanner2D answered "Start occupied" to all 26 planning calls.
+//
+// Where the code comes from (verified against the nav2 version in use, Kilted):
+//   * nav2_msgs/action/NavigateToPose.action has `uint16 error_code` +
+//     `string error_msg` in its RESULT (only NONE/UNKNOWN/
+//     FAILED_TO_LOAD_BEHAVIOR_TREE/TF_ERROR/TIMEOUT are declared on that
+//     action itself).
+//   * nav2_behavior_tree's BtActionServer::populateErrorCode copies the
+//     highest-priority (lowest-numbered) non-zero `<prefix>_error_code`
+//     blackboard entry into that result, for every prefix in
+//     `error_code_name_prefixes` (default list includes "compute_path").
+//   * trees/navigate_to_pose.xml wires ComputePathToPose with
+//     error_code_id="{compute_path_error_code}", so the planner's
+//     ComputePathToPose::Result::START_OCCUPIED (205) reaches the
+//     NavigateToPose result verbatim.
+//
+// The message fallback exists because that propagation is configuration-
+// dependent (a robot whose bt_navigator drops "compute_path" from
+// error_code_name_prefixes, or a tree that omits error_code_id, reports
+// UNKNOWN). nav2_smac_planner throws nav2_core::StartOccupied("Start occupied")
+// and planner_server puts that text in error_msg either way, so matching it is
+// a strictly additional signal — never the only one.
+// ---------------------------------------------------------------------------
+
+/// What made a blade-off NavigateToPose transit fail.
+enum class TransitFailure : uint8_t
+{
+  /// No result was available to classify (result never arrived, or the goal was
+  /// rejected before it ever ran).
+  kUnknown = 0,
+  /// The planner refused because the ROBOT'S CURRENT CELL is lethal. Retrying
+  /// from the same pose is futile — every goal fails identically.
+  kStartOccupied,
+  /// The GOAL cell is lethal. Specific to this swath start; other swaths may
+  /// still be reachable.
+  kGoalOccupied,
+  /// Planner searched and found nothing (obstacle field, walled-off region).
+  kNoValidPath,
+  /// Planning or navigation timed out.
+  kTimeout,
+  /// TF was unavailable/late.
+  kTfError,
+  /// A real error code that is none of the above.
+  kOther,
+};
+
+/// Human-readable tag for logs. Stable strings — field logs are grepped for
+/// these.
+inline const char* transitFailureName(TransitFailure kind)
+{
+  switch (kind)
+  {
+    case TransitFailure::kStartOccupied:
+      return "START_OCCUPIED";
+    case TransitFailure::kGoalOccupied:
+      return "GOAL_OCCUPIED";
+    case TransitFailure::kNoValidPath:
+      return "NO_VALID_PATH";
+    case TransitFailure::kTimeout:
+      return "TIMEOUT";
+    case TransitFailure::kTfError:
+      return "TF_ERROR";
+    case TransitFailure::kOther:
+      return "OTHER";
+    case TransitFailure::kUnknown:
+    default:
+      return "UNKNOWN";
+  }
+}
+
+namespace detail
+{
+
+/// ASCII-lowercase copy — the planner's message casing is not part of any API
+/// contract, so the substring fallback must not depend on it.
+inline std::string asciiLower(const std::string& s)
+{
+  std::string out = s;
+  std::transform(out.begin(),
+                 out.end(),
+                 out.begin(),
+                 [](unsigned char c)
+                 {
+                   return static_cast<char>(std::tolower(c));
+                 });
+  return out;
+}
+
+}  // namespace detail
+
+/// Classify a NavigateToPose result. `error_code` / `error_msg` are the fields
+/// of nav2_msgs::action::NavigateToPose::Result. Pure — unit-testable without
+/// ROS running.
+///
+/// The numeric code wins when it is one nav2 actually defines; the message text
+/// is only consulted when the code carries no information (0 = NONE, or the
+/// NavigateToPose-level UNKNOWN placeholder), which is exactly the case where
+/// the sub-action code failed to propagate.
+inline TransitFailure classifyTransitFailure(uint16_t error_code, const std::string& error_msg)
+{
+  using ComputePath = nav2_msgs::action::ComputePathToPose::Result;
+  using Navigate = nav2_msgs::action::NavigateToPose::Result;
+
+  switch (error_code)
+  {
+    case ComputePath::START_OCCUPIED:
+      return TransitFailure::kStartOccupied;
+    case ComputePath::GOAL_OCCUPIED:
+      return TransitFailure::kGoalOccupied;
+    case ComputePath::NO_VALID_PATH:
+      return TransitFailure::kNoValidPath;
+    case ComputePath::TIMEOUT:
+      return TransitFailure::kTimeout;
+    case ComputePath::TF_ERROR:
+      return TransitFailure::kTfError;
+    default:
+      break;
+  }
+  if (error_code == Navigate::TIMEOUT)
+  {
+    return TransitFailure::kTimeout;
+  }
+  if (error_code == Navigate::TF_ERROR)
+  {
+    return TransitFailure::kTfError;
+  }
+
+  // No usable code — fall back to the planner's own words. Only the
+  // start-occupied phrase is matched: it is the one condition whose handling
+  // differs, and nav2_smac_planner's exception text ("Start occupied") is
+  // stable across the supported versions.
+  const bool code_is_uninformative = (error_code == ComputePath::NONE) ||
+                                     (error_code == Navigate::UNKNOWN) ||
+                                     (error_code == ComputePath::UNKNOWN);
+  if (code_is_uninformative && !error_msg.empty())
+  {
+    const std::string lowered = detail::asciiLower(error_msg);
+    if (lowered.find("start occupied") != std::string::npos)
+    {
+      return TransitFailure::kStartOccupied;
+    }
+  }
+
+  if (error_code == ComputePath::NONE)
+  {
+    return TransitFailure::kUnknown;
+  }
+  return TransitFailure::kOther;
+}
+
+/// True when the failure means "the robot is standing somewhere the planner
+/// refuses to plan from" — i.e. nothing about the SWATH is wrong. FollowStrip
+/// uses this to tell a forfeit-the-field condition apart from a genuinely
+/// unmowable area.
+inline bool isStartPoseBlocked(TransitFailure kind)
+{
+  return kind == TransitFailure::kStartOccupied;
+}
+
+}  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -901,6 +901,9 @@ private:
       context_->attempted_areas.clear();
       context_->area_attempt_count.clear();
       context_->area_last_coverage.clear();
+      context_->coverage_start_blocked = false;
+      context_->start_blocked_area.reset();
+      context_->area_start_blocked_count.clear();
       clearCoverageResumeState(*context_);
       RCLCPP_INFO(get_logger(),
                   "Cleared coverage resume state on request — next start begins fresh");

--- a/ros2/src/mowgli_behavior/src/condition_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/condition_nodes.cpp
@@ -878,4 +878,31 @@ BT::NodeStatus IsCollisionStopSustained::tick()
   return BT::NodeStatus::FAILURE;
 }
 
+// ---------------------------------------------------------------------------
+// IsCoverageStartBlocked
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus IsCoverageStartBlocked::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+
+  // Consume: one blocked pass fires the recovery branch exactly once.
+  // Not guarded by context_mutex — coverage_start_blocked is written by
+  // FollowStrip from the BT tick itself, on the same MutuallyExclusive callback
+  // group (see the thread-safety comment in bt_context.hpp).
+  if (!ctx->coverage_start_blocked)
+  {
+    return BT::NodeStatus::FAILURE;
+  }
+  ctx->coverage_start_blocked = false;
+
+  RCLCPP_WARN(ctx->node->get_logger(),
+              "IsCoverageStartBlocked: the last coverage pass was refused from the robot's own "
+              "pose (START_OCCUPIED on every sub-path, 0 swaths mowed) — running the non-motion "
+              "recovery (stop, clear costmaps, wait) before retrying. NOTE: clearing the costmaps "
+              "only helps if the lethal cell came from a TRANSIENT obstacle reading; a keepout "
+              "zone is a static costmap FILTER and survives the clear");
+  return BT::NodeStatus::SUCCESS;
+}
+
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -334,8 +334,12 @@ BT::NodeStatus FollowStrip::onStart()
     swaths_.push_back(std::move(u));
   }
   swaths_skipped_ = 0;
+  swaths_skipped_start_occupied_ = 0;
+  swaths_mowed_this_pass_ = 0;
   transit_active_ = false;
   transit_pending_ = false;
+  transit_abort_seen_ = false;
+  transit_result_.reset();
   swath_goal_sent_ = false;
   // Swath-completion model (replaces the mow_progress cell grid): record this
   // area's swath count and resume at the first swath NOT already mowed. F2C is
@@ -645,8 +649,31 @@ bool FollowStrip::sendCurrentSwath(const std::shared_ptr<BTContext>& ctx)
     nav_goal.pose.header.frame_id = "map";
     nav_goal.pose.header.stamp = ctx->node->get_clock()->now();
     nav_handle_.reset();
-    nav_future_ = nav_client_->async_send_goal(nav_goal);
+    // Register a result callback (issue #487). Two reasons: it is what carries
+    // nav2's error_code/error_msg back to us so a "the robot is standing on a
+    // lethal cell" refusal can be told apart from "this swath is unreachable",
+    // AND rclcpp_action only REQUESTS the result at all when the send-goal
+    // options carry a result callback. The slot is shared_ptr-owned so a late
+    // callback can never write through a dangling `this`.
+    resetTransitResult();
+    rclcpp_action::Client<Nav2Navigate>::SendGoalOptions send_opts;
+    send_opts.result_callback = [slot = transit_result_](const NavGoalHandle::WrappedResult& r)
+    {
+      if (!slot)
+      {
+        return;
+      }
+      std::lock_guard<std::mutex> lk(slot->mutex);
+      slot->ready = true;
+      if (r.result)
+      {
+        slot->error_code = r.result->error_code;
+        slot->error_msg = r.result->error_msg;
+      }
+    };
+    nav_future_ = nav_client_->async_send_goal(nav_goal, send_opts);
     transit_active_ = true;
+    transit_abort_seen_ = false;
     swath_goal_sent_ = true;
     RCLCPP_INFO(ctx->node->get_logger(),
                 "FollowStrip: segment %zu/%zu starts %.2fm away — blade off, transit first",
@@ -660,6 +687,42 @@ bool FollowStrip::sendCurrentSwath(const std::shared_ptr<BTContext>& ctx)
   // cross-country crossing.
   transit_pending_ = false;
   return sendFollowGoal(ctx);
+}
+
+void FollowStrip::resetTransitResult()
+{
+  transit_result_ = std::make_shared<TransitResultSlot>();
+  transit_abort_seen_ = false;
+}
+
+std::optional<FollowStrip::TransitOutcome> FollowStrip::classifyFinishedTransit()
+{
+  bool ready = false;
+  uint16_t code = 0;
+  std::string msg;
+  if (transit_result_)
+  {
+    std::lock_guard<std::mutex> lk(transit_result_->mutex);
+    ready = transit_result_->ready;
+    code = transit_result_->error_code;
+    msg = transit_result_->error_msg;
+  }
+
+  if (!ready)
+  {
+    // The status topic reports the terminal state before the result response
+    // lands. Wait a bounded moment for it; past the budget classify as UNKNOWN
+    // so the transit can never wedge the pass waiting for a result that a
+    // crashed/restarted bt_navigator will never send.
+    const auto waited = std::chrono::steady_clock::now() - transit_abort_time_;
+    if (waited < std::chrono::duration<double>(kTransitResultWaitSec))
+    {
+      return std::nullopt;
+    }
+    return TransitOutcome{TransitFailure::kUnknown, 0, std::string{}};
+  }
+
+  return TransitOutcome{classifyTransitFailure(code, msg), code, msg};
 }
 
 BT::NodeStatus FollowStrip::onRunning()
@@ -723,9 +786,40 @@ BT::NodeStatus FollowStrip::onRunning()
     }
     if (swaths_skipped_ >= swaths_.size())
     {
+      // Issue #487. Two very different reasons land here; only one of them is
+      // "this area cannot be mowed".
+      //
+      // (a) EVERY skip was a START_OCCUPIED transit refusal and NOTHING was
+      //     mowed: the robot is parked on a lethal/keepout cell, so nav2
+      //     refuses to plan from it no matter where the goal is. The field is
+      //     fine — the pose is not. Flag it so the coverage subtree can run a
+      //     non-motion recovery (stop, clear costmaps, wait) and re-tick, and
+      //     so GetNextUnmowedArea does not spend the area's no-progress budget
+      //     on a pass that never had a chance. NOTE: no escape motion is
+      //     commanded from here — after an undock the robot REVERSED into the
+      //     spot, so reversing again drives deeper, and picking a direction is
+      //     a maintainer decision (see the proposal in the PR for #487).
+      // (b) anything else: genuinely unreachable goals this pass.
+      const bool start_pose_blocked = swaths_skipped_ > 0 && swaths_mowed_this_pass_ == 0 &&
+                                      swaths_skipped_start_occupied_ == swaths_skipped_;
+      if (start_pose_blocked)
+      {
+        ctx->coverage_start_blocked = true;
+        ctx->start_blocked_area = area_idx_;
+        RCLCPP_WARN(ctx->node->get_logger(),
+                    "FollowStrip: all %zu sub-path transits were refused with START_OCCUPIED and "
+                    "0 swaths were mowed — the ROBOT'S OWN POSE is blocked (standing on a lethal "
+                    "or keepout cell), NOT area %u. Keeping the area for a retry instead of "
+                    "declaring it unmowable (issue #487)",
+                    swaths_.size(),
+                    area_idx_);
+        return BT::NodeStatus::FAILURE;
+      }
       RCLCPP_WARN(ctx->node->get_logger(),
-                  "FollowStrip: all %zu swaths skipped — area %u not mowable now",
+                  "FollowStrip: all %zu swaths skipped (%zu of them because the planner refused "
+                  "to plan from the robot's pose) — area %u not mowable now",
                   swaths_.size(),
+                  swaths_skipped_start_occupied_,
                   area_idx_);
       return BT::NodeStatus::FAILURE;
     }
@@ -784,9 +878,13 @@ BT::NodeStatus FollowStrip::onRunning()
       nav_handle_ = nav_future_.get();
       if (!nav_handle_)
       {
+        // Rejected before it ever ran → no nav2 result, so no error code to
+        // classify. Counted as a plain skip (never as start-occupied).
         RCLCPP_WARN(ctx->node->get_logger(),
-                    "FollowStrip: segment %zu transit goal rejected — skipping",
-                    swath_idx_ + 1);
+                    "FollowStrip: segment %zu/%zu transit goal REJECTED by navigate_to_pose "
+                    "(no result, no error code) — skipping",
+                    swath_idx_ + 1,
+                    swaths_.size());
         transit_active_ = false;
         ++swaths_skipped_;
         return advance();
@@ -804,10 +902,45 @@ BT::NodeStatus FollowStrip::onRunning()
     if (nav_status == action_msgs::msg::GoalStatus::STATUS_ABORTED ||
         nav_status == action_msgs::msg::GoalStatus::STATUS_CANCELED)
     {
-      RCLCPP_WARN(ctx->node->get_logger(),
-                  "FollowStrip: segment %zu transit failed — skipping",
-                  swath_idx_ + 1);
+      // Classify WHY before skipping (issue #487). A START_OCCUPIED refusal is
+      // about the robot's own pose, not this swath — every remaining sub-path
+      // will fail identically, so the pass must not be read as "unmowable area".
+      if (!transit_abort_seen_)
+      {
+        transit_abort_seen_ = true;
+        transit_abort_time_ = std::chrono::steady_clock::now();
+      }
+      const auto outcome = classifyFinishedTransit();
+      if (!outcome.has_value())
+      {
+        return BT::NodeStatus::RUNNING;  // bounded wait for the nav2 result
+      }
+      if (isStartPoseBlocked(outcome->kind))
+      {
+        ++swaths_skipped_start_occupied_;
+        RCLCPP_WARN(ctx->node->get_logger(),
+                    "FollowStrip: segment %zu/%zu transit REFUSED — nav2 %s (code %u): \"%s\". "
+                    "The planner will not plan from the robot's CURRENT pose (lethal/keepout "
+                    "cell), so this is not about the swath — skipping it for now",
+                    swath_idx_ + 1,
+                    swaths_.size(),
+                    transitFailureName(outcome->kind),
+                    static_cast<unsigned>(outcome->error_code),
+                    outcome->error_msg.c_str());
+      }
+      else
+      {
+        RCLCPP_WARN(ctx->node->get_logger(),
+                    "FollowStrip: segment %zu/%zu transit failed — nav2 %s (code %u): \"%s\" — "
+                    "skipping",
+                    swath_idx_ + 1,
+                    swaths_.size(),
+                    transitFailureName(outcome->kind),
+                    static_cast<unsigned>(outcome->error_code),
+                    outcome->error_msg.c_str());
+      }
       transit_active_ = false;
+      transit_abort_seen_ = false;
       nav_handle_.reset();
       ++swaths_skipped_;
       return advance();
@@ -849,6 +982,7 @@ BT::NodeStatus FollowStrip::onRunning()
     ctx->area_resume_pose_index.erase(area_idx_);
     // Record this segment as mowed for the area (survives a resume re-plan).
     ctx->area_completed_swaths[area_idx_].insert(swath_idx_);
+    ++swaths_mowed_this_pass_;
     saveCoverageResumeState(*ctx);
     RCLCPP_INFO(ctx->node->get_logger(),
                 "FollowStrip: segment %zu/%zu completed (area %u)",
@@ -889,6 +1023,7 @@ BT::NodeStatus FollowStrip::onRunning()
                   area_idx_);
       ctx->area_resume_pose_index.erase(area_idx_);
       ctx->area_completed_swaths[area_idx_].insert(swath_idx_);
+      ++swaths_mowed_this_pass_;
       saveCoverageResumeState(*ctx);
       follow_handle_.reset();
       return advance();
@@ -974,6 +1109,8 @@ void FollowStrip::onHalted()
   nav_handle_.reset();
   transit_active_ = false;
   transit_pending_ = false;
+  transit_abort_seen_ = false;
+  transit_result_.reset();
   setBladeEnabled(false);
 }
 
@@ -1567,6 +1704,42 @@ BT::NodeStatus GetNextUnmowedArea::processResponse()
       done_swaths = it->second.size();
     }
   }
+  // Issue #487: the PREVIOUS pass on this area ended with every sub-path
+  // transit refused because the ROBOT'S own pose was a lethal/keepout cell, and
+  // nothing was mowed. That pass never had a chance to make progress, so
+  // charging it against the no-progress retirement counter retires a perfectly
+  // mowable field (observed 2026-08-24: the whole area forfeited at 0 %).
+  // Exempt it — but only kMaxStartBlockedAttempts times per area, so a robot
+  // that is genuinely parked on a lethal cell forever still gives up and docks.
+  const bool was_start_blocked =
+      ctx->start_blocked_area.has_value() && *ctx->start_blocked_area == current_area_idx_;
+  ctx->start_blocked_area.reset();  // consume: it describes ONE finished pass
+  if (was_start_blocked)
+  {
+    auto& blocked_n = ctx->area_start_blocked_count[current_area_idx_];
+    if (blocked_n < BTContext::kMaxStartBlockedAttempts)
+    {
+      blocked_n++;
+      setOutput("area_index", current_area_idx_);
+      ctx->current_area = static_cast<int>(current_area_idx_);
+      RCLCPP_WARN(ctx->node->get_logger(),
+                  "GetNextUnmowedArea: area %u re-dispatched after a START_OCCUPIED pass "
+                  "(retry %u/%u) — the robot's pose blocked planning, the area is not unmowable; "
+                  "no-progress budget NOT charged (still %u/%u)",
+                  current_area_idx_,
+                  blocked_n,
+                  BTContext::kMaxStartBlockedAttempts,
+                  ctx->area_attempt_count[current_area_idx_],
+                  BTContext::kMaxAreaAttempts);
+      return BT::NodeStatus::SUCCESS;
+    }
+    RCLCPP_WARN(ctx->node->get_logger(),
+                "GetNextUnmowedArea: area %u start-blocked again after %u exempted retries — "
+                "charging it to the no-progress budget from now on",
+                current_area_idx_,
+                blocked_n);
+  }
+
   auto& n = ctx->area_attempt_count[current_area_idx_];
   auto last_it = ctx->area_last_coverage.find(current_area_idx_);
   const bool made_progress = (last_it == ctx->area_last_coverage.end()) ||

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -53,6 +53,7 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<WasRecentlyInCollisionStop>("WasRecentlyInCollisionStop");
   factory.registerNodeType<IsScanStale>("IsScanStale");
   factory.registerNodeType<IsCollisionStopSustained>("IsCollisionStopSustained");
+  factory.registerNodeType<IsCoverageStartBlocked>("IsCoverageStartBlocked");
 
   // Action nodes
   factory.registerNodeType<SetMowerEnabled>("SetMowerEnabled");

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -183,6 +183,13 @@ BT::NodeStatus EndSession::tick()
   // (coverage reset / re-mow) is wrongly judged "no progress" and pushed
   // toward premature give-up at kMaxAreaAttempts.
   ctx->area_last_coverage.clear();
+  // Start-pose-blocked bookkeeping (issue #487) is per-session too: the next
+  // COMMAND_START must get a fresh exemption budget, and a stale
+  // start_blocked_area would make the first dispatch of the new session skip
+  // the no-progress counter for a pass that never happened.
+  ctx->coverage_start_blocked = false;
+  ctx->start_blocked_area.reset();
+  ctx->area_start_blocked_count.clear();
   // Swath-completion model (replaces the cell coverage grid): clear the
   // per-area completed-swath sets, swath counts, and the completed-area set so
   // the next COMMAND_START re-plans and re-mows every area from swath 0.

--- a/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
+++ b/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
@@ -221,3 +221,72 @@ TEST_F(GetNextUnmowedAreaTest, SelectsMowingAreaAtIndexZero)
   EXPECT_EQ(selected, 0u);
   EXPECT_EQ(ctx->current_area, 0);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #487 — a START_OCCUPIED pass must not retire the area.
+//
+// FollowStrip sets ctx->start_blocked_area when a whole pass ended with every
+// blade-off sub-path transit refused because the ROBOT'S OWN pose is a lethal
+// or keepout cell and ZERO swaths were mowed. Such a pass never had a chance to
+// make progress; charging it to the no-progress retirement counter is what
+// forfeited a mowable field at 0 % coverage on 2026-08-24.
+// ---------------------------------------------------------------------------
+
+// Before the fix, kMaxAreaAttempts (5) consecutive zero-progress dispatches
+// retired the area. With the exemption, five start-blocked dispatches all still
+// select the area.
+TEST_F(GetNextUnmowedAreaTest, StartBlockedPassesDoNotBurnTheNoProgressBudget)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  for (uint32_t attempt = 0; attempt < BTContext::kMaxAreaAttempts; ++attempt)
+  {
+    // Simulate the previous FollowStrip pass ending start-pose-blocked.
+    ctx->start_blocked_area = 0u;
+    auto tree = makeTree(/*max_areas=*/5);
+    EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS)
+        << "dispatch " << attempt << " must still select the area";
+    EXPECT_EQ(ctx->current_area, 0) << "dispatch " << attempt;
+  }
+  EXPECT_EQ(ctx->attempted_areas.count(0u), 0u)
+      << "a run of START_OCCUPIED passes must not retire a mowable area (#487)";
+}
+
+// ...but the exemption is BOUNDED. A robot genuinely parked on a lethal cell
+// forever must still give up and dock rather than loop.
+TEST_F(GetNextUnmowedAreaTest, StartBlockedExemptionIsBoundedSoTheAreaStillRetires)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  const uint32_t kMaxDispatches =
+      BTContext::kMaxStartBlockedAttempts + BTContext::kMaxAreaAttempts + 2;
+  bool retired = false;
+  for (uint32_t attempt = 0; attempt < kMaxDispatches && !retired; ++attempt)
+  {
+    ctx->start_blocked_area = 0u;
+    auto tree = makeTree(/*max_areas=*/5);
+    tickToCompletion(tree);
+    retired = ctx->attempted_areas.count(0u) > 0;
+  }
+  EXPECT_TRUE(retired) << "the start-blocked exemption must be bounded — an area the robot can "
+                          "never plan from has to retire so the session can dock";
+}
+
+// The flag describes ONE finished pass and is consumed by the dispatch that
+// reads it, so a single blocked pass buys exactly one exemption.
+TEST_F(GetNextUnmowedAreaTest, StartBlockedFlagIsConsumedByOneDispatch)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  ctx->start_blocked_area = 0u;
+  auto tree = makeTree(/*max_areas=*/5);
+  ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+
+  EXPECT_FALSE(ctx->start_blocked_area.has_value());
+  EXPECT_EQ(ctx->area_start_blocked_count[0u], 1u);
+  EXPECT_EQ(ctx->area_attempt_count[0u], 0u)
+      << "the exempted dispatch must not have advanced the no-progress counter";
+}

--- a/ros2/src/mowgli_behavior/test/test_start_occupied_retry.cpp
+++ b/ros2/src/mowgli_behavior/test/test_start_occupied_retry.cpp
@@ -1,0 +1,283 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_start_occupied_retry.cpp
+ * @brief Regression for issue #487 — one occupied start pose forfeited a whole
+ *        field.
+ *
+ * 2026-08-24, attempt 1 of an area-0 mow cut ZERO grass. The robot undocked to
+ * ~(4.47, 4.70), which sits inside the inflated keepout of a 0.25 m obstacle
+ * circle, and SmacPlanner2D (no start tolerance) answered every one of 26 plan
+ * calls with "Start occupied". FollowStrip treated each refused blade-off
+ * transit as an ordinary skipped swath, ran out of sub-paths, and declared the
+ * area unmowable. A second attempt 13 minutes later mowed the same area to
+ * 100 %.
+ *
+ * Three things are pinned here:
+ *   1. classifyTransitFailure() tells a START_OCCUPIED refusal (about the
+ *      ROBOT'S pose) apart from every other transit failure (about the GOAL),
+ *      from the nav2 error_code and, as a fallback, the planner's error_msg.
+ *   2. IsCoverageStartBlocked consumes the flag exactly once, so the recovery
+ *      branch cannot re-fire on an unrelated later failure.
+ *   3. main_tree.xml still carries the non-motion recovery branch (clear the
+ *      costmaps, wait, retry) and still commands NO escape motion — the
+ *      escape-direction decision is deliberately left to the maintainer.
+ */
+
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "behaviortree_cpp/bt_factory.h"
+#include "mowgli_behavior/bt_context.hpp"
+#include "mowgli_behavior/condition_nodes.hpp"
+#include "mowgli_behavior/transit_failure.hpp"
+#include "nav2_msgs/action/compute_path_to_pose.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include <gtest/gtest.h>
+
+using mowgli_behavior::BTContext;
+using mowgli_behavior::classifyTransitFailure;
+using mowgli_behavior::IsCoverageStartBlocked;
+using mowgli_behavior::isStartPoseBlocked;
+using mowgli_behavior::TransitFailure;
+using mowgli_behavior::transitFailureName;
+
+using ComputePath = nav2_msgs::action::ComputePathToPose::Result;
+using Navigate = nav2_msgs::action::NavigateToPose::Result;
+
+// ---------------------------------------------------------------------------
+// 1. Classification — pure, no ROS spinning.
+// ---------------------------------------------------------------------------
+
+// The exact field signature: bt_navigator copies ComputePathToPose's
+// START_OCCUPIED (205) into the NavigateToPose result because
+// navigate_to_pose.xml wires error_code_id="{compute_path_error_code}" and
+// "compute_path" is in bt_navigator's default error_code_name_prefixes.
+TEST(TransitFailureClassification, StartOccupiedErrorCodeIsRecognised)
+{
+  const auto kind = classifyTransitFailure(ComputePath::START_OCCUPIED, "Start occupied");
+  EXPECT_EQ(kind, TransitFailure::kStartOccupied);
+  EXPECT_TRUE(isStartPoseBlocked(kind));
+  EXPECT_STREQ(transitFailureName(kind), "START_OCCUPIED");
+}
+
+// A robot whose bt_navigator drops "compute_path" from error_code_name_prefixes
+// (or a tree without error_code_id) reports UNKNOWN. nav2_smac_planner still
+// throws nav2_core::StartOccupied("Start occupied") and planner_server still
+// puts that text in error_msg, so the message is a second, independent signal.
+TEST(TransitFailureClassification, StartOccupiedMessageIsRecognisedWithoutACode)
+{
+  EXPECT_TRUE(isStartPoseBlocked(classifyTransitFailure(
+      Navigate::UNKNOWN,
+      "GridBasedplugin failed to plan from (4.47, 4.70) to (2.07, 9.54): \"Start occupied\"")));
+  // Casing is not part of any API contract.
+  EXPECT_TRUE(isStartPoseBlocked(classifyTransitFailure(ComputePath::NONE, "START OCCUPIED")));
+}
+
+// The whole point of the change: a failure about the GOAL must stay an ordinary
+// skipped swath, because that swath really is unreachable this pass.
+TEST(TransitFailureClassification, GoalSideFailuresAreNotStartBlocked)
+{
+  EXPECT_EQ(classifyTransitFailure(ComputePath::GOAL_OCCUPIED, "Goal occupied"),
+            TransitFailure::kGoalOccupied);
+  EXPECT_EQ(classifyTransitFailure(ComputePath::NO_VALID_PATH, "No valid path"),
+            TransitFailure::kNoValidPath);
+  EXPECT_EQ(classifyTransitFailure(ComputePath::TIMEOUT, "timed out"), TransitFailure::kTimeout);
+  EXPECT_EQ(classifyTransitFailure(ComputePath::TF_ERROR, "tf"), TransitFailure::kTfError);
+  EXPECT_EQ(classifyTransitFailure(Navigate::TIMEOUT, ""), TransitFailure::kTimeout);
+
+  EXPECT_FALSE(isStartPoseBlocked(classifyTransitFailure(ComputePath::GOAL_OCCUPIED, "")));
+  EXPECT_FALSE(isStartPoseBlocked(classifyTransitFailure(ComputePath::NO_VALID_PATH, "")));
+  EXPECT_FALSE(isStartPoseBlocked(classifyTransitFailure(ComputePath::TIMEOUT, "")));
+}
+
+// No result at all (goal rejected, or bt_navigator died before answering) must
+// never be guessed into the start-blocked bucket — that bucket suppresses the
+// "area not mowable" verdict and must stay evidence-backed.
+TEST(TransitFailureClassification, MissingResultIsUnknownNotStartBlocked)
+{
+  const auto kind = classifyTransitFailure(ComputePath::NONE, "");
+  EXPECT_EQ(kind, TransitFailure::kUnknown);
+  EXPECT_FALSE(isStartPoseBlocked(kind));
+  EXPECT_STREQ(transitFailureName(kind), "UNKNOWN");
+}
+
+// An unrelated non-zero code is "other", not a silent start-block.
+TEST(TransitFailureClassification, UnrelatedCodeIsOther)
+{
+  const auto kind = classifyTransitFailure(ComputePath::INVALID_PLANNER, "no such planner");
+  EXPECT_EQ(kind, TransitFailure::kOther);
+  EXPECT_FALSE(isStartPoseBlocked(kind));
+}
+
+// A goal-side code must win over an incidental message match, so a planner that
+// mentions the phrase while reporting something else cannot suppress the
+// unmowable verdict.
+TEST(TransitFailureClassification, ExplicitCodeWinsOverTheMessageFallback)
+{
+  EXPECT_EQ(classifyTransitFailure(ComputePath::NO_VALID_PATH, "start occupied earlier, then..."),
+            TransitFailure::kNoValidPath);
+}
+
+// ---------------------------------------------------------------------------
+// 2. IsCoverageStartBlocked — consumed exactly once.
+// ---------------------------------------------------------------------------
+
+class RclcppEnvironment : public ::testing::Environment
+{
+public:
+  void SetUp() override
+  {
+    if (!rclcpp::ok())
+    {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+::testing::Environment* const rclcpp_env =
+    ::testing::AddGlobalTestEnvironment(new RclcppEnvironment());
+
+class StartBlockedConditionTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<BTContext> ctx;
+  BT::Blackboard::Ptr blackboard;
+  BT::BehaviorTreeFactory factory;
+
+  void SetUp() override
+  {
+    ctx = std::make_shared<BTContext>();
+    ctx->node = rclcpp::Node::make_shared("test_start_occupied_retry");
+    blackboard = BT::Blackboard::create();
+    blackboard->set("context", ctx);
+    factory.registerNodeType<IsCoverageStartBlocked>("IsCoverageStartBlocked");
+  }
+
+  BT::Tree makeTree()
+  {
+    const std::string xml =
+        "<root BTCPP_format=\"4\"><BehaviorTree ID=\"MainTree\">"
+        "<IsCoverageStartBlocked/>"
+        "</BehaviorTree></root>";
+    return factory.createTreeFromText(xml, blackboard);
+  }
+};
+
+TEST_F(StartBlockedConditionTest, FailsWhenNoPassWasStartBlocked)
+{
+  auto tree = makeTree();
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE);
+}
+
+TEST_F(StartBlockedConditionTest, FiresOnceThenConsumesTheFlag)
+{
+  ctx->coverage_start_blocked = true;
+  auto tree = makeTree();
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->coverage_start_blocked) << "the flag must be consumed on read";
+  EXPECT_EQ(tree.tickOnce(), BT::NodeStatus::FAILURE)
+      << "a second tick must not re-run the recovery for the same blocked pass";
+}
+
+// The two consumers are independent: the tree's condition node must not eat the
+// per-area retirement exemption that GetNextUnmowedArea reads.
+TEST_F(StartBlockedConditionTest, DoesNotConsumeTheAreaRetirementExemption)
+{
+  ctx->coverage_start_blocked = true;
+  ctx->start_blocked_area = 0u;
+  auto tree = makeTree();
+  ASSERT_EQ(tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  ASSERT_TRUE(ctx->start_blocked_area.has_value());
+  EXPECT_EQ(*ctx->start_blocked_area, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// 3. main_tree.xml still carries the NON-MOTION recovery branch.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+std::string ReadMainTree()
+{
+  std::ifstream f(MOWGLI_MAIN_TREE_PATH);
+  EXPECT_TRUE(f.is_open()) << "Cannot open " << MOWGLI_MAIN_TREE_PATH;
+  std::stringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+/// Text of the <Sequence name="StartPoseBlockedRetry"> ... </Sequence> block.
+std::string ExtractStartBlockedBranch(const std::string& xml)
+{
+  const std::string open = "<Sequence name=\"StartPoseBlockedRetry\">";
+  const auto begin = xml.find(open);
+  if (begin == std::string::npos)
+  {
+    return {};
+  }
+  const auto end = xml.find("</Sequence>", begin);
+  if (end == std::string::npos)
+  {
+    return {};
+  }
+  return xml.substr(begin, end - begin);
+}
+
+}  // namespace
+
+TEST(StartBlockedTreeStructure, RecoveryBranchExistsAndRetriesInsteadOfGivingUp)
+{
+  const std::string branch = ExtractStartBlockedBranch(ReadMainTree());
+  ASSERT_FALSE(branch.empty()) << "StartPoseBlockedRetry branch missing from main_tree.xml — a "
+                                  "START_OCCUPIED pass would forfeit the whole area again (#487)";
+  EXPECT_NE(branch.find("<IsCoverageStartBlocked/>"), std::string::npos)
+      << "the branch must be gated on the consumed start-blocked signal";
+  EXPECT_NE(branch.find("<ClearCostmap/>"), std::string::npos)
+      << "the retry must clear the costmaps first (helps only for a TRANSIENT obstacle; a keepout "
+         "is a static filter and survives the clear)";
+  EXPECT_NE(branch.find("<AlwaysFailure/>"), std::string::npos)
+      << "the branch must bubble up FAILURE so FollowStripRetry re-ticks FollowStrip";
+}
+
+// SAFETY: this robot has blades and the escape direction is genuinely ambiguous
+// (after an undock it REVERSED into the blocked spot, so reversing again drives
+// deeper). The recovery must stay non-motion until a maintainer picks a
+// strategy — see issue #487.
+TEST(StartBlockedTreeStructure, RecoveryBranchCommandsNoMotion)
+{
+  const std::string branch = ExtractStartBlockedBranch(ReadMainTree());
+  ASSERT_FALSE(branch.empty());
+  EXPECT_EQ(branch.find("<BackUp"), std::string::npos)
+      << "no reverse escape may be added without a maintainer decision (#487)";
+  EXPECT_EQ(branch.find("<Spin"), std::string::npos)
+      << "no spin escape may be added without a maintainer decision (#487)";
+  EXPECT_EQ(branch.find("<NavigateToPose"), std::string::npos)
+      << "no drive-out escape may be added without a maintainer decision (#487)";
+  EXPECT_NE(branch.find("<SetMowerEnabled enabled=\"false\"/>"), std::string::npos)
+      << "the blade must be OFF while the robot sits blocked";
+  EXPECT_NE(branch.find("<StopMoving/>"), std::string::npos);
+}

--- a/ros2/src/mowgli_behavior/test/test_start_occupied_retry.cpp
+++ b/ros2/src/mowgli_behavior/test/test_start_occupied_retry.cpp
@@ -30,7 +30,9 @@
  * Three things are pinned here:
  *   1. classifyTransitFailure() tells a START_OCCUPIED refusal (about the
  *      ROBOT'S pose) apart from every other transit failure (about the GOAL),
- *      from the nav2 error_code and, as a fallback, the planner's error_msg.
+ *      from the nav2 error_code ALONE — the planner's error_msg is never
+ *      parsed, so a nav2 upgrade that rewords the exception degrades to an
+ *      honest UNKNOWN rather than silently misclassifying.
  *   2. IsCoverageStartBlocked consumes the flag exactly once, so the recovery
  *      branch cannot re-fire on an unrelated later failure.
  *   3. main_tree.xml still carries the non-motion recovery branch (clear the
@@ -79,17 +81,24 @@ TEST(TransitFailureClassification, StartOccupiedErrorCodeIsRecognised)
   EXPECT_STREQ(transitFailureName(kind), "START_OCCUPIED");
 }
 
-// A robot whose bt_navigator drops "compute_path" from error_code_name_prefixes
-// (or a tree without error_code_id) reports UNKNOWN. nav2_smac_planner still
-// throws nav2_core::StartOccupied("Start occupied") and planner_server still
-// puts that text in error_msg, so the message is a second, independent signal.
-TEST(TransitFailureClassification, StartOccupiedMessageIsRecognisedWithoutACode)
+// Classification is ERROR-CODE-ONLY. A robot whose bt_navigator drops
+// "compute_path" from error_code_name_prefixes (or a tree without
+// error_code_id) reports UNKNOWN, and the planner's wording in error_msg must
+// NOT be used to recover the verdict: matching text would break silently on a
+// nav2 upgrade that rewords the exception. An honest kUnknown skips the swath
+// exactly as the pre-#487 code did. This test is the guard against anyone
+// re-adding a message fallback.
+TEST(TransitFailureClassification, StartOccupiedMessageWithoutACodeIsUnknown)
 {
-  EXPECT_TRUE(isStartPoseBlocked(classifyTransitFailure(
+  const auto kind = classifyTransitFailure(
       Navigate::UNKNOWN,
-      "GridBasedplugin failed to plan from (4.47, 4.70) to (2.07, 9.54): \"Start occupied\"")));
-  // Casing is not part of any API contract.
-  EXPECT_TRUE(isStartPoseBlocked(classifyTransitFailure(ComputePath::NONE, "START OCCUPIED")));
+      "GridBasedplugin failed to plan from (4.47, 4.70) to (2.07, 9.54): \"Start occupied\"");
+  EXPECT_EQ(kind, TransitFailure::kUnknown);
+  EXPECT_FALSE(isStartPoseBlocked(kind));
+
+  const auto no_code = classifyTransitFailure(ComputePath::NONE, "START OCCUPIED");
+  EXPECT_EQ(no_code, TransitFailure::kUnknown);
+  EXPECT_FALSE(isStartPoseBlocked(no_code));
 }
 
 // The whole point of the change: a failure about the GOAL must stay an ordinary
@@ -128,14 +137,10 @@ TEST(TransitFailureClassification, UnrelatedCodeIsOther)
   EXPECT_FALSE(isStartPoseBlocked(kind));
 }
 
-// A goal-side code must win over an incidental message match, so a planner that
-// mentions the phrase while reporting something else cannot suppress the
-// unmowable verdict.
-TEST(TransitFailureClassification, ExplicitCodeWinsOverTheMessageFallback)
-{
-  EXPECT_EQ(classifyTransitFailure(ComputePath::NO_VALID_PATH, "start occupied earlier, then..."),
-            TransitFailure::kNoValidPath);
-}
+// (ExplicitCodeWinsOverTheMessageFallback was dropped: with the message
+// fallback gone there is no fallback for a code to win over, and the "message
+// text is ignored" property is already pinned by
+// StartOccupiedMessageWithoutACodeIsUnknown above.)
 
 // ---------------------------------------------------------------------------
 // 2. IsCoverageStartBlocked — consumed exactly once.

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -749,6 +749,50 @@
                           <PublishHighLevelStatus state="2" state_name="MOWING"/>
                           <FollowStrip/>
                         </Sequence>
+                        <!-- Start-pose blocked recovery (issue #487).
+                             Every blade-off sub-path transit was refused by
+                             the Nav2 planner with START_OCCUPIED and NOTHING
+                             was mowed: the robot is STANDING on a lethal or
+                             keepout cell (2026-08-24: it undocked into the
+                             inflated keepout of a 0.25 m obstacle circle), so
+                             no plan exists from here regardless of the goal.
+                             That is NOT an unmowable field — a second attempt
+                             13 min later mowed the same area to 100 %.
+
+                             Non-motion recovery only: stop, clear the
+                             costmaps, wait for a fresh update, then bubble up
+                             FAILURE so FollowStripRetry re-ticks FollowStrip.
+                             Be honest about the clear: it only helps when the
+                             lethal cell came from a TRANSIENT obstacle_layer
+                             reading. A keepout zone is a static costmap
+                             FILTER — ClearEntireCostmap does not touch it, so
+                             the retry from an unchanged pose will fail again
+                             and GetNextUnmowedArea's bounded exemption
+                             (kMaxStartBlockedAttempts) eventually retires the
+                             area rather than looping.
+
+                             Deliberately commands NO escape motion: after an
+                             undock the robot REVERSED into the spot, so
+                             reversing again drives deeper, whereas mid-mow it
+                             arrived driving forward and reversing retraces
+                             known-good ground. Picking a direction on a
+                             machine with blades is a maintainer decision —
+                             see the options proposed on issue #487.
+
+                             Placed FIRST in MowOrRecover because
+                             IsCoverageStartBlocked is an exact, consumed
+                             signal, while IsObstacleStuck below would also
+                             match a robot that has simply not moved. -->
+                        <Sequence name="StartPoseBlockedRetry">
+                          <IsCoverageStartBlocked/>
+                          <PublishHighLevelStatus state="2"
+                                                  state_name="START_POSE_BLOCKED"/>
+                          <SetMowerEnabled enabled="false"/>
+                          <StopMoving/>
+                          <ClearCostmap/>
+                          <WaitForDuration duration_sec="2.0"/>
+                          <AlwaysFailure/>
+                        </Sequence>
                         <!-- Obstacle wedge recovery: BackUp + ClearCostmap
                              then bubble up FAILURE so RetryUntilSuccessful
                              re-ticks FollowStrip, which resumes at the


### PR DESCRIPTION
Fixes #487.

## The failure

Attempt 1 of the 2026-08-24 area-0 mow cut **zero grass**. The robot undocked to ~(4.47, 4.70), which is inside the inflated keepout of the 0.25 m obstacle circle at (4.06, 4.50) — the dock is at ~(6.2, 2.8) and undock reverses on a ~126° bearing, straight at it. SmacPlanner2D has no start tolerance, so all 26 plan calls answered `"Start occupied"`, `FollowStrip` skipped all four sub-paths one by one, and the run ended with `all 4 swaths skipped — area 0 not mowable now`. A second attempt 13 minutes later mowed the same area to 100 %.

Live probe confirming it was the pose, not the field:

| point | keepout_mask | global_costmap |
|---|---|---|
| (4.47, 4.70) — attempt 1 | **100 lethal** | 100 |
| (5.13, 4.21) — attempt 2 | 0 | 0 |

## What this PR changes (non-motion only)

**1. Transit failures are classified — from the nav2 `error_code` alone.**
`FollowStrip` now registers a `result_callback` on the blade-off `NavigateToPose` transit — which is also what makes `rclcpp_action` request the result at all — and reads the result's `error_code`.

Verified against the nav2 version in use (Kilted), not invented:
- `nav2_msgs/action/NavigateToPose.action` declares `uint16 error_code` + `string error_msg` in its **result**.
- `nav2_behavior_tree`'s `BtActionServer::populateErrorCode` copies the highest-priority (lowest-numbered) non-zero `<prefix>_error_code` blackboard entry into that result, for each prefix in `error_code_name_prefixes` — whose default list includes `"compute_path"`.
- Our `trees/navigate_to_pose.xml` wires `ComputePathToPose` with `error_code_id="{compute_path_error_code}"`, so `ComputePathToPose::Result::START_OCCUPIED` (**205**) reaches the `NavigateToPose` result verbatim.

`mowgli_behavior/transit_failure.hpp` (pure, header-only) maps that code plus `GOAL_OCCUPIED` / `NO_VALID_PATH` / `TIMEOUT` / `TF_ERROR`, and maps both actions' `UNKNOWN` placeholders to `kUnknown`.

**The `error_msg` is never parsed.** An earlier revision of this PR matched the planner's `"Start occupied"` text as a fallback; that was dropped in review. Text matching would break silently on a nav2 upgrade that rewords the exception, and a wrong "start blocked" verdict suppresses the "area not mowable" path — an honest `UNKNOWN` (which skips the swath exactly as `dev` does today) is the better failure mode. `classifyTransitFailure()` still *accepts* the message so call sites pass the whole result through one place and so a regression test can assert it is ignored.

*Documented deployment caveat, deliberately not papered over:* that code propagation is configuration-dependent. A bt_navigator whose `error_code_name_prefixes` omits `"compute_path"`, or a `navigate_to_pose` tree whose `ComputePathToPose` omits `error_code_id`, reports `UNKNOWN` instead of 205. On such a robot the start-blocked recovery never fires and `FollowStrip` behaves exactly as it did before this PR. The fix there is to restore the error-code plumbing, not to guess from text.

Waiting for the result is bounded at 2 s, after which the failure is `UNKNOWN` and the swath is skipped as before.

**2. A zero-progress, all-START_OCCUPIED pass no longer means "unmowable area".**
That combination is a property of where the robot is *standing*. `FollowStrip` flags it (`ctx->coverage_start_blocked` + `ctx->start_blocked_area`) and `GetNextUnmowedArea` **exempts** such a dispatch from the no-progress retirement counter, up to `kMaxStartBlockedAttempts = 3`. So the area routes back into its own 5-attempt dispatch loop rather than being retired at 0 % — and because the exemption is bounded, a robot genuinely parked on a lethal cell still retires the area and docks (worst case 3 + 5 dispatches).

**3. Costmaps are cleared before the retry.**
New `StartPoseBlockedRetry` branch in `MowOrRecover`, using the existing `ClearCostmap` node: stop, blade off, `ClearCostmap`, wait 2 s, `AlwaysFailure` so `FollowStripRetry` re-ticks `FollowStrip`. The comment and the log are honest that **this does not clear a keepout** — a keepout is a static costmap *filter*, so the clear only helps the transient-`obstacle_layer` case. It is worth doing because it is free and covers the one variant that is actually recoverable without motion.

**4. Logs name the cause.**
`transit failed — skipping` becomes `transit REFUSED — nav2 START_OCCUPIED (code 205): "…"`, the rejected-goal path says so explicitly, and the give-up line reports how many of the skips were planner refusals from the robot's own pose.

Also: `START_POSE_BLOCKED` aliased onto the `OBSTACLE_BACKOFF` node in the GUI's BT state graph so the state renders instead of vanishing.

## What this PR deliberately does NOT change

No recovery **motion**. Per review this ships as the non-motion change, and escape motion lands as a **separate follow-up PR implementing option B below**. A unit test (`RecoveryBranchCommandsNoMotion`) asserts the new branch contains no `BackUp`, `Spin`, or `NavigateToPose`, so the follow-up will deliberately update it.

## Proposal: the motion-based escape — decided: **option B**

The robot is on a lethal cell and no plan exists from there. Something has to physically move it ~0.3–0.5 m. The reason it isn't in this PR is that the safe direction is genuinely ambiguous: after an undock the robot **reversed into** the spot, so reversing again drives it deeper; mid-mow it **arrived driving forward**, so reversing retraces known-good ground. Options considered:

**A. Reverse a short distance (`BackUp 0.4 m @ 0.15 m/s`).**
Cheapest — the node already exists and is used for undock and the obstacle-wedge backoff. Correct mid-mow. **Wrong immediately after undock**, which is exactly the reported case. Could be gated on "did we just undock?" since the tree knows.

**B. Direction from the last commanded/measured motion — reverse the way we came. ← SELECTED**
Use the last non-zero `cmd_vel` (or the fused-pose delta over the last few seconds) and move *opposite* to it, bounded to ~0.4 m. Gets both cases right by construction: post-undock the last motion was reverse, so it drives forward, away from the obstacle; mid-mow the last motion was forward, so it reverses onto known-good ground. Needs a new bounded open-loop drive action (collision_monitor still applies) and a stale-signal stand-down, with **A** as the degenerate fallback when the direction signal is stale. Gated behind the `IsCoverageStartBlocked` signal added here so it only ever fires on a confirmed START_OCCUPIED-with-zero-progress pass.

**C. Escape toward the nearest free costmap cell.**
`FollowStrip` already subscribes to the global costmap and has a footprint-clearance search (`tryStartDetour` / `detour_resume.hpp`). Most principled, most new code, and the costmap is exactly the thing telling us we are lethal — needs care about stale/rotated masks.

**D. Nav2-side: give the planner a start tolerance.**
No motion at all, but SmacPlanner2D does not expose one; it would mean switching the transit planner or carrying a patch. Also arguably wrong — planning *out of* a keepout should not be silently allowed.

**E. Don't get there in the first place (complementary, not a substitute).**
The companion BackUp issue is the upstream cause: attempt 1 stopped short on the undock reverse and landed in the keepout. Fixing it reduces frequency but cannot remove the mid-mow case (a promoted dig keepout can appear under a stationary robot).

## Tests

New `test_start_occupied_retry`:
- `TransitFailureClassification.StartOccupiedErrorCodeIsRecognised`
- `TransitFailureClassification.StartOccupiedMessageWithoutACodeIsUnknown` — inverse assertion; the guard against re-adding a message fallback
- `TransitFailureClassification.GoalSideFailuresAreNotStartBlocked`
- `TransitFailureClassification.MissingResultIsUnknownNotStartBlocked`
- `TransitFailureClassification.UnrelatedCodeIsOther`
- `StartBlockedConditionTest.FailsWhenNoPassWasStartBlocked`
- `StartBlockedConditionTest.FiresOnceThenConsumesTheFlag`
- `StartBlockedConditionTest.DoesNotConsumeTheAreaRetirementExemption`
- `StartBlockedTreeStructure.RecoveryBranchExistsAndRetriesInsteadOfGivingUp`
- `StartBlockedTreeStructure.RecoveryBranchCommandsNoMotion`

Added to `test_get_next_unmowed_area`:
- `StartBlockedPassesDoNotBurnTheNoProgressBudget` (fails on `dev`: the area retires on the 5th dispatch)
- `StartBlockedExemptionIsBoundedSoTheAreaStillRetires`
- `StartBlockedFlagIsConsumedByOneDispatch`

## Test plan

- [ ] CI green on `feat/coverage-start-occupied-retry`.
- [ ] Field: reproduce by starting a mow with the robot parked inside a keepout — expect `transit REFUSED — nav2 START_OCCUPIED (code 205)` in the log, the `START_POSE_BLOCKED` state in the GUI, three exempted re-dispatches, then a clean retirement + dock instead of a silent 0 % "complete".
- [ ] Field: confirm a normal obstacle-blocked swath still logs `transit failed — nav2 NO_VALID_PATH/GOAL_OCCUPIED` and still skips (no behaviour change on the healthy path).
- [ ] Follow-up PR: escape motion, option B.

**Safety note for review:** this PR changes no blade logic and commands no new motion. The only behavioural change on the robot is that the coverage subtree stops, clears costmaps, waits, and retries where it previously abandoned the area.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
