### PR TITLE
Turn-geometry guard, connector fallback counter, and mowing_speed-derived turn speed (#499)

### DIFF
--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -267,6 +267,29 @@ mowgli:
     mowing_enabled: true
     mowing_speed: 0.2              # m/s during coverage paths (field-validated comfortable cut speed)
     transit_speed: 0.2             # m/s during point-to-point navigation (→ RPP desired_linear_vel)
+    # turn_speed_ratio: the coverage controller's speed THROUGH a bend, as a
+    # fraction of mowing_speed. Injected at launch as
+    # FollowCoveragePath.speed_slow = clamp(mowing_speed * turn_speed_ratio,
+    # min_speed_mps, mowing_speed) — see navigation.launch.py.
+    #
+    # WHY IT EXISTS (issue #499): speed_slow used to be a STATIC 0.16 in
+    # nav2_params_base.yaml while speed_fast tracked the operator's mowing_speed.
+    # An operator who lowered mowing_speed to 0.15 therefore ended up driving the
+    # swath-end TURNS 7 % FASTER than the straights — exactly backwards, and
+    # exactly where the robot carves the lawn. Deriving it from mowing_speed
+    # makes the speed slider apply to turns too, and (with a ratio <= 1) makes a
+    # turn never faster than a straight.
+    #
+    # 0.8 reproduces the historical 0.16 / 0.20 pair, so this is a no-op for a
+    # robot on the default mowing_speed. LOWER it to take heat out of swath-end
+    # turns: wheel speeds in a bend scale linearly with it (v_outer =
+    # v*(1 + track/2R)), so 0.6 removes ~25 % of the peak outer-wheel speed.
+    # It does NOT change the inner/outer wheel RATIO — that is set by the turn
+    # RADIUS against the half-track and is speed-independent (issue #499).
+    # Clamped to (0, 1.0] at launch; the effective speed is additionally floored
+    # at FollowCoveragePath.min_speed_mps, below which FTC's own floor would
+    # override it anyway (and the wheels stall under the firmware deadband).
+    turn_speed_ratio: 0.8
     # mow_angle_deg: swath direction. -1 (or any negative) = AUTO — the coverage
     # server picks the swath-count-minimising angle (F2C NSwath). 0..179 forces a
     # fixed swath angle in degrees. Flows to the BT (behavior_tree_node blackboard)

--- a/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
+++ b/ros2/src/mowgli_bringup/config/nav2_params_base.yaml
@@ -337,13 +337,23 @@ controller_server:
     # F2C route as one continuous goal — FTC tracks it; no per-swath feeding.
     FollowCoveragePath:
       plugin: "mowgli_nav2_plugins/FTCController"
-      # Carrot speed. speed_fast is overridden at launch by mowing_speed.
+      # Carrot speed. BOTH are overridden at launch (navigation.launch.py):
+      #   speed_fast = mowing_speed
+      #   speed_slow = clamp(mowing_speed * turn_speed_ratio,
+      #                      min_speed_mps, mowing_speed)
+      # Editing the literals below therefore does NOT change the running robot —
+      # change mowing_speed / turn_speed_ratio in mowgli_robot.yaml instead.
       speed_fast: 0.20
       speed_fast_threshold: 0.5
       speed_fast_threshold_angle: 10.0
-      # 0.16 kept conservative. The host clamp is now the RUNTIME param
-      # min_linear_vel (hardware_bridge_node.cpp, default 0.05 — not the old
-      # kMinLinVel=0.15), so this MAY be lowered.
+      # speed_slow is FTC's target wherever the path BENDS — every swath-end
+      # turn-around arc and every headland corner fillet. It used to be a STATIC
+      # 0.16 while speed_fast tracked the operator's mowing_speed, so an operator
+      # on mowing_speed=0.15 drove the TURNS 7 % FASTER than the straights —
+      # backwards everywhere, and worst exactly where the robot carves the lawn
+      # (issue #499). It is now derived; this literal is the fallback for a
+      # launch that cannot read the robot config, and 0.16 == 0.8 x the 0.20
+      # above, so the derived value reproduces it for a default robot.
       speed_slow: 0.16
       speed_angular: 45.0
       acceleration: 0.2

--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -72,7 +72,14 @@ from nav2_common.launch import RewrittenYaml
 # with the selected lidar/no-lidar overlay — one tested recursive-merge
 # implementation instead of a per-file copy that can drift.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from robot_config_util import DEFAULT_TOOL_WIDTH_M, deep_merge, load_robot_params  # noqa: E402
+from robot_config_util import (  # noqa: E402
+    DEFAULT_TOOL_WIDTH_M,
+    DEFAULT_WHEEL_TRACK_M,
+    check_turn_geometry,
+    deep_merge,
+    derive_turn_speed,
+    load_robot_params,
+)
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -374,6 +381,16 @@ def generate_launch_description() -> LaunchDescription:
     # Injected into coverage_server.connector_turn_radius; operator-tunable via
     # mowgli_robot.yaml (raise toward 0.30 if the tighter turns hesitate).
     connector_turn_radius = 0.18
+    # wheel_track: centre-to-centre wheel distance. NOT injected into anything
+    # here — it is read so the turn-geometry check below can compare the planned
+    # turn radii against the HALF-track. Must match the firmware WHEEL_BASE that
+    # does the actual differential-drive IK (left = vx - wz*track/2).
+    wheel_track = DEFAULT_WHEEL_TRACK_M
+    # turn_speed_ratio: FollowCoveragePath.speed_slow as a fraction of
+    # mowing_speed. See the mowgli_robot.yaml template for the rationale
+    # (issue #499 — speed_slow used to be static, so turns ran FASTER than the
+    # straights whenever the operator lowered mowing_speed).
+    turn_speed_ratio = 0.8
     # Fallback if progress_timeout_sec is absent from the resolved robot config
     # (normally the mowgli_robot.yaml template supplies it — default 30.0, see
     # #396). Kept equal to that default so the effective timeout is one number.
@@ -547,6 +564,8 @@ def generate_launch_description() -> LaunchDescription:
             "num_headland_passes", num_headland_passes))
         mow_direction = int(rt_rp.get("mow_direction", mow_direction))
         swath_overlap = float(rt_rp.get("swath_overlap", swath_overlap))
+        wheel_track = float(rt_rp.get("wheel_track", wheel_track))
+        turn_speed_ratio = float(rt_rp.get("turn_speed_ratio", turn_speed_ratio))
         min_turning_radius = float(rt_rp.get(
             "min_turning_radius", min_turning_radius))
         connector_turn_radius = float(rt_rp.get(
@@ -724,6 +743,45 @@ def generate_launch_description() -> LaunchDescription:
         if mowing_speed > ftc_speed_cap:
             fcp["max_cmd_vel_speed"] = mowing_speed
 
+        # ── Turn speed: derived from mowing_speed, not static (issue #499) ──
+        #
+        # speed_slow is FTC's carrot target wherever the path BENDS — every
+        # swath-end turn-around arc and every headland corner fillet. It used to
+        # be a STATIC value in nav2_params_base.yaml while speed_fast tracked the
+        # operator's mowing_speed, so lowering mowing_speed made the TURNS faster
+        # than the straights: backwards everywhere, and worst exactly where the
+        # robot carves the lawn. The arithmetic and both clamp rationales live in
+        # robot_config_util.derive_turn_speed — pure and unit-tested, because this
+        # launch file imports launch/launch_ros and cannot be imported outside a
+        # sourced ROS2 install.
+        turn_speed, turn_speed_warnings = derive_turn_speed(
+            mowing_speed, turn_speed_ratio, float(fcp.get("min_speed_mps", 0.15)))
+        for line in turn_speed_warnings:
+            print(line)
+        fcp["speed_slow"] = turn_speed
+
+        # Effective turn radii — the CLAMPED values actually injected into
+        # coverage_server further down. Computed here so the geometry check below
+        # reports the numbers the planner really receives, not the raw yaml values
+        # it would have clamped away. Clamp to the tuned [0.10, 0.50] band
+        # (sub-0.10 loops are untrackable, >0.50 bulges out of bounds);
+        # connector_turn_radius is additionally held at or above the floor —
+        # buildConnector floors it anyway, but the injected pair stays coherent.
+        eff_min_turn_radius = min(0.50, max(0.10, min_turning_radius))
+        eff_connector_turn_radius = min(
+            0.50, max(eff_min_turn_radius, connector_turn_radius))
+
+        # ── Turn-geometry sanity check (issue #499) ─────────────────────────
+        # WARN-only by design — see check_turn_geometry for why hard-failing here
+        # would brick every existing robot's navigation stack rather than protect
+        # it. wheel_track comes from the robot config, never a literal.
+        for line in check_turn_geometry(eff_min_turn_radius,
+                                        eff_connector_turn_radius,
+                                        wheel_track,
+                                        turn_speed,
+                                        float(fcp.get("max_cmd_vel_ang", 0.8))):
+            print(line)
+
         # Obstacle-avoidance knobs (GUI: Settings → Obstacles).
         # max_obstacle_avoidance_distance historically only reached
         # map_server.bypass_max_length (full_system.launch.py) while FTC's
@@ -863,13 +921,11 @@ def generate_launch_description() -> LaunchDescription:
         # Hard floor on the continuous path's turn-around / fillet arcs so no
         # turn is ever tighter than the robot can track (clamp to the tuned
         # [0.10, 0.50] band; sub-0.10 loops are untrackable, >0.50 bulges OOB).
-        cov_params["min_turning_radius"] = min(0.50, max(0.10, min_turning_radius))
+        cov_params["min_turning_radius"] = eff_min_turn_radius
         # Nominal turn-around radius for the continuous path (compact U vs big
-        # teardrop). Clamp to a sane band and never below the trackable floor:
-        # buildConnector floors it at min_turning_radius anyway, but keep the
-        # injected value coherent.
-        cov_params["connector_turn_radius"] = min(
-            0.50, max(min(0.50, max(0.10, min_turning_radius)), connector_turn_radius))
+        # teardrop). Clamped alongside the floor above (eff_min_turn_radius) so the
+        # geometry check and the injected value can never describe different plans.
+        cov_params["connector_turn_radius"] = eff_connector_turn_radius
 
         tmp = tempfile.NamedTemporaryFile(
             mode="w", prefix="mowgli_nav2_", suffix=".yaml", delete=False)

--- a/ros2/src/mowgli_bringup/launch/robot_config_util.py
+++ b/ros2/src/mowgli_bringup/launch/robot_config_util.py
@@ -46,6 +46,22 @@ DEFAULT_RUNTIME_PATH = "/ros2_ws/config/mowgli_robot.yaml"
 # test_tool_width_single_source.py).
 DEFAULT_TOOL_WIDTH_M = 0.18
 
+# Wheel track (distance between wheel centres, m). Fallback used ONLY if the
+# resolved robot config carries no "wheel_track" key — the LIVE default is
+# mowgli_bringup/config/mowgli_robot.yaml's wheel_track (Invariant 15).
+#
+# Single-sourced here for the same reason as DEFAULT_TOOL_WIDTH_M: more than one
+# consumer needs it and they must not each hardcode their own literal. It MUST
+# equal the firmware's WHEEL_BASE (firmware/stm32/ros_usbnode/include/board.h)
+# and hardware_bridge_node's wheel_track default — the firmware does the
+# differential-drive IK (left = vx - wz*track/2) with ITS copy, so a host value
+# that disagrees makes every derived turn geometry a lie.
+#
+# navigation.launch.py uses it to check the planned turn radii against the
+# HALF-track: an arc of radius <= track/2 needs the inner wheel to stop or
+# reverse, which is the swath-end carving in issue #499.
+DEFAULT_WHEEL_TRACK_M = 0.325
+
 
 def deep_merge(base, override):
     """Recursively merge ``override`` into a copy of ``base`` (override wins).
@@ -97,3 +113,126 @@ def load_robot_params(bringup_dir, runtime_path=DEFAULT_RUNTIME_PATH):
     """
     cfg = load_robot_config(bringup_dir, runtime_path)
     return cfg.get("mowgli", {}).get("ros__parameters", {})
+
+
+# ---------------------------------------------------------------------------
+# Coverage turn geometry / turn speed (issue #499)
+# ---------------------------------------------------------------------------
+#
+# The swath-end turns that carve the lawn come from two numbers that must be
+# consistent but live in different files with nothing relating them:
+#
+#   * coverage_server's turn radii  — mowgli_robot.yaml (min_turning_radius,
+#     connector_turn_radius), the floor and nominal of buildConnector's
+#     radius-shrink search;
+#   * FollowCoveragePath's clamps   — nav2_params_base.yaml (speed_slow,
+#     max_cmd_vel_ang), which bound what the controller can actually command.
+#
+# These two helpers are PURE so the arithmetic is unit-testable without a ROS2
+# runtime (navigation.launch.py cannot be imported outside a sourced install).
+# navigation.launch.py owns the printing; these own the decisions.
+
+
+def derive_turn_speed(mowing_speed, turn_speed_ratio, min_speed_mps):
+    """Turn speed (FollowCoveragePath.speed_slow) derived from mowing_speed.
+
+    Returns ``(speed, warnings)`` — ``warnings`` is a list of human-readable
+    strings the caller prints; an empty list means nothing was clamped.
+
+    speed_slow used to be a STATIC 0.16 in nav2_params_base.yaml while
+    speed_fast tracked the operator's mowing_speed, so an operator who lowered
+    mowing_speed to 0.15 ended up driving the swath-end TURNS 7 % FASTER than
+    the straights — backwards everywhere, and worst exactly where the robot
+    carves (peak wheel speed in a bend is v * (1 + track/2R), so turn speed
+    multiplies the whole problem).
+
+    Two clamps, both encoding a real limit rather than taste:
+      * ceiling ``mowing_speed`` — a turn must never be faster than a straight.
+        That is the defect being fixed, and it is also what a ratio > 1 means.
+      * floor ``min_speed_mps``  — FTC floors its own longitudinal output there,
+        so a lower target is a value the controller would silently ignore (and
+        below the firmware PWM deadband the wheels simply stall). Say so rather
+        than inject a fiction.
+    """
+    warnings = []
+    ratio = min(1.0, max(0.01, float(turn_speed_ratio)))
+    if ratio != float(turn_speed_ratio):
+        warnings.append(
+            "WARN: turn_speed_ratio={} is outside (0, 1.0] — clamped to {}. A ratio "
+            "above 1.0 would drive swath-end turns FASTER than the straights, which "
+            "is the issue #499 defect.".format(turn_speed_ratio, ratio))
+    speed = ratio * float(mowing_speed)
+    if speed < float(min_speed_mps):
+        warnings.append(
+            "WARN: turn_speed_ratio={} x mowing_speed={} = {:.3f} m/s is below "
+            "FollowCoveragePath.min_speed_mps={} m/s, which FTC would floor anyway "
+            "— using {} m/s. Lower min_speed_mps (and mind the ~0.13 m/s firmware "
+            "PWM deadband) if you need slower turns.".format(
+                ratio, mowing_speed, speed, min_speed_mps, min_speed_mps))
+        speed = float(min_speed_mps)
+    # Never above the straight-line speed — the defect this replaces.
+    return min(speed, float(mowing_speed)), warnings
+
+
+def check_turn_geometry(min_turn_radius, connector_turn_radius, wheel_track,
+                        turn_speed, max_cmd_vel_ang):
+    """Report ways the PLANNED coverage turn radii are undrivable as planned.
+
+    Returns a list of human-readable WARN strings (empty = geometry is sane).
+
+    WARNINGS ONLY — never an exception — and that is load-bearing:
+
+      1. the CURRENTLY SHIPPED defaults trip check A (min_turning_radius 0.15 <=
+         half-track 0.1625), so raising would refuse to start navigation on every
+         existing robot, turning a lawn-quality defect into a total outage;
+      2. neither condition is a safety hazard at launch. The firmware remains the
+         sole blade-safety authority and still owns the e-stop; what these degrade
+         is mowing QUALITY, and a robot that refuses to mow is strictly worse than
+         one that mows with poor turns while the operator reads the warning;
+      3. the genuinely nonsensical inputs (radius <= 0, connector radius below the
+         floor) are already contained by the clamps the caller applies before
+         injecting, so no unrecoverable input survives to reach here.
+
+    The bar for a hard failure is "cannot be made safe"; neither clears it. They
+    ARE loud and they print the numbers, because the whole point is that the
+    offending values live in different files and nothing previously related them.
+    """
+    warnings = []
+    half_track = 0.5 * float(wheel_track)
+    r_floor = float(min_turn_radius)
+    if r_floor <= half_track:
+        # Forward-only geometry: an arc of radius R needs the inner wheel at
+        # v*(1 - half_track/R). At R == half_track that is exactly zero; below it
+        # the inner wheel must REVERSE for the chassis to trace the arc. The
+        # coverage path is built as cusp-free FORWARD turn-around arcs and FTC
+        # runs forward_only, so nothing in the stack expects that — the wheel
+        # reverses anyway, in the soil, and carves.
+        v_out = turn_speed * (1.0 + half_track / max(r_floor, 1e-6))
+        v_in = turn_speed * (1.0 - half_track / max(r_floor, 1e-6))
+        warnings.append(
+            "WARN: min_turning_radius={} m is at/below the half-track ({} / 2 = "
+            "{:.4f} m). Every arc planned at that floor needs the INNER wheel at "
+            "{:+.3f} m/s while the outer runs {:.3f} m/s — a reversing inner wheel "
+            "carves the lawn at swath ends (issue #499). Raise "
+            "mowgli_robot.yaml.min_turning_radius above {:.4f} m, but read the "
+            "coverage server's 'PlanCoverage connectors:' fallback rate first — a "
+            "higher floor trades turn-around arcs for straight joins.".format(
+                r_floor, wheel_track, half_track, v_in, v_out, half_track))
+    # Planner/controller consistency: the tightest arc FTC can COMMAND at the turn
+    # speed is turn_speed / max_cmd_vel_ang. An arc tighter than that saturates the
+    # angular command for its whole length, so the controller falls behind, the
+    # heading error grows, and the chassis curls INSIDE the planned radius —
+    # measured at 0.09-0.14 m against a 0.15-0.18 m plan.
+    r_commandable = float(turn_speed) / max(float(max_cmd_vel_ang), 1e-6)
+    planned_tightest = min(r_floor, float(connector_turn_radius))
+    if planned_tightest < r_commandable:
+        warnings.append(
+            "WARN: coverage plans turn arcs down to {:.3f} m (min_turning_radius={}, "
+            "connector_turn_radius={}) but the tightest arc FollowCoveragePath can "
+            "command is speed_slow/max_cmd_vel_ang = {:.3f}/{} = {:.3f} m. Every "
+            "swath-end turn will saturate the angular command for its full length "
+            "and track inside the planned radius (issue #499). Raise the radii in "
+            "mowgli_robot.yaml, or lower turn_speed_ratio.".format(
+                planned_tightest, r_floor, connector_turn_radius, turn_speed,
+                max_cmd_vel_ang, r_commandable))
+    return warnings

--- a/ros2/src/mowgli_bringup/launch/robot_config_util.py
+++ b/ros2/src/mowgli_bringup/launch/robot_config_util.py
@@ -214,9 +214,10 @@ def check_turn_geometry(min_turn_radius, connector_turn_radius, wheel_track,
             "{:.4f} m). Every arc planned at that floor needs the INNER wheel at "
             "{:+.3f} m/s while the outer runs {:.3f} m/s — a reversing inner wheel "
             "carves the lawn at swath ends (issue #499). Raise "
-            "mowgli_robot.yaml.min_turning_radius above {:.4f} m, but read the "
-            "coverage server's 'PlanCoverage connectors:' fallback rate first — a "
-            "higher floor trades turn-around arcs for straight joins.".format(
+            "mowgli_robot.yaml.min_turning_radius above {:.4f} m — but note that "
+            "at the shipped headland apron the coverage server fits an arc at only "
+            "~1 join in 32 anyway ('PlanCoverage connectors:'), so this alone will "
+            "not change the swath-end turns.".format(
                 r_floor, wheel_track, half_track, v_in, v_out, half_track))
     # Planner/controller consistency: the tightest arc FTC can COMMAND at the turn
     # speed is turn_speed / max_cmd_vel_ang. An arc tighter than that saturates the

--- a/ros2/src/mowgli_bringup/test/test_nav2_params.py
+++ b/ros2/src/mowgli_bringup/test/test_nav2_params.py
@@ -829,3 +829,106 @@ def test_transit_lookahead_damps_pursuit_weave() -> None:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ── Turn geometry / turn speed (issue #499) ──────────────────────────────────
+#
+# The violent swath-end turns that dig the lawn were traced to two numbers that
+# must be consistent but live in different files with nothing relating them:
+# coverage_server's turn radii (mowgli_robot.yaml) and FollowCoveragePath's
+# speed/angular clamps (nav2_params_base.yaml). These tests pin the *relations*
+# and the guard that reports them — deliberately NOT any particular radius,
+# which is a field-measured trade against the connector fallback rate.
+
+
+def _template_robot_params() -> dict:
+    """The in-package mowgli_robot.yaml template (Invariant 15: defaults live
+    here, the installed file is sparse)."""
+    with open(_config_path("mowgli_robot.yaml"), "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)["mowgli"]["ros__parameters"]
+
+
+def test_default_wheel_track_matches_template() -> None:
+    """DEFAULT_WHEEL_TRACK_M is the last-resort floor beneath the template's
+    wheel_track, not a second source of truth for it. If the two diverge, the
+    half-track the turn-geometry check compares against stops describing the
+    robot. Same contract as DEFAULT_TOOL_WIDTH_M."""
+    from robot_config_util import DEFAULT_WHEEL_TRACK_M
+
+    template = _template_robot_params()
+    assert "wheel_track" in template, (
+        "mowgli_robot.yaml template lost wheel_track — the turn-geometry check "
+        "and the firmware kinematics push would fall back to a constant."
+    )
+    assert float(template["wheel_track"]) == pytest.approx(DEFAULT_WHEEL_TRACK_M), (
+        f"template wheel_track={template['wheel_track']} != "
+        f"DEFAULT_WHEEL_TRACK_M={DEFAULT_WHEEL_TRACK_M} — the fallback has drifted "
+        "from the real default."
+    )
+
+
+def test_template_turn_speed_ratio_is_a_slowdown() -> None:
+    """turn_speed_ratio scales mowing_speed into FollowCoveragePath.speed_slow.
+    A default above 1.0 would ship the exact defect it was added to fix: swath-end
+    turns driven FASTER than the straights."""
+    template = _template_robot_params()
+    assert "turn_speed_ratio" in template, (
+        "mowgli_robot.yaml template is missing turn_speed_ratio — speed_slow would "
+        "fall back to a static value and stop tracking the operator's mowing_speed."
+    )
+    ratio = float(template["turn_speed_ratio"])
+    assert 0.0 < ratio <= 1.0, (
+        f"turn_speed_ratio={ratio} must be in (0, 1.0]: >1 drives turns faster than "
+        "straights (issue #499), <=0 stops the robot in every bend."
+    )
+
+
+def test_navigation_launch_injects_derived_speed_slow() -> None:
+    """One load-bearing line: without this injection speed_slow falls back to the
+    static base.yaml value and the operator's mowing_speed stops applying to
+    swath-end turns — the issue #499 defect where turns ran FASTER than straights.
+
+    The arithmetic itself (ratio clamp, min_speed_mps floor, mowing_speed ceiling)
+    is exercised for real in test_robot_config_util.py::TestDeriveTurnSpeed; this
+    only guards that the launch actually calls it and injects the result."""
+    src = _read_text("launch/navigation.launch.py")
+    assert re.search(r"fcp\[.speed_slow.\]\s*=\s*turn_speed", src), (
+        "navigation.launch.py no longer injects FollowCoveragePath.speed_slow from "
+        "the derived turn speed — mowing_speed stops applying to turns (issue #499)."
+    )
+    assert "derive_turn_speed(" in src and "turn_speed_ratio" in src, (
+        "navigation.launch.py does not derive the turn speed from mowing_speed via "
+        "robot_config_util.derive_turn_speed."
+    )
+
+
+def test_navigation_launch_runs_the_turn_geometry_check() -> None:
+    """The check must run at launch and must be fed the CONFIGURED wheel track,
+    never a literal — the half-track is what makes an arc undrivable forward-only.
+
+    Its behaviour (what it flags, and that it never raises) is exercised for real
+    in test_robot_config_util.py::TestCheckTurnGeometry."""
+    src = _read_text("launch/navigation.launch.py")
+    assert "check_turn_geometry(" in src, (
+        "navigation.launch.py does not run the turn-geometry check — the issue #499 "
+        "geometry defect can be reintroduced silently."
+    )
+    assert re.search(r"wheel_track\s*=\s*float\(rt_rp\.get\(", src), (
+        "wheel_track is not read from the robot config — the turn-geometry check "
+        "must never compare against a hardcoded track."
+    )
+
+
+def test_base_ftc_can_command_its_own_turn_speed() -> None:
+    """Consistency inside the file we control: FTC's own speed_slow and
+    max_cmd_vel_ang imply a tightest commandable arc of speed_slow/max_cmd_vel_ang.
+    That must stay a sane, positive radius — if max_cmd_vel_ang were ever dropped
+    toward zero the controller could not turn at all."""
+    fcp = _controller_section(_load_params())["FollowCoveragePath"]
+    wz_max = float(fcp["max_cmd_vel_ang"])
+    assert wz_max > 0.0, "max_cmd_vel_ang must be positive or FTC cannot turn"
+    tightest = float(fcp["speed_slow"]) / wz_max
+    assert 0.0 < tightest < 1.0, (
+        f"speed_slow/max_cmd_vel_ang = {tightest:.3f} m is not a plausible turn "
+        "radius for this chassis — check the FollowCoveragePath speed/angular pair."
+    )

--- a/ros2/src/mowgli_bringup/test/test_robot_config_util.py
+++ b/ros2/src/mowgli_bringup/test/test_robot_config_util.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
 import yaml
 
 # mowgli_bringup package root: test/ -> package dir; the template lives at
@@ -34,6 +35,12 @@ def _load_helper():
 
 _util = _load_helper()
 load_robot_params = _util.load_robot_params
+# Pure turn-geometry / turn-speed helpers (issue #499) — see the tests at the
+# bottom of this file. Kept in robot_config_util because navigation.launch.py
+# imports launch/launch_ros and cannot be imported outside a sourced ROS2
+# install, so the arithmetic would otherwise be untestable.
+derive_turn_speed = _util.derive_turn_speed
+check_turn_geometry = _util.check_turn_geometry
 
 # Launch files that must derive their tool_width fallback from the one shared
 # constant instead of each hardcoding their own literal (task #17 — that
@@ -185,3 +192,156 @@ def test_map_server_and_coverage_launch_share_tool_width_default():
     # constant, not a bare numeric literal re-hardcoded at the call site.
     assert 'robot_params.get("tool_width", DEFAULT_TOOL_WIDTH_M)' in map_server_src
     assert "tool_width = DEFAULT_TOOL_WIDTH_M" in coverage_src
+
+
+# ── Coverage turn geometry / turn speed (issue #499) ─────────────────────────
+#
+# The violent swath-end turns that dig the lawn were traced to two numbers that
+# must be consistent but live in different files with nothing relating them:
+# coverage_server's turn radii (mowgli_robot.yaml) and FollowCoveragePath's
+# speed/angular clamps (nav2_params_base.yaml). These exercise the ARITHMETIC —
+# navigation.launch.py only prints what these return.
+
+
+class TestDeriveTurnSpeed:
+    """FollowCoveragePath.speed_slow derived from the operator's mowing_speed."""
+
+    def test_scales_mowing_speed_by_the_ratio(self):
+        # Arrange / Act
+        speed, warnings = derive_turn_speed(0.20, 0.8, 0.10)
+
+        # Assert — 0.8 x 0.20 reproduces the historical static 0.16 exactly, so a
+        # robot on the default mowing_speed sees no behaviour change.
+        assert speed == pytest.approx(0.16)
+        assert warnings == []
+
+    def test_turn_is_never_faster_than_the_straight(self):
+        """THE defect: with a static speed_slow=0.16 an operator on
+        mowing_speed=0.15 drove swath-end turns 7 % FASTER than the straights."""
+        # Arrange — the exact live robot config from the 2026-08-24 logs.
+        mowing_speed = 0.15
+
+        # Act
+        speed, _ = derive_turn_speed(mowing_speed, 0.8, 0.10)
+
+        # Assert
+        assert speed <= mowing_speed, (
+            f"turn speed {speed} exceeds mowing_speed {mowing_speed} — the issue "
+            "#499 defect is back")
+
+    def test_ratio_above_one_is_clamped_and_warned(self):
+        # Arrange / Act — a ratio > 1 IS the defect, expressed as config.
+        speed, warnings = derive_turn_speed(0.20, 1.5, 0.10)
+
+        # Assert
+        assert speed == pytest.approx(0.20), "clamped ratio must be exactly 1.0"
+        assert any("outside (0, 1.0]" in w for w in warnings)
+
+    def test_ratio_at_or_below_zero_is_clamped(self):
+        """A zero/negative ratio would stop the robot dead in every bend."""
+        # Arrange / Act
+        speed, warnings = derive_turn_speed(0.20, 0.0, 0.01)
+
+        # Assert
+        assert speed > 0.0
+        assert any("outside (0, 1.0]" in w for w in warnings)
+
+    def test_floored_at_min_speed_with_a_warning(self):
+        """Below FTC's own min_speed_mps the target is a fiction — FTC floors its
+        output there regardless, and the wheels stall under the firmware
+        deadband. Say so rather than inject a value that cannot happen."""
+        # Arrange — 0.6 x 0.15 = 0.09, under min_speed_mps.
+        # Act
+        speed, warnings = derive_turn_speed(0.15, 0.6, 0.15)
+
+        # Assert
+        assert speed == pytest.approx(0.15)
+        assert any("min_speed_mps" in w for w in warnings)
+
+    def test_ceiling_wins_over_floor_when_they_conflict(self):
+        """min_speed_mps above mowing_speed: the turn must still never exceed the
+        straight, so the mowing_speed ceiling is the binding constraint."""
+        # Arrange / Act
+        speed, _ = derive_turn_speed(0.12, 0.8, 0.20)
+
+        # Assert
+        assert speed <= 0.12
+
+
+class TestCheckTurnGeometry:
+    """Undrivable planned turn radii — reported, never raised."""
+
+    # The deployed pair as of issue #499: floor below the half-track.
+    LIVE_TRACK = 0.325
+    LIVE_MIN_R = 0.15
+    LIVE_CONN_R = 0.18
+    LIVE_TURN_SPEED = 0.16
+    LIVE_WZ_MAX = 0.8
+
+    def test_flags_the_live_config_inner_wheel_reversal(self):
+        """min_turning_radius 0.15 <= half-track 0.1625: the inner wheel must
+        REVERSE to trace the arc. This is the shipped state, and it must warn."""
+        # Act
+        warnings = check_turn_geometry(self.LIVE_MIN_R, self.LIVE_CONN_R,
+                                       self.LIVE_TRACK, self.LIVE_TURN_SPEED,
+                                       self.LIVE_WZ_MAX)
+
+        # Assert
+        assert any("half-track" in w for w in warnings), (
+            "the deployed 0.15 m floor against a 0.325 m track is exactly the "
+            "geometry that carves the lawn and must be reported")
+
+    def test_flags_the_planner_controller_mismatch(self):
+        """The tightest arc FTC can command is speed_slow/max_cmd_vel_ang =
+        0.16/0.8 = 0.20 m, but coverage plans down to 0.15 m."""
+        # Act
+        warnings = check_turn_geometry(self.LIVE_MIN_R, self.LIVE_CONN_R,
+                                       self.LIVE_TRACK, self.LIVE_TURN_SPEED,
+                                       self.LIVE_WZ_MAX)
+
+        # Assert
+        assert any("max_cmd_vel_ang" in w for w in warnings)
+
+    def test_silent_when_the_geometry_is_drivable(self):
+        """Radius comfortably above the half-track AND above the commandable
+        floor — nothing to say."""
+        # Arrange — 0.40 m arcs: inner/outer ratio 0.42, needs wz = 0.16/0.40 = 0.4.
+        # Act
+        warnings = check_turn_geometry(0.40, 0.45, self.LIVE_TRACK,
+                                       self.LIVE_TURN_SPEED, self.LIVE_WZ_MAX)
+
+        # Assert
+        assert warnings == []
+
+    def test_reports_the_actual_wheel_speeds(self):
+        """The warning has to carry NUMBERS — the whole failure was that the two
+        offending values lived in different files and nobody related them."""
+        # Act
+        warnings = check_turn_geometry(self.LIVE_MIN_R, self.LIVE_CONN_R,
+                                       self.LIVE_TRACK, self.LIVE_TURN_SPEED,
+                                       self.LIVE_WZ_MAX)
+
+        # Assert — v_inner = v(1 - b/R) = 0.16 * (1 - 0.1625/0.15) = -0.013 m/s.
+        carve = next(w for w in warnings if "half-track" in w)
+        assert "-0.013" in carve, f"inner-wheel speed missing from: {carve}"
+
+    def test_boundary_radius_equal_to_half_track_still_warns(self):
+        """At R == half-track the inner wheel is at exactly zero — the wheel is
+        dragged, not rolled. Still carving; must not be treated as fine."""
+        # Act
+        warnings = check_turn_geometry(0.1625, 0.20, 0.325, 0.16, 0.8)
+
+        # Assert
+        assert any("half-track" in w for w in warnings)
+
+    def test_never_raises_on_any_input(self):
+        """WARN-only is load-bearing: the shipped defaults trip this, so raising
+        would refuse to start navigation on every existing robot. Firmware stays
+        the sole blade-safety authority either way."""
+        # Arrange — including degenerate values the caller's clamps would contain.
+        for args in [(0.0, 0.0, 0.325, 0.16, 0.8),
+                     (0.15, 0.18, 0.0, 0.16, 0.8),
+                     (0.15, 0.18, 0.325, 0.0, 0.0),
+                     (5.0, 5.0, 0.325, 0.16, 0.8)]:
+            # Act / Assert — must return a list, never throw.
+            assert isinstance(check_turn_geometry(*args), list)

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
@@ -185,6 +185,43 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
                                     int ring_direction = 0,
                                     double min_turn_radius = 0.15);
 
+// Per-plan accounting of how every segment-to-segment join was resolved by
+// buildConnector's radius-shrink search. Pure visibility — populating it
+// changes no decision.
+//
+// WHY THIS EXISTS (issue #499): the swath-end turn radius is the lever on the
+// "violent turns dig the lawn" failure, but raising `min_turning_radius` is a
+// TRADE, not a free win — it is the FLOOR of buildConnector's shrink loop, so
+// raising it makes the search give up sooner and fall through to the straight
+// blind connector. Until that fallback rate is a NUMBER, nobody can tell a
+// radius change that fixed the turns from one that quietly replaced arcs with
+// straight joins (or, worse, with sub-path splits the robot has to bridge
+// blade-off). This counter is the prerequisite measurement, not the fix.
+//
+// The three outcomes are mutually exclusive and sum to `attempted`:
+struct ConnectorStats
+{
+  // Segment-to-segment joins where a connector was attempted (== segments - 1
+  // in the common single-sub-path case).
+  std::size_t attempted = 0;
+  // A real forward Dubins turn-around arc fitted at some radius in
+  // [min_turn_radius, turn_radius] and stayed in-bounds + clear of holes. This
+  // is the healthy outcome.
+  std::size_t arc = 0;
+  // The shrink loop found NO in-bounds arc, so buildConnector returned its
+  // straight blind connector — but that straight join happened to stay inside
+  // the boundary and clear of every hole, so it is DRIVEN BLADE-ON as part of
+  // the sub-path. Cheap in coverage terms, but it hands the controller a
+  // heading discontinuity instead of a tangent arc.
+  std::size_t straight_kept = 0;
+  // No drivable connector at all (empty, or a straight fallback that left the
+  // boundary / crossed a hole). The sub-path is BROKEN here and FollowStrip
+  // bridges the gap with a blade-off Nav2 transit. This is the expensive
+  // outcome — un-mowed transit time — and the one a too-high min_turn_radius
+  // would inflate.
+  std::size_t split = 0;
+};
+
 // Flatten a BoustrophedonPlan into ONE continuous, cusp-free, in-bounds
 // polyline so an MPPI-class sampling controller can track it without the
 // bimodal dither/spin it does at sharp ~180° reversals.
@@ -259,7 +296,8 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
     const std::vector<std::pair<double, double>>& boundary,
     double turn_radius,
     double min_turn_radius,
-    double step);
+    double step,
+    ConnectorStats* stats = nullptr);
 
 // 2-D point-in-polygon (ray casting) against `ring`, a list of (x, y)
 // vertices. Open or closed ring; winding-independent. Used by the server to

--- a/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
+++ b/ros2/src/mowgli_coverage/include/mowgli_coverage/coverage_planning.hpp
@@ -189,14 +189,33 @@ BoustrophedonPlan planBoustrophedon(const f2c::types::Cell& field_cell,
 // buildConnector's radius-shrink search. Pure visibility — populating it
 // changes no decision.
 //
-// WHY THIS EXISTS (issue #499): the swath-end turn radius is the lever on the
-// "violent turns dig the lawn" failure, but raising `min_turning_radius` is a
-// TRADE, not a free win — it is the FLOOR of buildConnector's shrink loop, so
-// raising it makes the search give up sooner and fall through to the straight
-// blind connector. Until that fallback rate is a NUMBER, nobody can tell a
-// radius change that fixed the turns from one that quietly replaced arcs with
-// straight joins (or, worse, with sub-path splits the robot has to bridge
-// blade-off). This counter is the prerequisite measurement, not the fix.
+// WHY THIS EXISTS (issue #499): the swath-end turn radius was believed to be
+// the lever on the "violent turns dig the lawn" failure, and raising
+// `min_turning_radius` was believed to be a TRADE rather than a free win — it
+// is the FLOOR of buildConnector's shrink loop, so raising it should make the
+// search give up sooner and fall through to the straight blind connector.
+// Nobody could tell a radius change that fixed the turns from one that quietly
+// replaced arcs with straight joins, so this counter shipped first as the
+// prerequisite measurement.
+//
+// WHAT IT MEASURED (2026-08-24, the first plan it ever counted): on the SHIPPED
+// geometry — num_headland_passes 2, op_width = tool_width - swath_overlap,
+// connector_turn_radius 0.18, min_turning_radius 0.15 — only 1 join in 32 gets
+// an arc. The other 31 are already straight blind connectors, and raising the
+// floor to 0.25 m moves exactly one more. So the fallback TRADE above is not
+// what constrains the radius, and the swath-end turns being carved are NOT
+// too-tight Dubins arcs: there is no arc there to be tight.
+//
+// The binding constraint is the mowed HEADLAND APRON beyond the swath ends. At
+// swath spacing d < 2R the turn-around must be an omega (RLR/LRL) loop whose
+// forward extent past the swath end is ~sqrt(4R^2 - (R + d/2)^2) + R (~0.43 m
+// at R = 0.18, d = 0.16), while the apron is num_headland_passes * op_width
+// (0.32 m as shipped). Nothing in [min_turn_radius, turn_radius] fits, so
+// buildConnector falls through; roundSharpCorners then cannot fillet the
+// resulting 90 degree corners either, because the fillet's tangent length is
+// floored at min_turn_radius (0.15 m) while the connector it must be trimmed
+// into is only op_width (0.16 m) long. The path handed to FTC at a swath end is
+// therefore a sharp corner, not an arc. See the CoverageConnectorStats tests.
 //
 // The three outcomes are mutually exclusive and sum to `attempted`:
 struct ConnectorStats
@@ -217,8 +236,9 @@ struct ConnectorStats
   // No drivable connector at all (empty, or a straight fallback that left the
   // boundary / crossed a hole). The sub-path is BROKEN here and FollowStrip
   // bridges the gap with a blade-off Nav2 transit. This is the expensive
-  // outcome — un-mowed transit time — and the one a too-high min_turn_radius
-  // would inflate.
+  // outcome — un-mowed transit time. A too-high min_turn_radius was expected to
+  // inflate it; measured on a hole-free field it stays at zero, because the
+  // straight fallbacks all verify in-bounds and are driven blade-on.
   std::size_t split = 0;
 };
 

--- a/ros2/src/mowgli_coverage/src/coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_planning.cpp
@@ -1339,7 +1339,8 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
     const std::vector<std::pair<double, double>>& boundary,
     double turn_radius,
     double min_turn_radius,
-    double step)
+    double step,
+    ConnectorStats* stats)
 {
   // Flatten the plan into ordered drivable segments (densified polylines),
   // rings first (outermost → inner) then the swaths.
@@ -1610,6 +1611,28 @@ std::vector<std::vector<std::pair<double, double>>> buildContinuousSubPaths(
         conn_safe =
             !conn.empty() &&
             (!fallback || (allInside(conn, boundary) && clearOfHoles(conn, plan.safe_holes)));
+        // Pure accounting of how this join resolved (issue #499) — see
+        // ConnectorStats. Deliberately AFTER conn_safe so the classification
+        // reflects what is actually driven, not just whether buildConnector
+        // reached its straight-connector last resort: a straight fallback that
+        // verifies in-bounds is driven blade-on, one that does not becomes a
+        // sub-path split. Changes no decision.
+        if (stats != nullptr)
+        {
+          ++stats->attempted;
+          if (!conn_safe)
+          {
+            ++stats->split;
+          }
+          else if (fallback)
+          {
+            ++stats->straight_kept;
+          }
+          else
+          {
+            ++stats->arc;
+          }
+        }
         if (conn_safe)
         {
           // conn is start-inclusive (== path.back()) / goal-exclusive; drop the

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -162,8 +162,17 @@ constexpr double kSwathStep = 0.10;  // m between poses on a straight swath
 // a straight blind connector or a sub-path split, at or above which the summary
 // is logged at WARN instead of INFO. 25 % is a judgement call, not a measured
 // threshold: below it the odd un-fittable join is normal on a concave field,
-// above it the plan is mostly NOT being joined by real turn-around arcs, which
-// is exactly the regression a raised min_turning_radius would cause.
+// above it the plan is mostly NOT being joined by real turn-around arcs.
+//
+// Expect this to WARN on every plan at the shipped defaults. The first
+// measurement this counter ever produced was ~97 % fallback (1 arc in 32 joins)
+// on a hole-free convex field, and that is the BASELINE, not a regression: the
+// headland apron beyond the swath ends (num_headland_passes * operation_width =
+// 0.32 m) is narrower than the omega turn-around's forward extent (~0.43 m at
+// connector_turn_radius 0.18, swath spacing 0.16), so no radius in the shrink
+// range fits. The WARN is kept rather than tuned away because a swath end that
+// is a straight join with a sharp corner instead of a tangent arc is exactly the
+// lawn-carving defect #499 is about — see ConnectorStats in coverage_planning.hpp.
 constexpr double kConnectorFallbackWarnPct = 25.0;
 // One format string, two severities — keeps the WARN and INFO variants from
 // drifting apart. A macro rather than a `constexpr const char*` so it expands to
@@ -175,10 +184,12 @@ constexpr double kConnectorFallbackWarnPct = 25.0;
 // makes clang-format 18 (what CI pins) and clang-format 22 (what the local
 // pre-push hook runs) disagree about the backslash column, so the two rewrite
 // each other forever.
-#define MOWGLI_CONNECTOR_STATS_FMT                                            \
-  "PlanCoverage connectors: %zu join(s): %zu turn-around arc, %zu straight "  \
-  "fallback (driven blade-on), %zu split (blade-off transit); fallback rate " \
-  "%.1f%% at connector_turn_radius=%.2f min_turning_radius=%.2f"
+#define MOWGLI_CONNECTOR_STATS_FMT                                             \
+  "PlanCoverage connectors: %zu join(s): %zu turn-around arc, %zu straight "   \
+  "fallback (driven blade-on), %zu split (blade-off transit); fallback rate "  \
+  "%.1f%% at connector_turn_radius=%.2f min_turning_radius=%.2f. A high rate " \
+  "is the headland apron (num_headland_passes x operation_width) being "       \
+  "narrower than the turn-around's forward extent, not the radii"
 
 // Build the F2C cell from the goal's outer boundary + obstacle holes.
 // F2C wants closed rings (first == last); the BT passes open rings.

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -158,6 +158,23 @@ namespace
 
 constexpr double kSwathStep = 0.10;  // m between poses on a straight swath
 
+// Connector-outcome reporting (issue #499). Share of segment joins resolved by
+// a straight blind connector or a sub-path split, at or above which the summary
+// is logged at WARN instead of INFO. 25 % is a judgement call, not a measured
+// threshold: below it the odd un-fittable join is normal on a concave field,
+// above it the plan is mostly NOT being joined by real turn-around arcs, which
+// is exactly the regression a raised min_turning_radius would cause.
+constexpr double kConnectorFallbackWarnPct = 25.0;
+// One format string, two severities — keeps the WARN and INFO variants from
+// drifting apart. A macro rather than a `constexpr const char*` so it expands to
+// a string LITERAL at each RCLCPP_* call site: the logging macros carry a
+// printf-style format attribute, so a non-literal format argument both loses the
+// compiler's argument-type checking and warns under -Wformat-nonliteral.
+#define MOWGLI_CONNECTOR_STATS_FMT                                                       \
+  "PlanCoverage connectors: %zu join(s) — %zu turn-around arc, %zu straight fallback " \
+  "(driven blade-on), %zu split (blade-off transit); fallback rate %.1f%% at "           \
+  "connector_turn_radius=%.2f min_turning_radius=%.2f"
+
 // Build the F2C cell from the goal's outer boundary + obstacle holes.
 // F2C wants closed rings (first == last); the BT passes open rings.
 // obstacle_margin (m) grows each HOLE outward at ingestion (bufferRingOutward)
@@ -574,8 +591,16 @@ void CoverageServer::planCoverage()
     // routes around the obstacle (issue #333). full_path is their concatenation
     // (GUI viz); drivable_subpaths is what the BT follows.
     const auto t_subpaths0 = now();
-    const auto subpaths = buildContinuousSubPaths(
-        plan, connector_boundary, connector_turn_radius, min_turning_radius, kConnectorStep);
+    // connector_stats is pure visibility (issue #499): it records how each
+    // segment join resolved — a real turn-around arc, a straight blind
+    // connector driven blade-on, or a sub-path split. See ConnectorStats.
+    mowgli_coverage::ConnectorStats connector_stats;
+    const auto subpaths = buildContinuousSubPaths(plan,
+                                                  connector_boundary,
+                                                  connector_turn_radius,
+                                                  min_turning_radius,
+                                                  kConnectorStep,
+                                                  &connector_stats);
     const double subpaths_ms = 1e3 * (now() - t_subpaths0).seconds();
 
     result->full_path.header = header;
@@ -680,6 +705,45 @@ void CoverageServer::planCoverage()
                 subpaths_ms,
                 verify_ms,
                 result->full_path.poses.size());
+    // Connector outcome breakdown (issue #499). This is the measurement that has
+    // to exist BEFORE anyone changes min_turning_radius / connector_turn_radius:
+    // raising the floor makes buildConnector's shrink search give up sooner, and
+    // without this line a radius change that traded real turn-around arcs for
+    // straight joins (or for blade-off splits) looks identical in every other
+    // log. Logged at WARN once the fallback share is material so an operator
+    // A/B'ing a radius sees it without turning on debug logging.
+    if (connector_stats.attempted > 0)
+    {
+      const std::size_t fallbacks = connector_stats.straight_kept + connector_stats.split;
+      const double fallback_pct =
+          100.0 * static_cast<double>(fallbacks) / static_cast<double>(connector_stats.attempted);
+      // Same text either way; only the severity changes, so a routine plan stays
+      // at INFO and a plan that is mostly straight joins is impossible to miss.
+      if (fallback_pct >= kConnectorFallbackWarnPct)
+      {
+        RCLCPP_WARN(get_logger(),
+                    MOWGLI_CONNECTOR_STATS_FMT,
+                    connector_stats.attempted,
+                    connector_stats.arc,
+                    connector_stats.straight_kept,
+                    connector_stats.split,
+                    fallback_pct,
+                    connector_turn_radius,
+                    min_turning_radius);
+      }
+      else
+      {
+        RCLCPP_INFO(get_logger(),
+                    MOWGLI_CONNECTOR_STATS_FMT,
+                    connector_stats.attempted,
+                    connector_stats.arc,
+                    connector_stats.straight_kept,
+                    connector_stats.split,
+                    fallback_pct,
+                    connector_turn_radius,
+                    min_turning_radius);
+      }
+    }
     if (result->drivable_subpaths.size() > 1)
     {
       RCLCPP_INFO(get_logger(),

--- a/ros2/src/mowgli_coverage/src/coverage_server.cpp
+++ b/ros2/src/mowgli_coverage/src/coverage_server.cpp
@@ -170,10 +170,15 @@ constexpr double kConnectorFallbackWarnPct = 25.0;
 // a string LITERAL at each RCLCPP_* call site: the logging macros carry a
 // printf-style format attribute, so a non-literal format argument both loses the
 // compiler's argument-type checking and warns under -Wformat-nonliteral.
-#define MOWGLI_CONNECTOR_STATS_FMT                                                       \
-  "PlanCoverage connectors: %zu join(s) — %zu turn-around arc, %zu straight fallback " \
-  "(driven blade-on), %zu split (blade-off transit); fallback rate %.1f%% at "           \
-  "connector_turn_radius=%.2f min_turning_radius=%.2f"
+//
+// ASCII-only on purpose: a non-ASCII character inside a line-continued macro
+// makes clang-format 18 (what CI pins) and clang-format 22 (what the local
+// pre-push hook runs) disagree about the backslash column, so the two rewrite
+// each other forever.
+#define MOWGLI_CONNECTOR_STATS_FMT                                            \
+  "PlanCoverage connectors: %zu join(s): %zu turn-around arc, %zu straight "  \
+  "fallback (driven blade-on), %zu split (blade-off transit); fallback rate " \
+  "%.1f%% at connector_turn_radius=%.2f min_turning_radius=%.2f"
 
 // Build the F2C cell from the goal's outer boundary + obstacle holes.
 // F2C wants closed rings (first == last); the BT passes open rings.

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -2125,87 +2125,197 @@ TEST(CoveragePlanning, DegenerateRecordedRingSanitizedToFullCoverage)
 // changing min_turning_radius / connector_turn_radius: raising the floor makes
 // buildConnector's shrink search give up sooner and fall through to a straight
 // blind connector, and nothing else in the plan or the logs distinguishes that
-// from a healthy turn-around arc. These tests pin the accounting itself, not
-// any particular radius — a radius change is expected to MOVE these numbers,
-// which is the entire point of having them.
+// from a healthy turn-around arc.
+//
+// WHAT THE COUNTER MEASURED, once it existed (2026-08-24, this PR): on the
+// SHIPPED coverage geometry — num_headland_passes = 2, op_width = tool_width −
+// swath_overlap, connector_turn_radius 0.18, min_turning_radius 0.15 — only
+// 1 join in 32 gets a real turn-around arc. The other 31 are straight blind
+// connectors. That is not a regression and not an artefact of the synthetic
+// field; it is the baseline, and it is geometric (see the apron test below).
+//
+// These tests therefore pin the MECHANISM that decides an arc from a straight
+// join — the width of the mowed headland apron beyond the swath ends, measured
+// against the forward extent of the turn-around — rather than any one radius or
+// any one fallback percentage. A radius change is expected to MOVE the raw
+// counts, which is the entire point of having them.
+
+// Shared plan geometry for the connector-outcome tests. Everything except the
+// ring count and the radii is held at the SHIPPED configuration so the numbers
+// these tests report are the numbers the robot actually plans with:
+// mowgli_robot.yaml tool_width 0.18 − swath_overlap 0.02 = op_width 0.16,
+// chassis_safety_inset 0.20, num_headland_passes 2.
+namespace
+{
+constexpr double kStatsOpWidth = 0.16;
+constexpr double kStatsHeadland = 0.18;
+constexpr double kStatsInset = 0.20;
+constexpr double kStatsMinSwath = 0.15;
+constexpr double kStatsTurnRadius = 0.18;
+constexpr double kStatsMinTurnRadius = 0.15;
+constexpr double kStatsStep = 0.03;
+constexpr int kShippedHeadlandPasses = 2;  // mowgli_robot.yaml num_headland_passes
+
+// Plan a 6 m square with `rings` perimeter passes, then join it exactly the way
+// coverage_server does — bounded by connector_clearance_boundary, not the looser
+// safe_boundary — and return how every join resolved.
+mowgli_coverage::ConnectorStats connectorOutcomes(
+    int rings, double op_width, double headland, double turn_radius, double min_turn_radius)
+{
+  const f2c::types::Cell cell = makeSquare(6.0);
+  const auto plan =
+      planBoustrophedon(cell, op_width, headland, rings, kStatsInset, -1.0, kStatsMinSwath);
+  EXPECT_FALSE(plan.rings.empty()) << "test geometry planned no perimeter rings";
+  const auto& connector_boundary = plan.connector_clearance_boundary.size() >= 3
+                                       ? plan.connector_clearance_boundary
+                                       : plan.safe_boundary;
+  mowgli_coverage::ConnectorStats stats;
+  (void)buildContinuousSubPaths(
+      plan, connector_boundary, turn_radius, min_turn_radius, kStatsStep, &stats);
+  return stats;
+}
+}  // namespace
 
 // The three outcomes partition every attempted join. If this ever fails, the
 // fallback rate derived from them is meaningless.
 TEST(CoverageConnectorStats, OutcomesPartitionAttemptedJoins)
 {
-  constexpr double kOpWidth = 0.16;
-  constexpr double kHeadland = 0.18;
-  constexpr double kInset = 0.15;
-  constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.18;
-  constexpr double kMinTurnRadius = 0.15;
-  constexpr double kStep = 0.03;
+  const auto stats = connectorOutcomes(
+      kShippedHeadlandPasses, kStatsOpWidth, kStatsHeadland, kStatsTurnRadius, kStatsMinTurnRadius);
 
-  const f2c::types::Cell cell = makeSquare(6.0);
-  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
-  ASSERT_FALSE(plan.rings.empty());
-
-  mowgli_coverage::ConnectorStats stats;
-  const auto subs =
-      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
-
-  ASSERT_FALSE(subs.empty());
   EXPECT_GT(stats.attempted, 0u) << "a multi-segment plan must attempt connectors";
   EXPECT_EQ(stats.attempted, stats.arc + stats.straight_kept + stats.split)
       << "arc/straight_kept/split must partition attempted — the fallback rate "
          "derived from them is otherwise nonsense";
 }
 
-// A hole-free convex field is the easy case: real turn-around arcs should fit at
-// nearly every join. This is the baseline a raised min_turning_radius would be
-// measured against — it pins "arcs dominate today", not a specific radius.
-TEST(CoverageConnectorStats, ConvexFieldIsJoinedMostlyByArcs)
+// Counter sanity on a case whose outcome is hand-checkable, so a stuck
+// classifier cannot masquerade as a planner result. With the swath spacing at
+// or above twice the turn radius (0.50 >= 2 * 0.18) the turn-around is a plain
+// RSR U-turn: quarter circle, straight, quarter circle. Its forward extent past
+// the swath end is exactly the turn radius, 0.18 m, and the single 0.50 m
+// headland pass leaves 0.50 m of mowed apron there. An arc MUST fit at every
+// join, so anything other than a clean sweep is a counting bug.
+TEST(CoverageConnectorStats, EveryJoinIsAnArcWhenSpacingExceedsTwiceTheTurnRadius)
 {
-  constexpr double kOpWidth = 0.16;
-  constexpr double kHeadland = 0.18;
-  constexpr double kInset = 0.15;
-  constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.18;
-  constexpr double kMinTurnRadius = 0.15;
-  constexpr double kStep = 0.03;
+  constexpr double kWideSpacing = 0.50;  // >= 2 * kStatsTurnRadius
+  const auto stats =
+      connectorOutcomes(1, kWideSpacing, kWideSpacing, kStatsTurnRadius, kStatsMinTurnRadius);
 
-  const f2c::types::Cell cell = makeSquare(6.0);
-  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
-  ASSERT_FALSE(plan.rings.empty());
+  ASSERT_GT(stats.attempted, 5u) << "need several joins for this to mean anything";
+  EXPECT_EQ(stats.arc, stats.attempted)
+      << "only " << stats.arc << "/" << stats.attempted
+      << " joins got an arc where a plain U-turn provably fits (spacing " << kWideSpacing
+      << " m >= 2 x turn radius " << kStatsTurnRadius << " m, apron " << kWideSpacing
+      << " m > extent " << kStatsTurnRadius
+      << " m) — the classifier or the connector search is broken, not the geometry";
+}
 
-  mowgli_coverage::ConnectorStats stats;
-  (void)
-      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
+// THE #499 FINDING. What decides an arc from a straight blind connector at a
+// swath end is the width of the mowed HEADLAND APRON beyond the swath ends, not
+// the turn radius.
+//
+// When the swath spacing d is below 2R the turn-around cannot be a half circle;
+// Dubins has to emit an omega (RLR/LRL) loop, whose forward extent past the
+// swath end is roughly sqrt(4R^2 - (R + d/2)^2) + R — about 0.43 m at R = 0.18,
+// d = 0.16. The apron available is num_headland_passes * op_width, so the
+// shipped two passes give 0.32 m and the omega does not fit: buildConnector
+// exhausts its shrink search and falls through to the straight connector. Widen
+// the apron and the same search, at the same radii, succeeds almost everywhere.
+//
+// If this test starts failing on the narrow arm, swath-end joins have started
+// getting real arcs — that is the desired outcome, not a regression: re-measure
+// and update issue #499 rather than relaxing the bound.
+TEST(CoverageConnectorStats, SwathEndArcsAreDecidedByTheHeadlandApronNotTheRadius)
+{
+  constexpr int kWideHeadlandPasses = 8;  // 8 * 0.16 = 1.28 m of apron
 
-  ASSERT_GT(stats.attempted, 0u);
-  const double arc_share = static_cast<double>(stats.arc) / static_cast<double>(stats.attempted);
-  EXPECT_GT(arc_share, 0.5) << "only " << stats.arc << "/" << stats.attempted
-                            << " joins got a real turn-around arc on a hole-free convex "
-                               "field — the connector search is failing where it should "
-                               "succeed";
+  const auto narrow = connectorOutcomes(
+      kShippedHeadlandPasses, kStatsOpWidth, kStatsHeadland, kStatsTurnRadius, kStatsMinTurnRadius);
+  const auto wide = connectorOutcomes(
+      kWideHeadlandPasses, kStatsOpWidth, kStatsHeadland, kStatsTurnRadius, kStatsMinTurnRadius);
+
+  ASSERT_GT(narrow.attempted, 10u);
+  ASSERT_GT(wide.attempted, 10u);
+  const double narrow_arc_share =
+      static_cast<double>(narrow.arc) / static_cast<double>(narrow.attempted);
+  const double wide_arc_share = static_cast<double>(wide.arc) / static_cast<double>(wide.attempted);
+
+  // Shipped apron: the omega does not fit, so almost every join is straight.
+  EXPECT_LT(narrow_arc_share, 0.2)
+      << "shipped geometry (" << kShippedHeadlandPasses << " headland passes, " << kStatsOpWidth
+      << " m apron/pass) now gets arcs at " << narrow.arc << "/" << narrow.attempted
+      << " joins. Swath-end turns are no longer straight blind connectors — "
+         "re-measure and update issue #499 instead of relaxing this bound";
+  // Wide apron: the SAME search at the SAME radii fits an arc nearly everywhere,
+  // which is what proves the radius is not the binding constraint.
+  EXPECT_GT(wide_arc_share, 0.8) << "with a " << kWideHeadlandPasses * kStatsOpWidth
+                                 << " m apron only " << wide.arc << "/" << wide.attempted
+                                 << " joins got an arc — the connector search itself has regressed";
+
+  // The straight fallbacks stay inside the connector-clearance envelope, so they
+  // are driven blade-on: the shipped plan is one continuous sub-path, NOT a
+  // fragmented one. This separates "no arc" (quality) from "no drivable
+  // connector" (extra blade-off transits), which are very different costs.
+  EXPECT_EQ(narrow.split, 0u)
+      << narrow.split << " join(s) had no drivable connector at all on a hole-free convex field";
+}
+
+// The trade issue #499 feared — that raising min_turning_radius buys fewer
+// carving arcs at the price of many more straight blind connectors — is not
+// present at the shipped headland apron, because there are almost no arcs left
+// to lose. Raising the floor from 0.15 m (below the 0.1625 m half-track) to
+// 0.25 m, with the ceiling raised alongside it so the shrink search still has
+// somewhere to start, moves at most one join and creates no sub-path split.
+//
+// This does not say what the radius SHOULD be — that decision is the
+// maintainer's. It says the fallback rate is not the argument against changing
+// it, which is the opposite of what #499 assumed.
+TEST(CoverageConnectorStats, RaisingTheTurnRadiusFloorBarelyMovesTheFallbackRate)
+{
+  constexpr double kCeiling = 0.30;  // >= both floors, so the search starts identically
+  constexpr double kRaisedFloor = 0.25;  // clears the 0.1625 m half-track
+
+  const auto low = connectorOutcomes(
+      kShippedHeadlandPasses, kStatsOpWidth, kStatsHeadland, kCeiling, kStatsMinTurnRadius);
+  const auto high = connectorOutcomes(
+      kShippedHeadlandPasses, kStatsOpWidth, kStatsHeadland, kCeiling, kRaisedFloor);
+
+  ASSERT_EQ(low.attempted, high.attempted) << "the two arms must plan the same joins";
+  ASSERT_GT(low.attempted, 10u);
+
+  const std::size_t low_fallbacks = low.straight_kept + low.split;
+  const std::size_t high_fallbacks = high.straight_kept + high.split;
+  ASSERT_GE(high_fallbacks, low_fallbacks) << "a higher floor cannot fit MORE arcs";
+  EXPECT_LE(high_fallbacks - low_fallbacks, 2u)
+      << "raising min_turning_radius " << kStatsMinTurnRadius << " -> " << kRaisedFloor
+      << " m turned " << (high_fallbacks - low_fallbacks) << " of " << low.attempted
+      << " joins into straight fallbacks (" << low.arc << " -> " << high.arc
+      << " arcs). The fallback trade #499 assumed is now real — re-open that "
+         "trade-off before choosing a radius";
+  EXPECT_EQ(high.split, 0u) << "a higher floor must not fragment a hole-free field into "
+                            << high.split << " blade-off transit(s)";
 }
 
 // The counter is opt-in: every existing caller passes no stats pointer, so the
 // nullptr path must stay safe and must not change the plan.
 TEST(CoverageConnectorStats, NullStatsPointerIsSafeAndChangesNothing)
 {
-  constexpr double kOpWidth = 0.16;
-  constexpr double kHeadland = 0.18;
-  constexpr double kInset = 0.15;
-  constexpr double kMinSwath = 0.15;
-  constexpr double kTurnRadius = 0.18;
-  constexpr double kMinTurnRadius = 0.15;
-  constexpr double kStep = 0.03;
-
   const f2c::types::Cell cell = makeSquare(6.0);
-  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
+  const auto plan = planBoustrophedon(cell,
+                                      kStatsOpWidth,
+                                      kStatsHeadland,
+                                      kShippedHeadlandPasses,
+                                      kStatsInset,
+                                      -1.0,
+                                      kStatsMinSwath);
   ASSERT_FALSE(plan.rings.empty());
 
-  const auto without =
-      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep);
+  const auto without = buildContinuousSubPaths(
+      plan, plan.safe_boundary, kStatsTurnRadius, kStatsMinTurnRadius, kStatsStep);
   mowgli_coverage::ConnectorStats stats;
-  const auto with =
-      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
+  const auto with = buildContinuousSubPaths(
+      plan, plan.safe_boundary, kStatsTurnRadius, kStatsMinTurnRadius, kStatsStep, &stats);
 
   ASSERT_EQ(without.size(), with.size()) << "collecting stats changed the sub-path split";
   for (std::size_t i = 0; i < without.size(); ++i)

--- a/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
+++ b/ros2/src/mowgli_coverage/test/test_coverage_planning.cpp
@@ -2118,3 +2118,99 @@ TEST(CoveragePlanning, DegenerateRecordedRingSanitizedToFullCoverage)
       << "swaths span only " << swath_span << " m of the field's " << field_span
       << " m x-extent — coverage is still partial";
 }
+
+// ── ConnectorStats (issue #499) ───────────────────────────────────────────────
+//
+// The connector-outcome counter is the prerequisite measurement for ever
+// changing min_turning_radius / connector_turn_radius: raising the floor makes
+// buildConnector's shrink search give up sooner and fall through to a straight
+// blind connector, and nothing else in the plan or the logs distinguishes that
+// from a healthy turn-around arc. These tests pin the accounting itself, not
+// any particular radius — a radius change is expected to MOVE these numbers,
+// which is the entire point of having them.
+
+// The three outcomes partition every attempted join. If this ever fails, the
+// fallback rate derived from them is meaningless.
+TEST(CoverageConnectorStats, OutcomesPartitionAttemptedJoins)
+{
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kInset = 0.15;
+  constexpr double kMinSwath = 0.15;
+  constexpr double kTurnRadius = 0.18;
+  constexpr double kMinTurnRadius = 0.15;
+  constexpr double kStep = 0.03;
+
+  const f2c::types::Cell cell = makeSquare(6.0);
+  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
+  ASSERT_FALSE(plan.rings.empty());
+
+  mowgli_coverage::ConnectorStats stats;
+  const auto subs =
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
+
+  ASSERT_FALSE(subs.empty());
+  EXPECT_GT(stats.attempted, 0u) << "a multi-segment plan must attempt connectors";
+  EXPECT_EQ(stats.attempted, stats.arc + stats.straight_kept + stats.split)
+      << "arc/straight_kept/split must partition attempted — the fallback rate "
+         "derived from them is otherwise nonsense";
+}
+
+// A hole-free convex field is the easy case: real turn-around arcs should fit at
+// nearly every join. This is the baseline a raised min_turning_radius would be
+// measured against — it pins "arcs dominate today", not a specific radius.
+TEST(CoverageConnectorStats, ConvexFieldIsJoinedMostlyByArcs)
+{
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kInset = 0.15;
+  constexpr double kMinSwath = 0.15;
+  constexpr double kTurnRadius = 0.18;
+  constexpr double kMinTurnRadius = 0.15;
+  constexpr double kStep = 0.03;
+
+  const f2c::types::Cell cell = makeSquare(6.0);
+  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
+  ASSERT_FALSE(plan.rings.empty());
+
+  mowgli_coverage::ConnectorStats stats;
+  (void)
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
+
+  ASSERT_GT(stats.attempted, 0u);
+  const double arc_share = static_cast<double>(stats.arc) / static_cast<double>(stats.attempted);
+  EXPECT_GT(arc_share, 0.5) << "only " << stats.arc << "/" << stats.attempted
+                            << " joins got a real turn-around arc on a hole-free convex "
+                               "field — the connector search is failing where it should "
+                               "succeed";
+}
+
+// The counter is opt-in: every existing caller passes no stats pointer, so the
+// nullptr path must stay safe and must not change the plan.
+TEST(CoverageConnectorStats, NullStatsPointerIsSafeAndChangesNothing)
+{
+  constexpr double kOpWidth = 0.16;
+  constexpr double kHeadland = 0.18;
+  constexpr double kInset = 0.15;
+  constexpr double kMinSwath = 0.15;
+  constexpr double kTurnRadius = 0.18;
+  constexpr double kMinTurnRadius = 0.15;
+  constexpr double kStep = 0.03;
+
+  const f2c::types::Cell cell = makeSquare(6.0);
+  const auto plan = planBoustrophedon(cell, kOpWidth, kHeadland, 0, kInset, -1.0, kMinSwath);
+  ASSERT_FALSE(plan.rings.empty());
+
+  const auto without =
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep);
+  mowgli_coverage::ConnectorStats stats;
+  const auto with =
+      buildContinuousSubPaths(plan, plan.safe_boundary, kTurnRadius, kMinTurnRadius, kStep, &stats);
+
+  ASSERT_EQ(without.size(), with.size()) << "collecting stats changed the sub-path split";
+  for (std::size_t i = 0; i < without.size(); ++i)
+  {
+    EXPECT_EQ(without[i].size(), with[i].size())
+        << "collecting stats changed sub-path " << i << "'s pose count";
+  }
+}


### PR DESCRIPTION
Addresses #499 (violent swath-end turns carving the lawn). Maintainer-approved scope: **the guard, the counter, and the turn-speed fix — and explicitly NOT a radius change.**

## Why one PR and not two

The guard and the turn-speed fix both live in the same ~40-line injection block of `navigation.launch.py` (the guard reports `speed_slow`, which the speed fix computes), so splitting them guarantees a conflict on the same hunk. They are separated as **two commits** instead:

| commit | scope | files |
|---|---|---|
| `6829f55f` **feat(coverage)** | connector fallback counter | `mowgli_coverage` only |
| `d33a5c70` **fix(nav2)** | turn speed + turn-geometry guard | `mowgli_bringup` (launch, config, tests) |

## What is NOT here

**No radius was changed.** `min_turning_radius` stays 0.15 and `connector_turn_radius` stays 0.18. The counter shipped first to produce the data — and it did, immediately and unexpectedly: see [What the counter measured](#⚠%EF%B8%8F-what-the-counter-measured--it-inverts-the-premise-of-499) below. The trade is now measured (one join in 32), which changes the argument but not the decision: the radius call stays the maintainer's.

---

## ⚠️ What the counter measured — it inverts the premise of #499

The first number `ConnectorStats` ever produced contradicted the reason it was built. CI caught it: the test asserting *"arcs dominate on a hole-free convex field"* failed at **1/33 joins**. The assertion was wrong; the planner was not.

Measured on the **shipped** coverage geometry (`num_headland_passes` 2, `op_width = tool_width − swath_overlap`, `connector_turn_radius` 0.18, `min_turning_radius` 0.15), with joins bounded by `connector_clearance_boundary` exactly as `coverage_server` bounds them — 6 m square, `chassis_safety_inset` 0.20:

| headland apron | rings | attempted | arc | straight_kept | split |
|---|---|---|---|---|---|
| **shipped (2 passes, 0.32 m)** | 2 | 32 | **1** | **31** | 0 |
| wide (8 passes, 1.28 m) | 8 | 26 | 24 | 2 | 0 |
| spacing ≥ 2R (0.50 m) | 1 | 10 | 10 | 0 | 0 |
| shipped, floor 0.15 → 0.25 | 2 | 32 | 2 → 1 | 30 → 31 | 0 |

**Three consequences, in order of importance:**

**1. The swath-end turns are not arcs.** 31 of 32 joins are straight blind connectors. `roundSharpCorners` cannot fillet the resulting 90° corners either: its tangent length is `d = r/tan((π−turn)/2) = min_turning_radius = 0.15 m`, and it requires `d ≤ 0.49 ×` the edge it trims into — but that edge is the connector itself, only `op_width = 0.16 m` long, so `0.15 > 0.078` and the fillet is rejected at every radius. Measured over the whole plan: **31 corners above 88°, max exactly 90.0°, minimum implied radius 0.018 m**. At a wide apron the same field has **2**.

That reconciles the two analyses. #499 §3 is right that every turn happens inside `FOLLOWING` (no `PRE_ROTATE`, no Nav2 `Spin`) — but the geometry being followed there is a sharp corner, not a Dubins Ω-loop. A saturated forward-only controller cutting a 90° corner produces exactly the reported signature, including the measured chassis radius of **0.09–0.14 m being *tighter* than the 0.15 m planner floor** — which under the arc hypothesis needed FTC to "fall behind and curl in", and under this one needs no explanation at all: nothing planned a 0.15 m arc.

**2. The fallback trade that deferred the radius decision is not present.** Raising `min_turning_radius` 0.15 → 0.25 (ceiling raised alongside so the shrink search starts identically) moves **one join out of 32** and splits nothing. The fear that a higher floor would trade arcs for straight joins assumed there were arcs to lose; at the shipped apron there is one.

**3. The binding constraint is the headland apron, not the radius.** At swath spacing `d < 2R` the turn-around must be an omega (RLR/LRL) loop whose forward extent past the swath end is `≈ sqrt(4R² − (R + d/2)²) + R` — **0.43 m** at `R = 0.18, d = 0.16`. The apron available is `num_headland_passes × op_width` = **0.32 m**. Nothing in `[0.15, 0.18]` fits, so `buildConnector` exhausts its search every time. Widen the apron and the *same search at the same radii* succeeds at 24/26.

The synthetic field is **not** the artefact here: `num_headland_passes: 2` is the field-validated shipped default, and the same sweep on a robot-scale 12 m field at the live `op_width` 0.13 gives **1/87**. Production is worse than the test, not better, because it bounds connectors to the tighter `connector_clearance_boundary`.

**This is posted on #499 as a comment.** The radius conversation restarts from a different place, and that call is still the maintainer's — **no radius is changed here.**

### What changed in this PR as a result

- The failing assertion is replaced by four tests that pin the **mechanism** rather than a number — see Testing below.
- Comments the measurement disproved are corrected: the `ConnectorStats` docblock, `kConnectorFallbackWarnPct`'s rationale, the stats log line, and `check_turn_geometry`'s advice.
- **Expect the connector WARN on every plan** at the shipped defaults (~97 % fallback). It is kept rather than tuned away — a swath end that is a sharp corner instead of a tangent arc *is* the defect — but the message now names the apron so an operator is not sent chasing the radii.

---

## 1. Connector fallback counter (`ConnectorStats`)

`min_turning_radius` is the **floor** of `buildConnector`'s radius-shrink search, so raising it makes the search give up sooner and fall through to the straight blind connector. Nothing in the plan, the action result, or the logs currently distinguishes that from a healthy turn-around arc — a radius change that *fixed* the turns and one that *quietly replaced every arc with a straight join* look identical.

Three mutually exclusive outcomes per segment join, summing to `attempted`:

| outcome | meaning | cost |
|---|---|---|
| `arc` | a real forward Dubins turn-around fitted in-bounds | healthy |
| `straight_kept` | shrink loop gave up; the straight join verified in-bounds and is **driven blade-on** | heading discontinuity instead of a tangent arc |
| `split` | no drivable connector; sub-path **broken**, bridged blade-off | un-mowed transit time |

The server logs the breakdown next to the radii that produced it, at **WARN** once the fallback share reaches 25 % so an operator A/B'ing a radius sees it without enabling debug logging:

```
PlanCoverage connectors: 47 join(s): 44 turn-around arc, 2 straight fallback
(driven blade-on), 1 split (blade-off transit); fallback rate 6.4% at
connector_turn_radius=0.18 min_turning_radius=0.15
```

**Changes no decision and no path.** The counter is an opt-in trailing out-param defaulting to `nullptr`; all 14 existing call sites are untouched, and a test pins that passing it changes neither the sub-path split nor any pose count.

**On the GUI:** deliberately log-only. The `PlanCoverage` action result has no diagnostics field, so surfacing it there means an `.action` change plus regenerated GUI message bindings — a large blast radius for a counter whose consumer is a log-reader doing an A/B. Easy to add later if the number proves worth a dashboard.

## 2. `speed_slow` derived from `mowing_speed`

`speed_fast` is overridden at launch by the operator's `mowing_speed`, but `speed_slow` — FTC's target wherever the path **bends**, i.e. every swath-end turn-around arc and every headland corner fillet — was a static `0.16`. The live robot runs `mowing_speed=0.15`, so it drove its **turns 7 % faster than its straights**. Lowering `mowing_speed` slowed no turn at all.

```
speed_slow = clamp(mowing_speed * turn_speed_ratio, min_speed_mps, mowing_speed)
```

`turn_speed_ratio` is a new operator knob defaulting to **0.8 in the in-package template** (Invariant 15 — the installed config stays sparse and "reset to default" keeps working). `0.8 × 0.20 = 0.16` reproduces the historical pair **exactly**, so a robot on the default `mowing_speed` sees no behaviour change.

Both clamps encode a real limit rather than taste:
- **ceiling `mowing_speed`** — a turn must never be faster than a straight. That *is* the defect, and it is also what a ratio > 1 would mean.
- **floor `min_speed_mps`** — FTC floors its own longitudinal output there, so a lower target is a value the controller would silently ignore (and below the firmware PWM deadband the wheels stall). It warns instead of injecting a fiction.

This also hands the operator a working lever on carve severity while the radius question is open: peak wheel speed in a bend is `v · (1 + track/2R)`, so it scales linearly with turn speed. It does **not** change the inner/outer wheel *ratio* — that is set by radius against half-track and is speed-independent.

**Existing `mowing_speed` plumbing is untouched**: `SetNavMode` and the `speed_fast` / `max_cmd_vel_speed` injection are unchanged; this only adds a second consumer of the same value.

## 3. Turn-geometry guard — WARN, not hard failure

`coverage_server`'s radii live in `mowgli_robot.yaml`; `FollowCoveragePath`'s clamps live in `nav2_params_base.yaml`. No check and no test tied them together, which is how both of these shipped:

- **`min_turning_radius` 0.15 m ≤ half-track 0.1625 m.** An arc of radius R needs the inner wheel at `v·(1 − track/2R)`; at R ≤ track/2 that is zero or **negative**. The path is built as cusp-free *forward* arcs and FTC runs `forward_only`, so nothing expects a reversing inner wheel — it reverses anyway, in the soil.
- **Tightest arc FTC can command** is `speed_slow / max_cmd_vel_ang` = 0.20 m, but coverage plans down to 0.15 m. Every swath-end turn saturates the angular command for its whole length; measured chassis radius was **0.09–0.14 m against a 0.15–0.18 m plan**.

Live output on the current robot config:

```
WARN: min_turning_radius=0.15 m is at/below the half-track (0.325 / 2 = 0.1625 m).
Every arc planned at that floor needs the INNER wheel at -0.013 m/s while the outer
runs 0.312 m/s — a reversing inner wheel carves the lawn at swath ends (issue #499).
Raise mowgli_robot.yaml.min_turning_radius above 0.1625 m, but read the coverage
server's 'PlanCoverage connectors:' fallback rate first — a higher floor trades
turn-around arcs for straight joins.

WARN: coverage plans turn arcs down to 0.150 m (min_turning_radius=0.15,
connector_turn_radius=0.18) but the tightest arc FollowCoveragePath can command is
speed_slow/max_cmd_vel_ang = 0.150/0.8 = 0.187 m. ...
```

### Why WARN and not a hard failure — the justification you asked for

1. **The currently shipped defaults trip check A** (0.15 ≤ 0.1625). Raising would refuse to start navigation on **every existing robot**, turning a lawn-quality defect into a total outage.
2. **Neither condition is a launch-time safety hazard.** Firmware remains the sole blade-safety authority and still owns the e-stop; what these degrade is mowing *quality*. A robot that refuses to mow is strictly worse than one that mows with poor turns while the operator reads the warning.
3. **No unrecoverable input survives to reach here.** Radius ≤ 0, or a connector radius below the floor, are already contained by the `[0.10, 0.50]` clamps applied before injection.

The bar for a hard failure is *"cannot be made safe"*, and neither clears it. There is consequently **no hard-guard branch at all** — adding one that no reachable input can trigger would be dead code. The warnings are loud and carry the numbers, because the whole failure was that the offending values lived in different files and nothing related them.

The guard reuses the **clamped** radii that are actually injected (hoisted into `eff_min_turn_radius` / `eff_connector_turn_radius`), so it can never report a plan the coverage server does not receive. `wheel_track` comes from the robot config, single-sourced as `DEFAULT_WHEEL_TRACK_M` — which a test pins equal to the template value, and which must equal the firmware `WHEEL_BASE` that does the real IK.

## Testing

`navigation.launch.py` imports `launch`/`launch_ros` and cannot be imported outside a sourced ROS2 install, which is why this logic was previously untestable. Both helpers are therefore **pure functions in `robot_config_util`**, exercised for real rather than by regex:

- **`TestDeriveTurnSpeed`** (6) — ratio scaling reproduces 0.16 exactly; turn never exceeds `mowing_speed` at the live 0.15; ratio > 1 and ≤ 0 clamped and warned; `min_speed_mps` floor warns; ceiling wins when floor and ceiling conflict.
- **`TestCheckTurnGeometry`** (6) — flags the live inner-wheel reversal and the planner/controller mismatch; silent on drivable geometry; the warning carries the actual `-0.013 m/s`; `R == half_track` still warns; **never raises on any input**, including degenerate ones.
- **`CoverageConnectorStats`** (5, gtest) — rewritten after the measurement above. The outcomes partition `attempted`; **every** join is an arc where a plain U-turn provably fits (spacing 0.50 ≥ 2×0.18, apron 0.50 m > extent 0.18 m — hand-checkable, so a stuck classifier cannot masquerade as a planner result); a narrow vs wide apron at *identical radii* separates the two outcomes; raising the floor 0.15 → 0.25 moves ≤ 2 joins and splits nothing; `nullptr` stats changes nothing. Each failure message says which direction moved and to re-measure #499 rather than relax the bound.
- Wiring guards in `test_nav2_params.py`; template guards for `turn_speed_ratio ∈ (0, 1]` and `DEFAULT_WHEEL_TRACK_M` vs template `wheel_track`.

**`mowgli_coverage` built and run for real** in a `docker-dev-sim` container (it carries `/opt/fields2cover-300`): **57 tests, 0 failures, 6 skipped**, including the five `CoverageConnectorStats` and the full lint set. Every number in the table above is from that run, not from arithmetic. **70 runtime-free `mowgli_bringup` tests pass** (three `*.launch.py` modules need a ROS2 runtime and two `test_urdf_xacro.py` cases need `xacro` — both pre-existing laptop gaps).

The stats format string is ASCII-only on purpose: a non-ASCII character inside a line-continued macro makes clang-format 18 (CI) and 22 (local pre-push hook) disagree about the backslash column forever. Both report clean on every touched file.

## Safety

No firmware change. No change to blade commands, the `ANTIDIG_*` gate, the e-stop path, or the dig detector. The only motion-affecting change is `speed_slow`, which for a default-config robot resolves to the same 0.16 it uses today, and which can now only ever be **lower** than the straight-line speed, never higher.

## Next step

The counter has now produced its fallback rate — **~97 %, and the apron rather than the radius is what sets it** — so a radius A/B (#499 §6B) is no longer the informative next experiment; `num_headland_passes` is. Still owed either way is the gyro recording described in #499 §6A — `/imu/data.angular_velocity.z` against `/cmd_vel.angular.z` over ≥10 swath-end turns, which is what separates real chassis rotation from the 1.7 rad/s the slipping encoders report.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ

