### PR TITLE
fix(lidar): correct STL27L runtime configuration

### DIFF
--- a/install/compose/docker-compose.lidar-stl27l.yml
+++ b/install/compose/docker-compose.lidar-stl27l.yml
@@ -23,11 +23,11 @@ services:
     command: >
       ros2 run ldlidar_stl_ros2 ldlidar_stl_ros2_node
       --ros-args
-      -p product_name:=STL27L
+      -p product_name:=${LIDAR_MODEL:-LDLiDAR_STL27L}
       -p topic_name:=scan
       -p frame_id:=lidar_link
       -p port_name:=${LIDAR_PORT:-/dev/lidar}
-      -p port_baudrate:=${LIDAR_BAUD:-230400}
+      -p port_baudrate:=${LIDAR_BAUD:-921600}
       -p laser_scan_dir:=true
       -p enable_angle_crop_func:=false
     restart: unless-stopped

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -1019,12 +1019,12 @@ parse_args() {
             LIDAR_CONNECTION="uart"; LIDAR_BAUD="230400"
             ;;
           stl27l-usb)
-            LIDAR_ENABLED="true"; LIDAR_TYPE="stl27l"; LIDAR_MODEL="STL27L"
-            LIDAR_CONNECTION="usb"; LIDAR_BAUD="230400"; LIDAR_UART_DEVICE=""
+            LIDAR_ENABLED="true"; LIDAR_TYPE="stl27l"; LIDAR_MODEL="LDLiDAR_STL27L"
+            LIDAR_CONNECTION="usb"; LIDAR_BAUD="921600"; LIDAR_UART_DEVICE=""
             ;;
           stl27l-uart)
-            LIDAR_ENABLED="true"; LIDAR_TYPE="stl27l"; LIDAR_MODEL="STL27L"
-            LIDAR_CONNECTION="uart"; LIDAR_BAUD="230400"
+            LIDAR_ENABLED="true"; LIDAR_TYPE="stl27l"; LIDAR_MODEL="LDLiDAR_STL27L"
+            LIDAR_CONNECTION="uart"; LIDAR_BAUD="921600"
             ;;
           *)
             error "Unknown lidar spec: $lidar_spec"

--- a/install/lib/env.sh
+++ b/install/lib/env.sh
@@ -243,11 +243,16 @@ setup_env() {
   # LiDAR
   : "${LIDAR_ENABLED:=true}"
   : "${LIDAR_TYPE:=ldlidar}"
-  : "${LIDAR_MODEL:=LDLiDAR_LD19}"
   : "${LIDAR_CONNECTION:=uart}"
   : "${LIDAR_PORT:=/dev/lidar}"
   : "${LIDAR_UART_DEVICE:=/dev/ttyAMA5}"
-  : "${LIDAR_BAUD:=230400}"
+  if [[ "${LIDAR_TYPE:-ldlidar}" == "stl27l" ]]; then
+    : "${LIDAR_MODEL:=LDLiDAR_STL27L}"
+    : "${LIDAR_BAUD:=921600}"
+  else
+    : "${LIDAR_MODEL:=LDLiDAR_LD19}"
+    : "${LIDAR_BAUD:=230400}"
+  fi
 
   # TF-Luna
   : "${TFLUNA_FRONT_ENABLED:=false}"

--- a/install/lib/lidar.sh
+++ b/install/lib/lidar.sh
@@ -10,6 +10,14 @@ configure_lidar() {
   if [[ "${PRESET_LOADED:-false}" == "true" && -n "${LIDAR_TYPE:-}" ]]; then
     : "${LIDAR_PORT:=/dev/lidar}"
 
+    # Keep STL27L's driver contract available even when an older/minimal
+    # preset only records the lidar type.  Explicit preset/user overrides
+    # remain authoritative.
+    if [[ "${LIDAR_TYPE}" == "stl27l" ]]; then
+      : "${LIDAR_MODEL:=LDLiDAR_STL27L}"
+      : "${LIDAR_BAUD:=921600}"
+    fi
+
     info "LiDAR pre-configured (skipping prompts)"
 
     # For UART connections, always let user confirm/change the port
@@ -60,8 +68,8 @@ configure_lidar() {
       4)
         LIDAR_ENABLED="true"
         LIDAR_TYPE="stl27l"
-        LIDAR_MODEL="STL27L"
-        LIDAR_BAUD="230400"
+        LIDAR_MODEL="LDLiDAR_STL27L"
+        LIDAR_BAUD="921600"
         ;;
       *)
         error "$MSG_LIDAR_INVALID_TYPE"

--- a/install/tests/lib/harness.sh
+++ b/install/tests/lib/harness.sh
@@ -257,12 +257,12 @@ harness_set_preset() {
             LIDAR_CONNECTION=uart; LIDAR_UART_DEVICE=/dev/ttyAMA5; LIDAR_BAUD=230400
             ;;
           stl27l-usb)
-            LIDAR_ENABLED=true; LIDAR_TYPE=stl27l; LIDAR_MODEL=STL27L
-            LIDAR_CONNECTION=usb; LIDAR_UART_DEVICE=""; LIDAR_BAUD=230400
+            LIDAR_ENABLED=true; LIDAR_TYPE=stl27l; LIDAR_MODEL=LDLiDAR_STL27L
+            LIDAR_CONNECTION=usb; LIDAR_UART_DEVICE=""; LIDAR_BAUD=921600
             ;;
           stl27l-uart)
-            LIDAR_ENABLED=true; LIDAR_TYPE=stl27l; LIDAR_MODEL=STL27L
-            LIDAR_CONNECTION=uart; LIDAR_UART_DEVICE=/dev/ttyAMA5; LIDAR_BAUD=230400
+            LIDAR_ENABLED=true; LIDAR_TYPE=stl27l; LIDAR_MODEL=LDLiDAR_STL27L
+            LIDAR_CONNECTION=uart; LIDAR_UART_DEVICE=/dev/ttyAMA5; LIDAR_BAUD=921600
             ;;
         esac
         ;;

--- a/install/tests/test_lidar_matrix.sh
+++ b/install/tests/test_lidar_matrix.sh
@@ -27,7 +27,7 @@ services_in() {
   grep -E '^\s+container_name:' "$1/docker/docker-compose.yaml" | awk '{print $2}' | sort
 }
 
-# Run a preset and assert on LIDAR_TYPE / LIDAR_BAUD / LIDAR_IMAGE
+# Run a preset and assert on LIDAR_TYPE / LIDAR_MODEL / LIDAR_BAUD / LIDAR_IMAGE
 # and the resulting compose. Args:
 #   $1 label    — short tag for the section
 #   $2 preset   — the lidar=... value
@@ -49,6 +49,16 @@ check_lidar_preset() {
     return
   fi
   assert_eq "$label: LIDAR_TYPE" "$type_exp" "$(env_value "$repo" LIDAR_TYPE)"
+  case "$type_exp" in
+    # setup_env historically keeps the generic LD19 fallback in .env even
+    # when the lidar service is disabled; keep that contract pinned here.
+    none)    model_exp="LDLiDAR_LD19" ;;
+    rplidar) model_exp="RPLIDAR_A1" ;;
+    ldlidar) model_exp="LDLiDAR_LD19" ;;
+    stl27l)  model_exp="LDLiDAR_STL27L" ;;
+    *)       model_exp="" ;;
+  esac
+  assert_eq "$label: LIDAR_MODEL" "$model_exp" "$(env_value "$repo" LIDAR_MODEL)"
   if [ -n "$baud_exp" ]; then
     assert_eq "$label: LIDAR_BAUD" "$baud_exp" "$(env_value "$repo" LIDAR_BAUD)"
   fi
@@ -59,6 +69,26 @@ check_lidar_preset() {
       *)                 fail "$label: LIDAR_IMAGE contains '$image_substr'" "got '$img'" ;;
     esac
   fi
+
+  local compose_content
+  compose_content="$(cat "$repo/docker/docker-compose.yaml")"
+  case "$type_exp" in
+    stl27l)
+      # The generated compose intentionally keeps env references so later
+      # edits to docker/.env take effect.  Assert both the canonical runtime
+      # fallback and the generated env value that supplies it on install.
+      assert_contains "$label: STL27L compose product_name fallback" \
+        'product_name:=${LIDAR_MODEL:-LDLiDAR_STL27L}' "$compose_content"
+      assert_contains "$label: STL27L compose baud fallback" \
+        'port_baudrate:=${LIDAR_BAUD:-921600}' "$compose_content"
+      assert_not_contains "$label: STL27L compose rejects legacy product name" \
+        'product_name:=STL27L' "$compose_content"
+      ;;
+    rplidar)
+      assert_contains "$label: RPLidar compose baud default unchanged" \
+        'serial_baudrate:=${LIDAR_BAUD:-115200}' "$compose_content"
+      ;;
+  esac
   case "$(services_in "$repo")" in
     *mowgli-lidar*)
       if [ "$want_service" = "1" ]; then
@@ -85,7 +115,36 @@ check_lidar_preset "ldlidar_uart"  "ldlidar-uart"  "ldlidar"   "230400"  "lidar-
 check_lidar_preset "ldlidar_usb"   "ldlidar-usb"   "ldlidar"   "230400"  "lidar-ldlidar"          "1"
 check_lidar_preset "rplidar_uart"  "rplidar-uart"  "rplidar"   "115200"  "lidar-rplidar"          "1"
 check_lidar_preset "rplidar_usb"   "rplidar-usb"   "rplidar"   "115200"  "lidar-rplidar"          "1"
-check_lidar_preset "stl27l_uart"   "stl27l-uart"   "stl27l"    "230400"  "lidar-stl27l"           "1"
-check_lidar_preset "stl27l_usb"    "stl27l-usb"    "stl27l"    "230400"  "lidar-stl27l"           "1"
+check_lidar_preset "stl27l_uart"   "stl27l-uart"   "stl27l"    "921600"  "lidar-stl27l"           "1"
+check_lidar_preset "stl27l_usb"    "stl27l-usb"    "stl27l"    "921600"  "lidar-stl27l"           "1"
+
+section "STL27L type-specific setup_env defaults"
+repo_defaults="$SANDBOX/repo_lidar_defaults"
+sandbox_repo "$repo_defaults"
+harness_init "$repo_defaults"
+LIDAR_TYPE="stl27l"
+unset LIDAR_MODEL LIDAR_BAUD
+if setup_env >/dev/null 2>&1; then
+  pass "defaults: setup_env"
+  assert_eq "defaults: LIDAR_MODEL" "LDLiDAR_STL27L" "$(env_value "$repo_defaults" LIDAR_MODEL)"
+  assert_eq "defaults: LIDAR_BAUD" "921600" "$(env_value "$repo_defaults" LIDAR_BAUD)"
+else
+  fail "defaults: setup_env"
+fi
+
+section "STL27L explicit overrides remain effective"
+repo_override="$SANDBOX/repo_lidar_override"
+sandbox_repo "$repo_override"
+harness_init "$repo_override"
+harness_set_preset gnss=auto gnss_connection=uart lidar=stl27l-uart tfluna=none
+LIDAR_MODEL="custom-stl27l-driver"
+LIDAR_BAUD="123456"
+if harness_run >/dev/null 2>&1; then
+  pass "override: harness_run"
+  assert_eq "override: LIDAR_MODEL" "custom-stl27l-driver" "$(env_value "$repo_override" LIDAR_MODEL)"
+  assert_eq "override: LIDAR_BAUD" "123456" "$(env_value "$repo_override" LIDAR_BAUD)"
+else
+  fail "override: harness_run"
+fi
 
 test_summary

--- a/sensors/lidar-stl27l/Dockerfile
+++ b/sensors/lidar-stl27l/Dockerfile
@@ -53,10 +53,10 @@ RUN chmod +x /ros2_entrypoint.sh
 ENTRYPOINT ["/ros2_entrypoint.sh"]
 CMD ["ros2", "run", "ldlidar_stl_ros2", "ldlidar_stl_ros2_node", \
      "--ros-args", \
-     "-p", "product_name:=STL27L", \
+     "-p", "product_name:=LDLiDAR_STL27L", \
      "-p", "topic_name:=scan", \
      "-p", "frame_id:=lidar_link", \
      "-p", "port_name:=/dev/ttyS1", \
-     "-p", "port_baudrate:=230400", \
+     "-p", "port_baudrate:=921600", \
      "-p", "laser_scan_dir:=true", \
      "-p", "enable_angle_crop_func:=false"]


### PR DESCRIPTION
### Summary

- correct the STL27L driver product identifier
- use the STL27L UART baud rate confirmed in #463
- add regression coverage for generated and runtime configuration

### Why

The existing STL27L configuration passes values that `ldlidar_stl_ros2` does not accept or cannot use, causing the LiDAR container to restart repeatedly. The issue reporter verified `LDLiDAR_STL27L` with `921600` baud on STL27L hardware.

### Testing

- `bash install/tests/test_lidar_matrix.sh` — 54 tests passed
- `bash install/tests/test_env_output.sh` — 90 tests passed
- remaining installer test scripts — passed except pre-existing Windows/WSL harness failures in `test_compose_validity.sh`, `test_config_dir_squat.sh`, and `test_serial_probe.sh`
- `bash -n install/lib/config.sh install/lib/env.sh install/lib/lidar.sh install/tests/lib/harness.sh install/tests/test_lidar_matrix.sh` — passed
- `docker compose -f install/compose/docker-compose.lidar-stl27l.yml config --no-interpolate` — passed
- rendered Compose command validation with `LIDAR_MODEL=LDLiDAR_STL27L` and `LIDAR_BAUD=921600` — passed
- `git diff --check` — passed

Closes #463