### PR TITLE
fix(behavior): stop area recording throwing away boundary detail

### DIFF
--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/recording_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/recording_nodes.hpp
@@ -38,25 +38,86 @@ namespace mowgli_behavior
 // RecordArea — record robot trajectory and save as mowing area polygon
 // ---------------------------------------------------------------------------
 
-/// Records the robot's position at ~1 Hz while the user drives along the
-/// boundary. On finish (COMMAND_RECORD_FINISH=5), simplifies the trajectory
-/// using Douglas-Peucker algorithm and saves it as a mowing area via the
+/// Records the robot's position while the user drives along the boundary. On
+/// finish (COMMAND_RECORD_FINISH=5), simplifies the trajectory using the
+/// Douglas-Peucker algorithm and saves it as a mowing area via the
 /// map_server_node/add_area service.
 ///
 /// On cancel (COMMAND_RECORD_CANCEL=6), discards the recording.
 ///
 /// Returns RUNNING while recording, SUCCESS on finish, FAILURE on cancel or error.
 ///
+/// BOUNDARY RESOLUTION — the three limiters, and why they are set where they are.
+/// A field recording produced only 24 vertices for a 38.13 m perimeter (~1.6 m
+/// between vertices on a hand-driven garden boundary). Two knobs caused it:
+///
+///  1. `simplification_tolerance` was 0.2 m. Douglas-Peucker guarantees only
+///     that the stored polygon stays WITHIN the tolerance of the driven path,
+///     so the saved boundary could be wrong by 0.2 m — wider than a full
+///     cutting swath (`tool_width`, 0.18 m default, 0.15 m on some builds).
+///     A boundary error larger than one swath is the wrong order of magnitude:
+///     it can cost (or over-cut) an entire outermost pass.
+///  2. `record_rate_hz` was 2.0. kMinSampleSpacingM (below) is the INTENDED
+///     resolution floor, but at 2 Hz and any real driving speed the samples
+///     arrive 0.15-0.25 m apart, so the gate never bit and the SAMPLE RATE was
+///     the true limiter — DP was simplifying an already-coarse polyline.
+///
+/// The values are now derived rather than picked:
+///  * Rate: the gate binds when v / rate <= kMinSampleSpacingM. `max_mps`
+///    (0.5 m/s) is a hard runtime wheel-speed ceiling pushed to the STM32, so
+///    the robot CANNOT be driven faster than that while recording. This gives
+///    rate >= 0.5 / 0.05 = 10 Hz. That is also the ceiling: onRunning() only
+///    executes when the tree ticks, so `tick_rate` (10 Hz) caps the achievable
+///    rate — a higher record_rate_hz is silently ineffective, and is warned
+///    about at onStart() using the `bt_tick_rate` blackboard entry.
+///  * Tolerance: the useful window is [kMinSampleSpacingM, tool_width). Below
+///    the sampling gate DP cannot recover detail that was never sampled — it
+///    only preserves jitter — and above tool_width the error exceeds a swath.
+///    kMinSampleSpacingM (0.05 m) is where "as fine as the data supports" and
+///    "comfortably under a swath" (0.05 m is tool_width / 3) coincide.
+///
+/// The third limiter is downstream and needs no change: `mowgli_coverage`'s
+/// dedupClosedRing() collapses the ingested boundary ring at 1 cm (metric
+/// dedup) / 5 mm (near-collinear spike removal). Both sit an order of magnitude
+/// below the 5 cm sampling floor, so they cost no recorded detail — and the
+/// collinear pass doubles as the second-stage collapse of straight runs that
+/// keeps the vertex count off F2C. map_server's on_add_area() stores the
+/// polygon verbatim (no re-simplification, no clamping, no resampling).
+///
 /// Input ports:
-///   simplification_tolerance (double, default "0.2") — Douglas-Peucker tolerance in metres.
+///   simplification_tolerance (double, default kDefaultSimplificationToleranceM)
+///       — Douglas-Peucker tolerance in metres.
 ///   min_vertices (uint32_t, default "3") — minimum polygon vertices after simplification.
 ///   min_area (double, default "1.0") — minimum polygon area in square metres.
-///   record_rate_hz (double, default "1.0") — position recording frequency.
+///   record_rate_hz (double, default kDefaultRecordRateHz) — position sampling frequency.
 class RecordArea : public BT::StatefulActionNode
 {
   friend class ::RecordAreaAlgorithmTest;  // test access to private static methods
 
 public:
+  /// Minimum spacing between two consecutive RECORDED trajectory points (m).
+  /// This is the intended boundary resolution floor: a sample closer than this
+  /// to the previous kept point is dropped as a duplicate. It also sets the
+  /// floor for a useful `simplification_tolerance` (see the class comment).
+  static constexpr double kMinSampleSpacingM = 0.05;
+
+  /// Default Douglas-Peucker tolerance (m). Equal to kMinSampleSpacingM — the
+  /// finest tolerance the sampled data can actually support, and one third of
+  /// the 0.18 m default `tool_width`.
+  static constexpr double kDefaultSimplificationToleranceM = kMinSampleSpacingM;
+
+  /// Default position sampling rate (Hz). Chosen so kMinSampleSpacingM is the
+  /// binding limiter at `max_mps` (0.5 m/s), the hard wheel-speed ceiling.
+  /// Also equals the default BT `tick_rate`, which is the achievable maximum.
+  static constexpr double kDefaultRecordRateHz = 10.0;
+
+  /// Rate (Hz) at which the live trajectory preview Path is republished to the
+  /// GUI. Deliberately DECOUPLED from (and far below) the sampling rate: each
+  /// publish rebuilds the entire trajectory, so publishing every sample is
+  /// O(n^2) allocation work over a recording — ~700 poses at 10 Hz — for a
+  /// preview no operator can perceive at more than a few Hz.
+  static constexpr double kPreviewPublishRateHz = 2.0;
+
   RecordArea(const std::string& name, const BT::NodeConfig& config)
       : BT::StatefulActionNode(name, config)
   {
@@ -65,10 +126,12 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-        BT::InputPort<double>("simplification_tolerance", 0.2, "Douglas-Peucker tolerance (m)"),
+        BT::InputPort<double>("simplification_tolerance",
+                              kDefaultSimplificationToleranceM,
+                              "Douglas-Peucker tolerance (m)"),
         BT::InputPort<uint32_t>("min_vertices", 3u, "Minimum polygon vertices"),
         BT::InputPort<double>("min_area", 1.0, "Minimum polygon area (m^2)"),
-        BT::InputPort<double>("record_rate_hz", 1.0, "Recording frequency (Hz)"),
+        BT::InputPort<double>("record_rate_hz", kDefaultRecordRateHz, "Recording frequency (Hz)"),
         BT::InputPort<bool>("is_exclusion_zone", false, "Record as exclusion zone"),
     };
   }
@@ -80,6 +143,12 @@ public:
 private:
   /// Record current robot position into trajectory_.
   void record_position();
+
+  /// True when `candidate` is at least kMinSampleSpacingM from `last` and so
+  /// should be appended to the trajectory. This is the minimum-spacing gate —
+  /// the intended boundary-resolution floor.
+  static bool is_sample_far_enough(const geometry_msgs::msg::Point32& last,
+                                   const geometry_msgs::msg::Point32& candidate);
 
   /// Apply Douglas-Peucker simplification to the trajectory.
   static std::vector<geometry_msgs::msg::Point32> douglas_peucker(
@@ -106,11 +175,20 @@ private:
   /// Recorded trajectory points in map frame.
   std::vector<geometry_msgs::msg::Point32> trajectory_;
 
+  /// Publish the live trajectory preview Path (all points recorded so far).
+  void publish_preview();
+
   /// Timestamp of last recorded position.
   std::chrono::steady_clock::time_point last_record_time_;
 
-  /// Recording interval (computed from record_rate_hz).
-  std::chrono::milliseconds record_interval_{1000};
+  /// Timestamp of last published trajectory preview.
+  std::chrono::steady_clock::time_point last_preview_time_;
+
+  /// Position sampling interval (computed from record_rate_hz).
+  std::chrono::milliseconds record_interval_{100};
+
+  /// Trajectory-preview publish interval (kPreviewPublishRateHz).
+  std::chrono::milliseconds preview_interval_{static_cast<int>(1000.0 / kPreviewPublishRateHz)};
 
   /// Publisher for live trajectory preview.
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr trajectory_pub_;

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -35,6 +35,7 @@
 #include "mowgli_behavior/coverage_persistence.hpp"
 #include "mowgli_behavior/escape_nodes.hpp"
 #include "mowgli_behavior/localization_health.hpp"
+#include "mowgli_behavior/recording_nodes.hpp"
 #include "mowgli_behavior/status_snapshot.hpp"
 #include "mowgli_interfaces/gnss_status_utils.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
@@ -945,6 +946,26 @@ private:
     // the plan_coverage action goal (mow_angle_deg).
     const double mow_angle_deg = declare_parameter<double>("mow_angle_deg", kMowAngleAutoDeg);
     blackboard_->set("mow_angle_deg", mow_angle_deg);
+
+    // Area-recording boundary resolution — operator-tunable in
+    // mowgli_robot.yaml, previously HARDCODED in main_tree.xml (a 0.2 m
+    // Douglas-Peucker tolerance and a 2 Hz sample rate, which together gave a
+    // field recording 24 vertices for a 38 m perimeter). Pushed onto the
+    // blackboard so the XML pulls them as {area_simplification_tolerance} /
+    // {area_record_rate_hz}. See RecordArea's class comment for the derivation
+    // of both defaults.
+    const double area_simplification_tolerance =
+        declare_parameter<double>("area_simplification_tolerance",
+                                  RecordArea::kDefaultSimplificationToleranceM);
+    const double area_record_rate_hz =
+        declare_parameter<double>("area_record_rate_hz", RecordArea::kDefaultRecordRateHz);
+    blackboard_->set("area_simplification_tolerance", area_simplification_tolerance);
+    blackboard_->set("area_record_rate_hz", area_record_rate_hz);
+
+    // RecordArea samples once per BT tick at best, so it needs the tick rate to
+    // warn when a configured record rate is unachievable rather than silently
+    // sampling slower than asked.
+    blackboard_->set("bt_tick_rate", get_parameter("tick_rate").as_double());
 
     tree_ = factory_.createTreeFromFile(tree_file, blackboard_);
 

--- a/ros2/src/mowgli_behavior/src/recording_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/recording_nodes.cpp
@@ -36,12 +36,43 @@ BT::NodeStatus RecordArea::onStart()
   // Clear any previous recording
   trajectory_.clear();
 
-  // Parse recording rate
-  double rate_hz = 1.0;
+  // Parse position sampling rate.
+  double rate_hz = kDefaultRecordRateHz;
   getInput<double>("record_rate_hz", rate_hz);
   if (rate_hz <= 0.0)
-    rate_hz = 1.0;
+    rate_hz = kDefaultRecordRateHz;
+
+  // onRunning() only executes when the tree ticks, so the BT tick rate is a
+  // hard ceiling on the achievable sampling rate. Warn rather than silently
+  // under-delivering: a rate that quietly does nothing is exactly the failure
+  // mode that made the old 2 Hz default look like a working knob.
+  double tick_rate_hz = 0.0;
+  if (config().blackboard->get("bt_tick_rate", tick_rate_hz) && tick_rate_hz > 0.0 &&
+      rate_hz > tick_rate_hz)
+  {
+    RCLCPP_WARN(ctx->node->get_logger(),
+                "RecordArea: record_rate_hz=%.1f exceeds the BT tick_rate=%.1f Hz and cannot be "
+                "achieved; sampling will run at %.1f Hz. Raise tick_rate to sample faster.",
+                rate_hz,
+                tick_rate_hz,
+                tick_rate_hz);
+    rate_hz = tick_rate_hz;
+  }
+
   record_interval_ = std::chrono::milliseconds(static_cast<int>(1000.0 / rate_hz));
+
+  // A tolerance below the sampling floor cannot recover detail that was never
+  // sampled — it only preserves GNSS/steering jitter as extra vertices.
+  double tolerance_check = kDefaultSimplificationToleranceM;
+  getInput<double>("simplification_tolerance", tolerance_check);
+  if (tolerance_check < kMinSampleSpacingM)
+  {
+    RCLCPP_WARN(ctx->node->get_logger(),
+                "RecordArea: simplification_tolerance=%.3f m is below the %.2f m sampling floor; "
+                "it cannot add boundary detail, only retain jitter.",
+                tolerance_check,
+                kMinSampleSpacingM);
+  }
 
   // Create trajectory preview publisher (latched for GUI)
   if (!trajectory_pub_)
@@ -54,11 +85,15 @@ BT::NodeStatus RecordArea::onStart()
   // Record initial position
   record_position();
   last_record_time_ = std::chrono::steady_clock::now();
+  last_preview_time_ = last_record_time_;
 
   RCLCPP_INFO(ctx->node->get_logger(),
-              "RecordArea: started recording (rate=%.1f Hz, interval=%ld ms)",
+              "RecordArea: started recording (rate=%.1f Hz, interval=%ld ms, "
+              "min spacing=%.2f m, DP tolerance=%.3f m)",
               rate_hz,
-              record_interval_.count());
+              record_interval_.count(),
+              kMinSampleSpacingM,
+              tolerance_check);
 
   return BT::NodeStatus::RUNNING;
 }
@@ -77,7 +112,7 @@ BT::NodeStatus RecordArea::onRunning()
                   trajectory_.size());
 
       // Get parameters
-      double tolerance = 0.2;
+      double tolerance = kDefaultSimplificationToleranceM;
       uint32_t min_verts = 3;
       double min_area_val = 1.0;
       bool is_exclusion = false;
@@ -189,33 +224,51 @@ BT::NodeStatus RecordArea::onRunning()
     }
   }
 
-  // Record position at the configured rate
+  // Sample position at the configured rate.
   auto now = std::chrono::steady_clock::now();
   if (now - last_record_time_ >= record_interval_)
   {
     record_position();
     last_record_time_ = now;
 
-    // Publish trajectory preview
-    nav_msgs::msg::Path preview;
-    preview.header.frame_id = "map";
-    preview.header.stamp = ctx->node->get_clock()->now();
-    for (const auto& pt : trajectory_)
-    {
-      geometry_msgs::msg::PoseStamped pose;
-      pose.header = preview.header;
-      pose.pose.position.x = static_cast<double>(pt.x);
-      pose.pose.position.y = static_cast<double>(pt.y);
-      pose.pose.position.z = 0.0;
-      pose.pose.orientation.w = 1.0;
-      preview.poses.push_back(pose);
-    }
-    trajectory_pub_->publish(preview);
-
     RCLCPP_DEBUG(ctx->node->get_logger(), "RecordArea: %zu points recorded", trajectory_.size());
   }
 
+  // Republish the preview on its OWN, slower clock. Each publish rebuilds the
+  // whole trajectory, so tying it to the sampling rate would make a recording
+  // cost O(n^2) allocations for a preview nobody can perceive that fast.
+  if (now - last_preview_time_ >= preview_interval_)
+  {
+    publish_preview();
+    last_preview_time_ = now;
+  }
+
   return BT::NodeStatus::RUNNING;
+}
+
+void RecordArea::publish_preview()
+{
+  if (!trajectory_pub_)
+  {
+    return;
+  }
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+
+  nav_msgs::msg::Path preview;
+  preview.header.frame_id = "map";
+  preview.header.stamp = ctx->node->get_clock()->now();
+  preview.poses.reserve(trajectory_.size());
+  for (const auto& pt : trajectory_)
+  {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header = preview.header;
+    pose.pose.position.x = static_cast<double>(pt.x);
+    pose.pose.position.y = static_cast<double>(pt.y);
+    pose.pose.position.z = 0.0;
+    pose.pose.orientation.w = 1.0;
+    preview.poses.push_back(pose);
+  }
+  trajectory_pub_->publish(preview);
 }
 
 void RecordArea::onHalted()
@@ -242,16 +295,12 @@ void RecordArea::record_position()
     pt.y = static_cast<float>(tf.transform.translation.y);
     pt.z = 0.0f;
 
-    // Skip if too close to last point (less than 5cm) to avoid duplicates
-    if (!trajectory_.empty())
+    // Drop a sample closer than kMinSampleSpacingM to the last KEPT point.
+    // This is the intended boundary-resolution floor (and the reason the
+    // sampling rate must be fast enough for it — not the rate — to bind).
+    if (!trajectory_.empty() && !is_sample_far_enough(trajectory_.back(), pt))
     {
-      const auto& last = trajectory_.back();
-      double dx = static_cast<double>(pt.x - last.x);
-      double dy = static_cast<double>(pt.y - last.y);
-      if (dx * dx + dy * dy < 0.0025)  // 5cm squared
-      {
-        return;
-      }
+      return;
     }
 
     trajectory_.push_back(pt);
@@ -264,6 +313,14 @@ void RecordArea::record_position()
                          "RecordArea: TF lookup failed: %s",
                          ex.what());
   }
+}
+
+bool RecordArea::is_sample_far_enough(const geometry_msgs::msg::Point32& last,
+                                      const geometry_msgs::msg::Point32& candidate)
+{
+  const double dx = static_cast<double>(candidate.x) - static_cast<double>(last.x);
+  const double dy = static_cast<double>(candidate.y) - static_cast<double>(last.y);
+  return dx * dx + dy * dy >= kMinSampleSpacingM * kMinSampleSpacingM;
 }
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/test/test_recording_nodes.cpp
+++ b/ros2/src/mowgli_behavior/test/test_recording_nodes.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cmath>
+#include <utility>
 #include <vector>
 
 #include <rclcpp/rclcpp.hpp>
@@ -92,7 +93,219 @@ protected:
   {
     return mowgli_behavior::RecordArea::douglas_peucker(points, tolerance);
   }
+
+  static bool is_sample_far_enough(const geometry_msgs::msg::Point32& last,
+                                   const geometry_msgs::msg::Point32& candidate)
+  {
+    return mowgli_behavior::RecordArea::is_sample_far_enough(last, candidate);
+  }
+
+  /// Replay a densely-sampled drive through RecordArea's minimum-spacing gate,
+  /// exactly as record_position() does, and return the kept trajectory.
+  static std::vector<geometry_msgs::msg::Point32> apply_spacing_gate(
+      const std::vector<geometry_msgs::msg::Point32>& samples)
+  {
+    std::vector<geometry_msgs::msg::Point32> kept;
+    for (const auto& s : samples)
+    {
+      if (kept.empty() || is_sample_far_enough(kept.back(), s))
+      {
+        kept.push_back(s);
+      }
+    }
+    return kept;
+  }
 };
+
+namespace
+{
+constexpr double kTolerance = mowgli_behavior::RecordArea::kDefaultSimplificationToleranceM;
+constexpr double kOldTolerance = 0.2;  // the pre-fix hardcoded value
+constexpr double kMinSpacing = mowgli_behavior::RecordArea::kMinSampleSpacingM;
+
+/// Sample a closed rectangular boundary at `step` metres, as a recording drive
+/// at `speed` and a given sample rate would. Perimeter = 2 * (w + h).
+std::vector<geometry_msgs::msg::Point32> sample_rectangle(float w, float h, double step)
+{
+  std::vector<geometry_msgs::msg::Point32> pts;
+  const std::vector<std::pair<geometry_msgs::msg::Point32, geometry_msgs::msg::Point32>> edges = {
+      {make_point(0.0f, 0.0f), make_point(w, 0.0f)},
+      {make_point(w, 0.0f), make_point(w, h)},
+      {make_point(w, h), make_point(0.0f, h)},
+      {make_point(0.0f, h), make_point(0.0f, 0.0f)},
+  };
+  for (const auto& e : edges)
+  {
+    const double len = std::hypot(e.second.x - e.first.x, e.second.y - e.first.y);
+    const int n = static_cast<int>(len / step);
+    for (int i = 0; i < n; ++i)
+    {
+      const double t = static_cast<double>(i) / static_cast<double>(n);
+      pts.push_back(make_point(static_cast<float>(e.first.x + t * (e.second.x - e.first.x)),
+                               static_cast<float>(e.first.y + t * (e.second.y - e.first.y))));
+    }
+  }
+  return pts;
+}
+}  // namespace
+
+// ===========================================================================
+// Boundary-resolution regression tests
+//
+// Field report: a recorded 38.13 m perimeter came back with only 24 vertices
+// (~1.6 m apart) because simplification_tolerance was 0.2 m — wider than
+// tool_width — and record_rate_hz was 2 Hz, so the 0.05 m spacing gate never
+// bound and the sample rate was the real limiter.
+// ===========================================================================
+
+TEST_F(RecordAreaAlgorithmTest, DefaultToleranceIsBelowToolWidthAndAtSamplingFloor)
+{
+  // The tolerance IS the worst-case boundary error (DP's guarantee), so it must
+  // stay well under one cutting swath. tool_width defaults to 0.18 m and is
+  // 0.15 m on some builds; the tolerance must clear the smaller of those.
+  constexpr double kNarrowestToolWidth = 0.15;
+  EXPECT_LT(kTolerance, kNarrowestToolWidth)
+      << "boundary error must never exceed a full cutting swath";
+  EXPECT_LE(kTolerance / kNarrowestToolWidth, 0.5)
+      << "tolerance should be comfortably below tool_width, not merely under it";
+
+  // Below the sampling floor DP cannot recover detail that was never sampled.
+  EXPECT_GE(kTolerance, kMinSpacing) << "a tolerance finer than the sample spacing buys nothing";
+}
+
+TEST_F(RecordAreaAlgorithmTest, DefaultRateMakesSpacingGateBindAtMaxSpeed)
+{
+  // max_mps (0.5 m/s) is a hard runtime wheel-speed ceiling pushed to the STM32,
+  // so it bounds how fast the robot can be driven while recording. The gate
+  // binds only when the per-sample travel is at or below the spacing floor.
+  constexpr double kMaxMps = 0.5;
+  const double rate = mowgli_behavior::RecordArea::kDefaultRecordRateHz;
+  EXPECT_LE(kMaxMps / rate, kMinSpacing)
+      << "at max_mps the sample rate, not the 5 cm gate, would be the limiter";
+
+  // And the old 2 Hz default did NOT bind — this is the bug being fixed.
+  EXPECT_GT(kMaxMps / 2.0, kMinSpacing);
+
+  // onRunning() runs inside the BT tick, so tick_rate is the achievable ceiling.
+  // A default above it would be silently unattainable.
+  constexpr double kDefaultTickRate = 10.0;
+  EXPECT_LE(rate, kDefaultTickRate) << "default record rate must be achievable at the BT tick rate";
+}
+
+TEST_F(RecordAreaAlgorithmTest, NewTolerancePreservesFeatureThatOldToleranceDestroyed)
+{
+  // A 0.12 m bump on an otherwise straight 4 m run — smaller than the old 0.2 m
+  // tolerance, larger than the new 0.05 m one. This is exactly the class of
+  // garden-boundary detail (a shrub, a bed corner) that used to vanish.
+  std::vector<geometry_msgs::msg::Point32> path;
+  for (int i = 0; i <= 40; ++i)
+  {
+    const float x = static_cast<float>(i) * 0.1f;
+    const float y = (i == 20) ? 0.12f : 0.0f;
+    path.push_back(make_point(x, y));
+  }
+
+  const auto old_result = douglas_peucker(path, kOldTolerance);
+  EXPECT_EQ(old_result.size(), 2u) << "old tolerance flattened the bump into a straight line";
+
+  const auto new_result = douglas_peucker(path, kTolerance);
+  ASSERT_GT(new_result.size(), 2u) << "new tolerance must retain the bump";
+
+  bool bump_kept = false;
+  for (const auto& p : new_result)
+  {
+    if (std::abs(p.y - 0.12f) < 1e-4f)
+    {
+      bump_kept = true;
+    }
+  }
+  EXPECT_TRUE(bump_kept) << "the apex of the feature must survive simplification";
+}
+
+TEST_F(RecordAreaAlgorithmTest, SpacingGateCollapsesDuplicatesAndSubThresholdSamples)
+{
+  const auto origin = make_point(1.0f, 2.0f);
+
+  // Exact duplicate and near-duplicates below the floor are rejected.
+  EXPECT_FALSE(is_sample_far_enough(origin, origin));
+  EXPECT_FALSE(is_sample_far_enough(origin, make_point(1.02f, 2.0f)));
+  EXPECT_FALSE(is_sample_far_enough(origin, make_point(1.0f, 2.049f)));
+
+  // At/above the floor they are kept — including on a diagonal.
+  EXPECT_TRUE(is_sample_far_enough(origin, make_point(1.06f, 2.0f)));
+  EXPECT_TRUE(is_sample_far_enough(origin, make_point(1.04f, 2.04f)));
+
+  // Replaying a stationary robot (TF jitter only) must not grow the trajectory.
+  std::vector<geometry_msgs::msg::Point32> jitter;
+  for (int i = 0; i < 100; ++i)
+  {
+    jitter.push_back(make_point(1.0f + 0.003f * static_cast<float>(i % 3), 2.0f));
+  }
+  EXPECT_EQ(apply_spacing_gate(jitter).size(), 1u)
+      << "a parked robot must record exactly one point";
+}
+
+TEST_F(RecordAreaAlgorithmTest, RealisticPerimeterYieldsUsefulButBoundedVertexCount)
+{
+  // A 38.13 m perimeter, matching the operator's recorded_area_1. Sampled at
+  // 10 Hz while driving 0.3 m/s => 0.03 m raw steps, which the gate thins.
+  const float w = 11.0f;
+  const float h = 8.065f;  // 2 * (11 + 8.065) = 38.13 m
+  const auto raw = sample_rectangle(w, h, 0.03);
+  const auto kept = apply_spacing_gate(raw);
+
+  // The gate — not the sample rate — is what sets the spacing.
+  for (size_t i = 1; i < kept.size(); ++i)
+  {
+    const double d = std::hypot(kept[i].x - kept[i - 1].x, kept[i].y - kept[i - 1].y);
+    EXPECT_GE(d, kMinSpacing - 1e-6) << "gate must enforce the floor at index " << i;
+    EXPECT_LT(d, kMinSpacing + 0.03 + 1e-6) << "spacing must not exceed floor + one sample step";
+  }
+  EXPECT_GT(kept.size(), 600u) << "38 m at ~6 cm spacing should retain hundreds of raw samples";
+
+  // DP then collapses the straight runs. A boundary this simple must come back
+  // near its true corner count — and must NOT explode into hundreds of vertices
+  // that would bloat areas.dat and slow F2C/costmap polygon work.
+  const auto simplified = douglas_peucker(kept, kTolerance);
+  EXPECT_LE(simplified.size(), 40u) << "straight runs must collapse; no vertex explosion";
+
+  // The old settings are what produced the 24-vertex field result; the new
+  // pipeline must do better than ~1.6 m between vertices on a real boundary.
+  const double perimeter = 2.0 * (static_cast<double>(w) + static_cast<double>(h));
+  EXPECT_LT(perimeter / static_cast<double>(kept.size()), 0.1)
+      << "recorded resolution must be well under a cutting swath";
+}
+
+TEST_F(RecordAreaAlgorithmTest, DegenerateTrajectoryStillTrippedByMinVerticesAndMinArea)
+{
+  // Guard 1: a trajectory that cannot form a polygon. douglas_peucker returns
+  // it untouched (< 3 points), so the min_vertices check in onRunning() sees a
+  // sub-minimum count and bails rather than saving garbage.
+  const std::vector<geometry_msgs::msg::Point32> two_points = {make_point(0.0f, 0.0f),
+                                                               make_point(1.0f, 0.0f)};
+  const auto simplified_pair = douglas_peucker(two_points, kTolerance);
+  EXPECT_EQ(simplified_pair.size(), 2u);
+  EXPECT_LT(simplified_pair.size(), 3u) << "must fail the min_vertices=3 guard";
+  EXPECT_DOUBLE_EQ(polygon_area(simplified_pair), 0.0);
+
+  // Guard 2: a collinear drive (robot pushed in a straight line, never closing
+  // a loop) simplifies to its endpoints and has zero area.
+  std::vector<geometry_msgs::msg::Point32> straight;
+  for (int i = 0; i <= 30; ++i)
+  {
+    straight.push_back(make_point(static_cast<float>(i) * 0.06f, 0.0f));
+  }
+  const auto simplified_straight = douglas_peucker(straight, kTolerance);
+  EXPECT_EQ(simplified_straight.size(), 2u);
+  EXPECT_NEAR(polygon_area(simplified_straight), 0.0, 1e-6) << "must fail the min_area=1.0 guard";
+
+  // Guard 3: a real but tiny loop keeps its vertices yet is still under
+  // min_area, so it is rejected on area rather than slipping through.
+  const auto tiny = sample_rectangle(0.4f, 0.4f, 0.03);
+  const auto simplified_tiny = douglas_peucker(apply_spacing_gate(tiny), kTolerance);
+  EXPECT_GE(simplified_tiny.size(), 3u);
+  EXPECT_LT(polygon_area(simplified_tiny), 1.0) << "~0.15 m^2 must fail the min_area=1.0 guard";
+}
 
 // ===========================================================================
 // perpendicular_distance tests

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -998,8 +998,8 @@
         <!-- ============================================================
              d. Recording (COMMAND_S1 = 3 = COMMAND_RECORD_AREA)
              User drives robot along boundary. The RecordArea node
-             records positions at 2 Hz and publishes a live trajectory
-             preview. When the user presses "Finish" (command 5) the
+             samples positions at area_record_rate_hz and publishes a
+             live trajectory preview. When the user presses "Finish" (command 5) the
              trajectory is simplified with Douglas-Peucker and saved
              as a mowing area. "Cancel" (command 6) discards it.
              ============================================================ -->
@@ -1033,11 +1033,17 @@
             <IsCommand command="6"/>
           </Fallback>
           <PublishHighLevelStatus state="3" state_name="RECORDING"/>
+          <!-- simplification_tolerance / record_rate_hz come from
+               mowgli_robot.yaml via behavior_tree_node's blackboard (they were
+               hardcoded at 0.2 m / 2 Hz, which cost a field recording all but
+               24 vertices of a 38 m perimeter). min_vertices / min_area stay
+               hardcoded: they are degenerate-polygon guards, not resolution
+               knobs, and nothing sane wants them retuned. -->
           <RecordArea
-            simplification_tolerance="0.2"
+            simplification_tolerance="{area_simplification_tolerance}"
             min_vertices="3"
             min_area="1.0"
-            record_rate_hz="2.0"
+            record_rate_hz="{area_record_rate_hz}"
             is_exclusion_zone="false"/>
           <PublishHighLevelStatus state="1" state_name="RECORDING_COMPLETE"/>
           <EndSession/>

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -91,6 +91,42 @@ mowgli:
     yaw_gyro_sign: 1
     # Behavior tree tuning (consumed by behavior_tree_node)
     tick_rate: 10.0
+
+    # -----------------------------------------------------------------
+    # Area recording (RecordArea — "drive the boundary" teach-in)
+    # -----------------------------------------------------------------
+    # Both of these were HARDCODED in main_tree.xml until 2026-08-25. A field
+    # recording came back with 24 vertices for a 38.13 m perimeter (~1.6 m
+    # between vertices on a hand-driven garden boundary), because BOTH limiters
+    # were set far coarser than the job needs. RecordArea also applies a fixed
+    # 0.05 m minimum spacing between consecutive kept points; that gate is the
+    # INTENDED resolution floor, and these two values exist to let it bind.
+    #
+    # area_simplification_tolerance: Douglas-Peucker tolerance in metres. DP
+    # guarantees only that the stored polygon stays WITHIN this distance of the
+    # driven path, so this IS the worst-case boundary error. It was 0.2 m —
+    # larger than tool_width (0.18 m), i.e. the saved boundary could be off by
+    # more than a full cutting swath. The useful window is [0.05, tool_width):
+    # below 0.05 m there is nothing to gain (the sampler never produces points
+    # closer than that, so a finer tolerance only preserves GNSS/steering
+    # jitter as extra vertices), and at/above tool_width the error costs a whole
+    # outermost pass. 0.05 m is both ends of that window's sweet spot:
+    # tool_width / 3, and exactly as fine as the sampled data supports.
+    area_simplification_tolerance: 0.05
+    #
+    # area_record_rate_hz: position sampling frequency. It was 2.0, which at any
+    # real driving speed put samples 0.15-0.25 m apart — so the 0.05 m gate
+    # almost never fired and the SAMPLE RATE, not the gate, was the real
+    # limiter. The gate binds when speed / rate <= 0.05; max_mps (0.5 m/s) is a
+    # hard runtime wheel-speed ceiling pushed to the STM32, so the robot cannot
+    # be driven faster than that while recording, giving 0.5 / 0.05 = 10 Hz.
+    # 10 Hz is ALSO the ceiling: RecordArea samples inside the BT tick, so
+    # tick_rate (above) caps it — a larger value here is silently ineffective
+    # and logs a warning at recording start. Raise tick_rate first if you ever
+    # want to sample faster. The per-tick cost is one TF lookup plus a distance
+    # compare; the trajectory preview republishes on its own 2 Hz clock so the
+    # GUI path message does not get rebuilt at the sampling rate.
+    area_record_rate_hz: 10.0
     # Localization-quality gate (LocalizationGuard): pause blade-on mowing
     # while ABSOLUTE POSITION is untrustworthy. Field incident 2026-08-02:
     # >60 s plain-GPS fallback (σ ≈ 1.5 m) drove the robot out of the area

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -246,6 +246,21 @@ def generate_launch_description() -> LaunchDescription:
             # fixed swath angle in degrees. Read by PlanCoverageArea::buildGoal
             # off the BT blackboard into the plan_coverage action goal.
             {"mow_angle_deg": float(robot_params.get("mow_angle_deg", -1.0))},
+            # Area-recording boundary resolution. Both were hardcoded in
+            # main_tree.xml (0.2 m Douglas-Peucker tolerance, 2 Hz sampling),
+            # which cost a field recording all but 24 vertices of a 38 m
+            # perimeter. The tolerance must stay well under tool_width so a
+            # boundary error can never exceed one cutting swath, and the rate
+            # must be fast enough that RecordArea's 0.05 m minimum-spacing gate
+            # — not the sample rate — is the binding limiter. 10 Hz covers
+            # max_mps (0.5 m/s) and is also the BT tick_rate ceiling, above
+            # which a higher value has no effect.
+            {
+                "area_simplification_tolerance": float(
+                    robot_params.get("area_simplification_tolerance", 0.05)
+                )
+            },
+            {"area_record_rate_hz": float(robot_params.get("area_record_rate_hz", 10.0))},
             # LocalizationGuard thresholds. These were previously listed in
             # mowgli_robot.yaml but NEVER forwarded here, so the node silently
             # ran its compiled defaults and the GUI's reset-to-default had


### PR DESCRIPTION
## Problem

The operator's live `recorded_area_1` has **24 boundary points for a 38.13 m perimeter** — about 1.6 m between vertices on a hand-driven garden boundary. Two limiters, both hardcoded in `main_tree.xml`, caused it.

**1. `simplification_tolerance = 0.2` m.** Douglas-Peucker guarantees only that the stored polygon stays *within* the tolerance of the driven path, so 0.2 m **was the worst-case boundary error** — wider than `tool_width` (0.18 m default, 0.15 m on the reporter's build). A boundary error larger than one full cutting swath is the wrong order of magnitude: it can cost or over-cut an entire outermost pass.

**2. `record_rate_hz = 2.0`.** `RecordArea` already had a 5 cm minimum-spacing gate that reads like the intended resolution floor — but at 2 Hz and any real driving speed the samples land 0.15-0.25 m apart, so the gate almost never fired and the **sample rate** was the true limiter. DP was simplifying an already-coarse polyline.

## Values chosen, and the argument for each

Both are derived, not picked.

**Rate -> 10 Hz.** The 5 cm gate binds when `speed / rate <= 0.05`. `max_mps` (0.5 m/s) is a *hard runtime wheel-speed ceiling* pushed down to the STM32, so the robot **cannot** be driven faster than that while recording — that is a bound, not an estimate. It gives `0.5 / 0.05 = 10 Hz`, at which the gate binds across the entire achievable speed range.

10 Hz is **also the ceiling**, which is the part worth flagging: `RecordArea::onRunning()` executes only inside a BT tick, so `tick_rate` (10 Hz, `full_system.launch.py`) caps the achievable rate. Anything higher was *silently* ineffective — the same class of bug as the one being fixed — so it now warns at recording start via a `bt_tick_rate` blackboard entry.

**Tolerance -> 0.05 m.** The useful window is `[sampling floor, tool_width)`. Below 0.05 m, DP cannot recover detail that was never sampled — it only preserves GNSS/steering jitter as extra vertices. At or above `tool_width`, the error costs a swath. 0.05 m is the single point where "as fine as the sampled data supports" and "comfortably under a swath" (`tool_width / 3`) coincide.

## Third limiter — checked, and left alone

I read the whole path (`RecordArea::tick` -> trajectory accumulation -> `save_area` -> `map_server` -> coverage ingest):

- **`map_server::on_add_area()` stores the polygon verbatim** — no re-simplification, no clamping, no resampling. `areas.dat` is written at `setprecision(6)` (1 um).
- **`mowgli_coverage::dedupClosedRing()`** collapses the ingested boundary ring at **1 cm** (`kRingDedupTolM`, metric dedup) and **5 mm** (`kRingSpikeTolM`, near-collinear spike removal). Both sit an order of magnitude below the 5 cm sampling floor, so they cost no recorded detail — and the collinear pass already *is* the second-stage collapse of straight runs, so no vertex cap is warranted here.
- **`coverage_server.cpp`'s other DP (`kDpTol = 0.08` m in `ringToArcs`)** only shapes the discrete `segments` list kept for the GUI and resume bookkeeping. The **driven** path is `drivable_subpaths`, built by `buildContinuousSubPaths` from the raw `plan.rings`, so this never touches what gets mowed.

Net: no third limiter needed changing.

## Vertex-count sanity check

38.13 m at ~6 cm spacing is **~634 raw samples**, verified against the actual gate + DP implementations. DP then collapses straight runs hard (a clean rectangle of that perimeter comes back at 5 vertices; a wobbly hand-driven boundary lands well below the raw count).

Even the pathological no-collapse case is fine: ~13 KB of `areas.dat`, and the same order as the densification F2C already performs internally (`kSwathStep = 0.10` m per ring, several concentric rings). The one measurable cost is `grid_map::PolygonIterator`'s O(cells x vertices) stamp on `add_area` — tens of ms, once. No vertex cap or extra collapse stage added.

## Configurability

Both are now ROS parameters seeded onto the BT blackboard, following the existing `{undock_speed}` / `{battery_low_pct}` pattern in `behavior_tree_node.cpp`, referenced from the tree as `{area_simplification_tolerance}` / `{area_record_rate_hz}`.

Defaults live in the **in-package template** `mowgli_bringup/config/mowgli_robot.yaml` (Invariant 15 — *not* the sparse installed config) and are plumbed through `full_system.launch.py` alongside the existing BT params. `min_vertices` / `min_area` stay hardcoded: they are degenerate-polygon guards, not resolution knobs.

The GUI `mower_config.schema.json` has no `additionalProperties: false`, so the new keys do not break config saves. Surfacing them in the GUI Settings page is deliberately out of scope.

## Backward compatibility

**Confirmed, not assumed.** `load_areas_from_file()` parses each stored polygon with `parse_polygon_string()` **verbatim** — the only load-time dedup is whole-*obstacle* duplicate collapse, never boundary vertices, and the datum re-projection (Invariant 4) transforms coordinates while preserving vertex count. These values are read only while recording a **new** area. Existing `areas.dat` entries are unaffected.

## Also in this PR

The trajectory preview publish is **decoupled from the sample rate**. Each publish rebuilds the entire `Path`, so tying it to 10 Hz sampling would be O(n^2) allocation work over a recording (~634 poses, 10x/s) for a preview no operator perceives that fast. It now runs on its own 2 Hz clock — which is what the sampling rate used to be, so the GUI sees no change.

The 5 cm gate is hoisted out of a magic number into `kMinSampleSpacingM` and extracted as a testable `is_sample_far_enough()` predicate.

## Test plan

New gtests in `test_recording_nodes.cpp` (numeric expectations pre-verified against a standalone replica of the gate + DP, not guessed):

- [x] `DefaultToleranceIsBelowToolWidthAndAtSamplingFloor` — pins the tolerance inside `[sampling floor, 0.5 x narrowest tool_width]`.
- [x] `DefaultRateMakesSpacingGateBindAtMaxSpeed` — pins that the gate binds at `max_mps`, that the **old 2 Hz did not**, and that the default is achievable at `tick_rate`.
- [x] `NewTolerancePreservesFeatureThatOldToleranceDestroyed` — a 0.12 m bump on a straight 4 m run: old 0.2 m flattens it to 2 points; new 0.05 m keeps 5 including the apex.
- [x] `SpacingGateCollapsesDuplicatesAndSubThresholdSamples` — exact duplicates, axis and diagonal sub-threshold samples, and a parked robot (100 jitter samples -> exactly 1 point).
- [x] `RealisticPerimeterYieldsUsefulButBoundedVertexCount` — 38.13 m perimeter: asserts the gate (not the rate) sets spacing, ~634 raw points retained, resolution < 0.1 m, and no vertex explosion after DP.
- [x] `DegenerateTrajectoryStillTrippedByMinVerticesAndMinArea` — 2-point trajectory fails `min_vertices`; a collinear drive simplifies to 2 points with zero area; a real 0.4 x 0.4 m loop keeps its vertices but fails `min_area`.

CI-matching clang-format 18 run and clean (`did not modify any files`).

- [ ] **Field**: record a boundary and confirm the saved vertex count and shape fidelity against the driven path.

Claude-Session: https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
