### PR TITLE
fix(behavior): stop a targeted mow rolling over into the next area

### DIFF
--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -226,10 +226,16 @@ if(BUILD_TESTING)
   # real in-process get_mowing_area service returning a nav-only area + a mowing
   # area and ticks GetNextUnmowedArea to confirm the nav-only zone is never
   # selected for coverage.
+  # Also covers targeted runs (~/start_in_area): "mow only area N" is session
+  # state, so the run must not roll over into another area when the BT re-enters
+  # MowingSequence after the target completes. status_nodes/status_snapshot are
+  # linked in for the real EndSession node (the session boundary that clears it).
   ament_add_gtest(test_get_next_unmowed_area
     test/test_get_next_unmowed_area.cpp
     src/coverage_nodes.cpp
     src/coverage_persistence.cpp
+    src/status_nodes.cpp
+    src/status_snapshot.cpp
   )
 
   target_include_directories(test_get_next_unmowed_area PUBLIC

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -78,7 +78,8 @@ struct BTContext
   /// BT condition/action nodes.  Use std::lock_guard for RAII locking.
   ///
   /// Does NOT cover the coverage-tracking fields below (command state +
-  /// swath-completion model: target_area_index, attempted_areas,
+  /// swath-completion model: target_area_index, single_area_target,
+  /// attempted_areas,
   /// area_attempt_count, area_last_coverage, area_completed_swaths,
   /// area_swath_count, area_resume_pose_index, area_path_pose_count,
   /// area_plan_fingerprint, completed_areas, coverage_all_complete). Those
@@ -111,12 +112,31 @@ struct BTContext
   /// COMMAND_RESET_EMERGENCY=254, …).
   uint8_t current_command{0};
 
-  /// Set by ~/start_in_area service to request mowing a single, specific
-  /// area instead of iterating all areas. Consumed (and reset) by
-  /// GetNextUnmowedArea on its first call within a mowing run; once the
-  /// requested area is complete, the BT exits MowingSequence and docks
-  /// rather than rolling over to other areas.
+  /// Set by the ~/start_in_area service to REQUEST mowing a single, specific
+  /// area instead of iterating all areas. This is the one-shot *request*:
+  /// GetNextUnmowedArea consumes it on the next onStart() and latches the
+  /// index into single_area_target (below), which is what actually constrains
+  /// the run. Consuming it exactly once matters — it is also what triggers
+  /// the completed/attempted erase for an explicit re-mow.
   std::optional<int> target_area_index;
+
+  /// SESSION-scoped "single-area mode": the area index a targeted run
+  /// (~/start_in_area) is clipped to. Every GetNextUnmowedArea::onStart()
+  /// honours it, so the constraint survives the BT re-entering
+  /// MowingSequence after the targeted area finishes.
+  ///
+  /// It exists because the clip used to live ONLY in GetNextUnmowedArea's
+  /// own members (current_area_idx_ / max_areas_), which onStart() resets on
+  /// every entry, while target_area_index was consumed on the FIRST entry —
+  /// so the second entry had no memory of the request and iterated from area
+  /// 0. Field log 2026-08-24: "targeted run — mowing only area 1", ~56 min
+  /// later "area 0 selected" with no targeted-run line, i.e. the robot rolled
+  /// over into an area the operator never asked for.
+  ///
+  /// Cleared at the session boundary by EndSession, and by a plain
+  /// COMMAND_START (see clearSingleAreaMode) so the next full-lawn run
+  /// iterates normally.
+  std::optional<uint32_t> single_area_target;
 
   /// Areas already dispatched to PlanCoverageArea+FollowStrip in the
   /// current session. GetNextUnmowedArea skips any index in this set
@@ -598,5 +618,29 @@ struct BTContext
   // -----------------------------------------------------------------------
   rclcpp::Node::SharedPtr helper_node;
 };
+
+/// Drop any "mow only this area" constraint, so the next GetNextUnmowedArea
+/// run iterates every area normally.
+///
+/// Two callers, two reasons, and BOTH are needed:
+///   * EndSession — the real session boundary, alongside every other
+///     per-session set (attempted_areas, completed_areas, …). This is the
+///     normal path: a targeted run finishes its area, docks, EndSession runs.
+///   * the ~/high_level_control handler on a plain COMMAND_START — a mowing
+///     session does NOT always end with EndSession (a low-battery dock or an
+///     emergency deliberately keeps the session alive so mowing auto-resumes),
+///     so a stale single-area clip could otherwise still be latched when the
+///     operator presses the ordinary "Start" button and expects the whole
+///     lawn. The GUI's "mow this area" button calls ~/start_in_area, which
+///     sets current_command itself and never goes through that handler, so
+///     clearing there cannot cancel a targeted request.
+/// Also drops an unconsumed target_area_index: a request that was never
+/// picked up (e.g. start_in_area during an emergency) must not silently
+/// hijack a later plain start.
+inline void clearSingleAreaMode(BTContext& ctx)
+{
+  ctx.single_area_target.reset();
+  ctx.target_area_index.reset();
+}
 
 }  // namespace mowgli_behavior

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -79,8 +79,8 @@ struct BTContext
   ///
   /// Does NOT cover the coverage-tracking fields below (command state +
   /// swath-completion model: target_area_index, single_area_target,
-  /// attempted_areas,
-  /// area_attempt_count, area_last_coverage, area_completed_swaths,
+  /// attempted_areas, area_attempt_count, area_last_coverage,
+  /// area_completed_swaths,
   /// area_swath_count, area_resume_pose_index, area_path_pose_count,
   /// area_plan_fingerprint, completed_areas, coverage_all_complete). Those
   /// are mutated ONLY from this node's own BT action-node callbacks

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -566,6 +566,19 @@ private:
           {
             std::lock_guard<std::mutex> lock(context_->context_mutex);
             context_->current_command = cmd;
+            // A plain COMMAND_START means "mow the lawn", so it must cancel any
+            // single-area clip still latched from an earlier ~/start_in_area run.
+            // EndSession normally clears it, but a session can legitimately stay
+            // alive without one (low-battery dock + auto-resume, emergency), and
+            // the clip is session state by design — it has to survive
+            // GetNextUnmowedArea re-entering after the targeted area finishes.
+            // Safe to do here: the GUI's "mow this area" button calls
+            // ~/start_in_area, which sets current_command itself and never
+            // reaches this handler, so this cannot cancel a targeted request.
+            if (cmd == HighLevelControl::Request::COMMAND_START)
+            {
+              clearSingleAreaMode(*context_);
+            }
           }
           resp->success = true;
         });
@@ -573,9 +586,12 @@ private:
     RCLCPP_DEBUG(get_logger(), "~/high_level_control service server created");
 
     // ~/start_in_area: GUI hook for "mow this specific area only".
-    // Pre-loads target_area_index for the next GetNextUnmowedArea call,
-    // then issues COMMAND_START so MowingSequence picks it up. The BT
-    // exits after that single area is done (no roll-over to other areas).
+    // Pre-loads target_area_index for the next GetNextUnmowedArea call, then
+    // issues COMMAND_START so MowingSequence picks it up. GetNextUnmowedArea
+    // consumes that request once and latches it into
+    // BTContext::single_area_target, which constrains the run for as long as
+    // the session lasts — so the BT exits after that single area is done (no
+    // roll-over to other areas) even though it re-enters MowingSequence.
     using StartInArea = mowgli_interfaces::srv::StartInArea;
     start_in_area_srv_ = create_service<StartInArea>(
         "~/start_in_area",

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -1488,32 +1488,55 @@ BT::NodeStatus GetNextUnmowedArea::onStart()
   // thread-only.
   ctx->coverage_all_complete = false;
 
-  // Honor a one-shot user-selected target area (set by ~/start_in_area).
-  // We start the iteration from the requested index AND clip max_areas_ to
-  // (target + 1) so the BT mows just that area and exits MowingSequence,
-  // instead of rolling over to the next area. The optional is consumed
-  // here so subsequent COMMAND_START runs use the normal ordering.
+  // Honor a user-selected target area (set by ~/start_in_area). Deliberately
+  // two-stage:
+  //
+  //  (1) ctx->target_area_index is the ONE-SHOT *request*. Consuming it here
+  //      latches the index into ctx->single_area_target and — exactly once per
+  //      request — erases that area's stale completed/attempted flags.
+  //  (2) ctx->single_area_target is SESSION state, honoured on EVERY onStart().
+  //
+  // The clip cannot live in this node's members alone: onStart() resets them
+  // and runs again every time the BT re-enters MowingSequence — including
+  // immediately after the targeted area completes. With the constraint held
+  // only in the consumed optional, that second entry started from area 0 and
+  // the robot rolled over into an area the operator never selected (field log
+  // 2026-08-24: "mowing only area 1" … 56 min later "area 0 selected", no
+  // targeted-run line). Now the second entry re-applies the clip, the skip
+  // loop below finds the target already completed, and the run ends via
+  // coverage_all_complete → MOWING_COMPLETE → dock.
   if (ctx->target_area_index.has_value())
   {
     const int target = *ctx->target_area_index;
     if (target >= 0)
     {
-      current_area_idx_ = static_cast<uint32_t>(target);
-      max_areas_ = current_area_idx_ + 1;
+      ctx->single_area_target = static_cast<uint32_t>(target);
       // Explicit single-area re-mow: clear any stale completed/attempted flag
       // for THIS target so the skip loop below cannot advance past it. Without
       // this, re-selecting an area already mown this session (sets are only
       // cleared by EndSession) makes the skip loop overshoot max_areas_ →
       // "all areas completed" → FAILURE → the requested area never mows.
-      // Guarded to the explicit-target path only, so normal COMMAND_START
-      // iteration still honors completed/attempted skipping.
-      ctx->completed_areas.erase(current_area_idx_);
-      ctx->attempted_areas.erase(current_area_idx_);
-      RCLCPP_INFO(ctx->node->get_logger(),
-                  "GetNextUnmowedArea: targeted run — mowing only area %u (single-area mode)",
-                  current_area_idx_);
+      // Tied to the ONE-SHOT request (not to single_area_target) on purpose:
+      // repeating the erase on every onStart() would wipe the completion the
+      // targeted area just earned and re-mow it forever. Guarded to the
+      // explicit-target path, so normal COMMAND_START iteration still honors
+      // completed/attempted skipping.
+      ctx->completed_areas.erase(*ctx->single_area_target);
+      ctx->attempted_areas.erase(*ctx->single_area_target);
     }
     ctx->target_area_index.reset();
+  }
+
+  // Apply the session-scoped clip: start the iteration at the requested index
+  // AND clip max_areas_ to (target + 1) so the BT mows just that area and then
+  // exits MowingSequence instead of rolling over to the next area.
+  if (ctx->single_area_target.has_value())
+  {
+    current_area_idx_ = *ctx->single_area_target;
+    max_areas_ = current_area_idx_ + 1;
+    RCLCPP_INFO(ctx->node->get_logger(),
+                "GetNextUnmowedArea: targeted run — mowing only area %u (single-area mode)",
+                current_area_idx_);
   }
 
   // Skip any area that has already burned its attempt budget this
@@ -1534,8 +1557,21 @@ BT::NodeStatus GetNextUnmowedArea::onStart()
   }
   if (current_area_idx_ >= max_areas_)
   {
-    RCLCPP_INFO(ctx->node->get_logger(),
-                "GetNextUnmowedArea: all areas already completed/attempted this session");
+    if (ctx->single_area_target.has_value())
+    {
+      // The targeted area is done (or gave up). This is the CLEAN exit of a
+      // targeted run: coverage_all_complete routes the tree to
+      // MOWING_COMPLETE + dock, not to COVERAGE_FAILED_DOCKING.
+      RCLCPP_INFO(ctx->node->get_logger(),
+                  "GetNextUnmowedArea: targeted area %u finished — ending the run "
+                  "(no roll-over to other areas)",
+                  *ctx->single_area_target);
+    }
+    else
+    {
+      RCLCPP_INFO(ctx->node->get_logger(),
+                  "GetNextUnmowedArea: all areas already completed/attempted this session");
+    }
     ctx->coverage_all_complete = true;  // genuine completion → MOWING_COMPLETE
     return BT::NodeStatus::FAILURE;
   }

--- a/ros2/src/mowgli_behavior/src/coverage_persistence.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_persistence.cpp
@@ -63,6 +63,14 @@ bool saveCoverageResumeState(const BTContext& ctx)
   // file (clearCoverageResumeState), so a stale active command is never left on
   // disk.
   out << "current_command " << static_cast<unsigned>(ctx.current_command) << '\n';
+  // Single-area mode (a ~/start_in_area targeted run). Persisted for the same
+  // reason as current_command: a restart mid-run auto-re-enters MowingSequence,
+  // and without this the restored run would silently widen into a mow-the-whole-
+  // lawn run the moment the targeted area finished. Absent line = not targeted.
+  if (ctx.single_area_target.has_value())
+  {
+    out << "single_area_target " << *ctx.single_area_target << '\n';
+  }
   out << "current_area " << ctx.current_area << '\n';
   out << "completed_areas";
   for (uint32_t idx : ctx.completed_areas)
@@ -145,6 +153,15 @@ bool loadCoverageResumeState(BTContext& ctx)
       unsigned v;
       if (ls >> v)
         ctx.current_command = static_cast<uint8_t>(v);
+    }
+    else if (tag == "single_area_target")
+    {
+      // Absent in files written before targeted runs became session state (and
+      // in every non-targeted run) → single_area_target stays empty, i.e. the
+      // normal all-areas iteration.
+      uint32_t v;
+      if (ls >> v)
+        ctx.single_area_target = v;
     }
     else if (tag == "current_area")
     {

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -210,6 +210,12 @@ BT::NodeStatus EndSession::tick()
   ctx->area_path_pose_count.clear();
   ctx->area_plan_fingerprint.clear();
   ctx->completed_areas.clear();
+  // Drop any "mow only area N" constraint from a targeted run (~/start_in_area)
+  // at the same boundary as every other per-session set, so the next plain
+  // COMMAND_START mows the whole lawn again. The clip is session state (it must
+  // survive GetNextUnmowedArea re-entering after the targeted area finishes, or
+  // the run rolls over into the next area), so THIS is where it dies.
+  clearSingleAreaMode(*ctx);
   // Remove the on-disk resume snapshot too: this is a real session boundary, so
   // the next COMMAND_START must start fresh rather than resume a finished (or
   // aborted-and-docked) session from the persisted cursor.

--- a/ros2/src/mowgli_behavior/test/test_coverage_persistence.cpp
+++ b/ros2/src/mowgli_behavior/test/test_coverage_persistence.cpp
@@ -197,6 +197,50 @@ TEST(CoveragePersistence, AbsentCurrentCommandDefaultsToIdle)
   std::remove(path.c_str());
 }
 
+TEST(CoveragePersistence, RoundTripsSingleAreaTarget)
+{
+  // A targeted run (~/start_in_area) must stay targeted across a restart: the
+  // restored current_command auto-re-enters MowingSequence, so without this the
+  // run would silently widen into a mow-the-whole-lawn run once the requested
+  // area finished.
+  const std::string path = tempPath("coverage_resume_single_area.txt");
+  std::remove(path.c_str());
+
+  BTContext saved;
+  seedContext(saved, path);
+  saved.current_command = 1;
+  saved.single_area_target = 3u;
+  ASSERT_TRUE(saveCoverageResumeState(saved));
+
+  BTContext loaded;
+  loaded.coverage_resume_path = path;
+  ASSERT_TRUE(loadCoverageResumeState(loaded));
+  ASSERT_TRUE(loaded.single_area_target.has_value());
+  EXPECT_EQ(*loaded.single_area_target, 3u);
+
+  std::remove(path.c_str());
+}
+
+TEST(CoveragePersistence, AbsentSingleAreaTargetMeansAllAreas)
+{
+  // Absent in every non-targeted run (and in files written before targeted runs
+  // became session state) — that must read back as "no clip", not as area 0.
+  const std::string path = tempPath("coverage_resume_no_single_area.txt");
+  std::remove(path.c_str());
+
+  BTContext saved;
+  seedContext(saved, path);
+  saved.current_command = 1;
+  ASSERT_TRUE(saveCoverageResumeState(saved));
+
+  BTContext loaded;
+  loaded.coverage_resume_path = path;
+  ASSERT_TRUE(loadCoverageResumeState(loaded));
+  EXPECT_FALSE(loaded.single_area_target.has_value());
+
+  std::remove(path.c_str());
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
+++ b/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
@@ -25,6 +25,11 @@
  * so the skip lives on the BT selection side. These tests stand up a REAL
  * in-process get_mowing_area service (no robot, no mocked interfaces) and tick
  * the StatefulActionNode to verify a nav-only area is never selected.
+ *
+ * It also covers TARGETED runs (~/start_in_area, "mow only this area"): the
+ * single-area constraint is session state, so a run must not roll over into
+ * another area when the BT re-enters MowingSequence after the requested area
+ * completes (field regression, 2026-08-24).
  */
 
 #include <chrono>
@@ -38,10 +43,13 @@
 #include "behaviortree_cpp/bt_factory.h"
 #include "mowgli_behavior/bt_context.hpp"
 #include "mowgli_behavior/coverage_nodes.hpp"
+#include "mowgli_behavior/status_nodes.hpp"
 #include "mowgli_interfaces/srv/get_mowing_area.hpp"
 #include <gtest/gtest.h>
 
 using mowgli_behavior::BTContext;
+using mowgli_behavior::clearSingleAreaMode;
+using mowgli_behavior::EndSession;
 using mowgli_behavior::GetNextUnmowedArea;
 using GetMowingArea = mowgli_interfaces::srv::GetMowingArea;
 
@@ -99,6 +107,7 @@ protected:
     blackboard->set("context", ctx);
 
     factory.registerNodeType<GetNextUnmowedArea>("GetNextUnmowedArea");
+    factory.registerNodeType<EndSession>("EndSession");
 
     server_node = rclcpp::Node::make_shared("fake_map_server");
     service = server_node->create_service<GetMowingArea>(
@@ -165,6 +174,18 @@ protected:
         "<GetNextUnmowedArea max_areas=\"" +
         std::to_string(max_areas) +
         "\" area_index=\"{area_index}\"/>"
+        "</BehaviorTree></root>";
+    return factory.createTreeFromText(xml, blackboard);
+  }
+
+  /// A bare <EndSession/> tree — the real session-boundary node, so the
+  /// "cleared at session end" assertion exercises production code rather than
+  /// a hand-rolled reset.
+  BT::Tree makeEndSessionTree()
+  {
+    const std::string xml =
+        "<root BTCPP_format=\"4\"><BehaviorTree ID=\"MainTree\">"
+        "<EndSession/>"
         "</BehaviorTree></root>";
     return factory.createTreeFromText(xml, blackboard);
   }
@@ -289,4 +310,150 @@ TEST_F(GetNextUnmowedAreaTest, StartBlockedFlagIsConsumedByOneDispatch)
   EXPECT_EQ(ctx->area_start_blocked_count[0u], 1u);
   EXPECT_EQ(ctx->area_attempt_count[0u], 0u)
       << "the exempted dispatch must not have advanced the no-progress counter";
+}
+
+// ---------------------------------------------------------------------------
+// Targeted run (~/start_in_area): mow ONE area, then stop — no roll-over.
+//
+// Field log 2026-08-24: "StartInArea: received area=1" → "targeted run — mowing
+// only area 1 (single-area mode)" → ~56 min of mowing → "area 0 selected" with
+// NO targeted-run line. The BT re-enters MowingSequence when the targeted area
+// completes, so GetNextUnmowedArea::onStart() runs again; the clip used to live
+// only in members onStart() resets plus a one-shot optional consumed on the
+// first entry, so the second entry iterated from area 0 and the robot mowed an
+// area the operator never selected.
+// ---------------------------------------------------------------------------
+
+// The regression itself: the dispatch that follows the targeted area's
+// completion must NOT select another area.
+TEST_F(GetNextUnmowedAreaTest, TargetedRunDoesNotRollOverToTheNextArea)
+{
+  areas[0] = {"front_lawn", /*is_navigation_area=*/false};
+  areas[1] = {"back_lawn", /*is_navigation_area=*/false};
+  areas[2] = {"side_strip", /*is_navigation_area=*/false};
+  waitForService();
+
+  // Operator picks area 1 in the GUI (~/start_in_area).
+  ctx->target_area_index = 1;
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+    EXPECT_EQ(ctx->current_area, 1);
+  }
+  // The one-shot request is consumed, but the constraint is now session state.
+  EXPECT_FALSE(ctx->target_area_index.has_value());
+  ASSERT_TRUE(ctx->single_area_target.has_value());
+  EXPECT_EQ(*ctx->single_area_target, 1u);
+
+  // FollowStrip mows area 1 to completion, and the BT re-enters MowingSequence.
+  ctx->completed_areas.insert(1u);
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::FAILURE)
+        << "a targeted run must end after its area, not roll over to another";
+  }
+  EXPECT_EQ(ctx->current_area, 1) << "no other area may be selected for mowing";
+  uint32_t selected = 99;
+  ASSERT_TRUE(blackboard->get("area_index", selected));
+  EXPECT_EQ(selected, 1u);
+  // FAILURE + coverage_all_complete is the CLEAN exit: the tree routes it to
+  // MOWING_COMPLETE + dock (CoverageCompleteDock), not COVERAGE_FAILED_DOCKING.
+  EXPECT_TRUE(ctx->coverage_all_complete)
+      << "a finished targeted run must dock via MOWING_COMPLETE, not report a coverage failure";
+}
+
+// An explicitly targeted area is re-mown even when it is already marked
+// completed/attempted this session (the operator asked for it on purpose).
+TEST_F(GetNextUnmowedAreaTest, TargetedRunReMowsAnAlreadyCompletedArea)
+{
+  areas[0] = {"front_lawn", /*is_navigation_area=*/false};
+  areas[1] = {"back_lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  ctx->completed_areas.insert(1u);
+  ctx->attempted_areas.insert(1u);
+
+  ctx->target_area_index = 1;
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS)
+      << "an explicit re-mow request must clear the stale completed/attempted flags";
+  EXPECT_EQ(ctx->current_area, 1);
+}
+
+// ...but that erase is tied to the ONE-SHOT request, not to the session flag:
+// repeating it on every onStart() would wipe the completion the targeted area
+// just earned and re-mow it forever.
+TEST_F(GetNextUnmowedAreaTest, TargetedRunDoesNotReMowItsOwnCompletedArea)
+{
+  areas[0] = {"front_lawn", /*is_navigation_area=*/false};
+  areas[1] = {"back_lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  ctx->target_area_index = 1;
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  }
+  ctx->completed_areas.insert(1u);
+
+  // Two further re-entries: both must end the run, never re-select area 1.
+  for (int i = 0; i < 2; ++i)
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::FAILURE) << "re-entry " << i;
+    EXPECT_GT(ctx->completed_areas.count(1u), 0u)
+        << "the targeted area's completion must survive re-entry " << i;
+  }
+}
+
+// A plain COMMAND_START after a targeted run iterates all areas again. The
+// clear is production code (clearSingleAreaMode), called by the
+// ~/high_level_control handler on COMMAND_START.
+TEST_F(GetNextUnmowedAreaTest, PlainStartAfterATargetedRunIteratesAllAreas)
+{
+  areas[0] = {"front_lawn", /*is_navigation_area=*/false};
+  areas[1] = {"back_lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  ctx->target_area_index = 1;
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+    ASSERT_EQ(ctx->current_area, 1);
+  }
+  ctx->completed_areas.insert(1u);
+
+  // Operator presses the ordinary "Start" button — same session (no EndSession,
+  // as after a low-battery dock + resume).
+  clearSingleAreaMode(*ctx);
+
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->current_area, 0) << "a plain start must resume normal all-areas iteration";
+}
+
+// EndSession is the session boundary: the single-area clip dies there with the
+// other per-session sets, so the next session starts unconstrained.
+TEST_F(GetNextUnmowedAreaTest, EndSessionClearsSingleAreaMode)
+{
+  areas[0] = {"front_lawn", /*is_navigation_area=*/false};
+  areas[1] = {"back_lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  ctx->target_area_index = 1;
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+    ASSERT_TRUE(ctx->single_area_target.has_value());
+  }
+
+  auto end_tree = makeEndSessionTree();
+  ASSERT_EQ(end_tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->single_area_target.has_value());
+  EXPECT_FALSE(ctx->target_area_index.has_value());
+
+  // Next session: normal iteration from area 0.
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->current_area, 0);
 }


### PR DESCRIPTION
## Problem

A targeted mow — the GUI's "mow this area" button (`~/start_in_area` → `COMMAND_START`) — mowed the requested area and then **rolled over into another area** instead of stopping and docking.

Field log, robot, 2026-08-24:

```
1787590666  StartInArea: received area=1
1787590684  GetNextUnmowedArea: targeted run — mowing only area 1 (single-area mode)
1787590684  GetNextUnmowedArea: area 1 selected (0 swath(s) done so far) — dispatch attempt 1/5
            ... ~56 minutes mowing area 1 ...
1787594063  GetNextUnmowedArea: area 0 selected (0 swath(s) done so far) — dispatch attempt 1/5   <-- BUG
1787594113  HighLevelControl: received command=2   (operator had to send it home)
```

Note the second selection carries **no** "targeted run" line.

## Root cause

The single-area constraint lived only in `GetNextUnmowedArea`'s own members:

* `onStart()` resets `current_area_idx_ = 0` on **every** entry;
* the clip (`current_area_idx_ = target; max_areas_ = target + 1;`) was applied only from `ctx->target_area_index`, which `onStart()` **consumed** on first use.

The BT re-enters `MowingSequence` once the targeted area completes, so that second `onStart()` had nothing left to read — the clip was gone and it iterated from area 0. Consuming the optional on the first *tick* cannot distinguish a later tick of the SAME run from a NEW run.

## Fix — single-area mode becomes session state

* **`BTContext::single_area_target`** holds the clip for the whole session. `target_area_index` stays the one-shot *request*: consuming it latches `single_area_target` and — still exactly once per request — erases that area's stale `completed_areas`/`attempted_areas` flags, so an explicit re-mow of an already-mown area is not skipped. Keeping the erase tied to the request is load-bearing: repeating it on every `onStart()` would wipe the completion the targeted area just earned and re-mow it forever.
* **`onStart()` honours `single_area_target` on every entry.** The follow-up entry now finds the target already completed, the skip loop overshoots `max_areas_`, and the node sets `coverage_all_complete` + returns `FAILURE`.
* **Clean exit confirmed:** that `FAILURE` + `coverage_all_complete` combination is exactly what `CoverageEnded` → `IsCoverageComplete` → `CoverageCompleteDock` consumes, i.e. **mow area N → `MOWING_COMPLETE` → dock**, not `COVERAGE_FAILED_DOCKING`.
* **Cleared in two places, both needed** (justified in comments at each site):
  * `EndSession` — the real session boundary, alongside every other per-session set. The normal path.
  * the `~/high_level_control` handler on a plain `COMMAND_START` — a session can legitimately outlive a dock (low-battery auto-resume, emergency keep it alive so mowing resumes), so a stale clip could still be latched when the operator presses the ordinary Start button expecting the whole lawn. Safe: the GUI's per-area button calls `~/start_in_area`, which sets `current_command` itself and never reaches that handler, so this cannot cancel a targeted request. It also drops an unconsumed `target_area_index` so a request that was never picked up can't hijack a later plain start.
* **Persisted** in the coverage resume snapshot next to `current_command`: that restored command auto-re-enters `MowingSequence` after a container restart, so without persisting the clip a restarted targeted run silently widened into a whole-lawn run again. An absent line = not targeted (backward compatible).

## Tests

`test_get_next_unmowed_area.cpp` (real in-process `get_mowing_area` service, real BT ticks):

* `TargetedRunDoesNotRollOverToTheNextArea` — the dispatch after the target completes selects nothing and reports `coverage_all_complete` (**fails on `dev`**: it selects area 0)
* `TargetedRunReMowsAnAlreadyCompletedArea` — the existing completed/attempted erase is preserved
* `TargetedRunDoesNotReMowItsOwnCompletedArea` — the erase does not repeat on re-entry
* `PlainStartAfterATargetedRunIteratesAllAreas` — via the production `clearSingleAreaMode`
* `EndSessionClearsSingleAreaMode` — ticks the real `EndSession` node

`test_coverage_persistence.cpp`: `RoundTripsSingleAreaTarget`, `AbsentSingleAreaTargetMeansAllAreas`.

`status_nodes.cpp` + `status_snapshot.cpp` were added to the `test_get_next_unmowed_area` target so the session-end assertion exercises the real `EndSession` rather than a hand-rolled reset.

## Safety

No change to blade commands, motion, or firmware interaction. The behavioural change is strictly *narrowing*: a targeted run now stops where the operator asked instead of mowing an area they did not select.

## Test plan

- [ ] CI green on `feat/targeted-mow-single-area`
- [ ] Robot: GUI → "mow this area" on a non-zero area → confirm the log shows the targeted-run line on the follow-up dispatch and then `targeted area N finished — ending the run`, followed by `MOWING_COMPLETE` + dock (not another area, not `COVERAGE_FAILED_DOCKING`)
- [ ] Robot: plain Start afterwards mows all areas from index 0
- [ ] Robot: targeted run interrupted by a container restart stays targeted

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
