### PR TITLE
fix(nav2): restore FTC setPlan's shared reset/augment/publish tail

### DIFF
--- a/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
+++ b/ros2/src/mowgli_nav2_plugins/src/ftc_controller.cpp
@@ -657,51 +657,60 @@ void FTCController::setPlan(const nav_msgs::msg::Path& path)
   // Starting at 0 makes the two consistent again.
   //
   // snap_to_nearest_on_set_plan restores the old behaviour if a site needs it.
+  //
+  // NOTE: this block chooses the START INDEX ONLY. Everything after it —
+  // PID/derivative/stall reset, the tail-duplication the state machine's
+  // `size() - 2` arithmetic depends on, the latched plan publish, and the
+  // <3-pose termination guard — is SHARED and must run on BOTH paths. An
+  // earlier revision returned early from the default branch and skipped all of
+  // it, which leaked integrator windup from an aborted strip into the next
+  // strip's first tick and transitioned the state machine one segment early.
+  // Do not reintroduce an early return here.
   if (!config_.snap_to_nearest_on_set_plan)
   {
+    // current_index_ is already 0 from the reset above.
     RCLCPP_INFO(logger_,
                 "FTCController: setPlan with %zu points, starting at idx=0.",
                 global_plan_.size());
-    last_time_ = clock_->now();
-    current_movement_speed_ = config_.speed_slow;
-    return;
   }
-
-  try
+  else
   {
-    const auto base_to_map = tf_buffer_->lookupTransform("map",
-                                                         "base_link",
-                                                         tf2::TimePointZero,
-                                                         tf2::durationFromSec(0.5));
-    const double rx = base_to_map.transform.translation.x;
-    const double ry = base_to_map.transform.translation.y;
-
-    std::vector<std::pair<double, double>> xy;
-    xy.reserve(global_plan_.size());
-    for (const auto& p : global_plan_)
+    try
     {
-      xy.emplace_back(p.pose.position.x, p.pose.position.y);
-    }
-    current_index_ = static_cast<uint32_t>(ChooseStartIndex(true, xy, rx, ry));
+      const auto base_to_map = tf_buffer_->lookupTransform("map",
+                                                           "base_link",
+                                                           tf2::TimePointZero,
+                                                           tf2::durationFromSec(0.5));
+      const double rx = base_to_map.transform.translation.x;
+      const double ry = base_to_map.transform.translation.y;
 
-    const double bdx = global_plan_[current_index_].pose.position.x - rx;
-    const double bdy = global_plan_[current_index_].pose.position.y - ry;
-    const double best_dist = std::hypot(bdx, bdy);
-    RCLCPP_INFO(logger_,
-                "FTCController: setPlan with %zu points, starting at idx=%u (%.2fm from robot at "
-                "%.2f,%.2f).",
-                global_plan_.size(),
-                current_index_,
-                best_dist,
-                rx,
-                ry);
-  }
-  catch (const tf2::TransformException& ex)
-  {
-    RCLCPP_WARN(logger_,
-                "FTCController: TF lookup in setPlan failed (%s), starting from idx=0.",
-                ex.what());
-    current_index_ = 0;
+      std::vector<std::pair<double, double>> xy;
+      xy.reserve(global_plan_.size());
+      for (const auto& p : global_plan_)
+      {
+        xy.emplace_back(p.pose.position.x, p.pose.position.y);
+      }
+      current_index_ = static_cast<uint32_t>(ChooseStartIndex(true, xy, rx, ry));
+
+      const double bdx = global_plan_[current_index_].pose.position.x - rx;
+      const double bdy = global_plan_[current_index_].pose.position.y - ry;
+      const double best_dist = std::hypot(bdx, bdy);
+      RCLCPP_INFO(logger_,
+                  "FTCController: setPlan with %zu points, starting at idx=%u (%.2fm from robot "
+                  "at %.2f,%.2f).",
+                  global_plan_.size(),
+                  current_index_,
+                  best_dist,
+                  rx,
+                  ry);
+    }
+    catch (const tf2::TransformException& ex)
+    {
+      RCLCPP_WARN(logger_,
+                  "FTCController: TF lookup in setPlan failed (%s), starting from idx=0.",
+                  ex.what());
+      current_index_ = 0;
+    }
   }
 
   last_time_ = clock_->now();


### PR DESCRIPTION
Regression introduced by #490 (already merged to `dev`). Found by an adversarial multi-agent review of the merged branch, then confirmed against the merged source.

## What went wrong

#490 added an early return on the default `setPlan` path — and the shipped default is `snap_to_nearest_on_set_plan=false`, so this hit **every robot on every strip re-dispatch**:

```cpp
if (!config_.snap_to_nearest_on_set_plan) {
  RCLCPP_INFO(... "starting at idx=0.");
  last_time_ = clock_->now();
  current_movement_speed_ = config_.speed_slow;
  return;                                    // ← skipped everything below
}
...
stall_time_ = 0.0;  is_stalled_ = false;
i_lon_error_ = 0.0; ... d_angle_filt_ = 0.0;
global_plan_.push_back(global_plan_.back());
global_plan_pub_->publish(pub_path);
// and the <3-pose → FINISHED guard
```

Four consequences:

1. **PID / derivative / stall state leaked between plans.** `i_lon_error_`, `i_lat_error_`, `i_angle_error_`, `last_*_error_`, `d_*_filt_`, `stall_time_`, `is_stalled_` all carried over. A strip aborted with a saturated integrator (`ki_lon_max = 10`, up to 10 s of windup) dumped that into the next strip's first tick. Class defaults are 0.0, so the *first* plan of a process was fine — only re-dispatches were affected, which is why a short field run would not surface it.
2. **Tail-duplication never ran.** `update_planner_state` and the carrot loop both key off `global_plan_.size() - 2`, which is only correct after the duplicate tail pose is appended. Without it, FOLLOWING transitions one segment early and the final segment loses the heading the augmentation copies in.
3. **`<plugin>/global_plan` stopped publishing**, freezing the plan overlay.
4. **The `<3`-pose guard never fired**, so a 2-pose plan hung in `WAITING_FOR_GOAL_APPROACH` until `goal_timeout` instead of terminating as `FINISHED`.

The state reset *above* the early return (`angle_error_raw_prev_`, `is_avoiding_`, `lateral_deviation_`, `reverse_escape_active_`) **was** happening, which is what made the omission easy to miss on review.

## The fix

The branch now chooses the **start index only**; the reset / augment / publish tail is shared and runs on both paths. A comment at the branch says so explicitly, because the failure mode is invisible at the call site.

**No change to index selection.** The default still starts at 0 — #490's actual fix, which stops a closed headland ring being skipped and was field-verified (a 436-pose ring went from 2.0 s to 224.7 s). `snap_to_nearest_on_set_plan` still restores the legacy nearest-point search.

## Testing gap, stated honestly

`setPlan` has no unit test — it needs a constructed `FTCController` and the package's existing gtests are pure-helper only (`ftc_stall.hpp`, `ftc_start_index.hpp`). This fix is verified by reading the merged source and by CI compiling it, not by a new test. A test that pins "both branches leave the plan augmented and the PID state zeroed" would need a controller fixture; worth doing, out of scope here.

**Recommend merging before the next field run** — `dev` currently carries the regression.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ