### PR TITLE
feat(gui): preselect firmware config from robot model

### DIFF
--- a/gui/pkg/types/firmware.go
+++ b/gui/pkg/types/firmware.go
@@ -16,6 +16,13 @@ type FirmwareConfig struct {
 	Version                        string  `json:"version"`
 	BoardType                      string  `json:"boardType"`
 	PanelType                      string  `json:"panelType"`
+	// Firmware selection provenance is written alongside the saved config so
+	// later mower-model changes can update only fields that still follow model
+	// defaults. Empty/unknown values are legacy and are handled conservatively
+	// by the GUI.
+	BoardTypeOrigin                string  `json:"boardTypeOrigin,omitempty"`
+	PanelTypeOrigin                string  `json:"panelTypeOrigin,omitempty"`
+	FirmwareSelectionModel         string  `json:"firmwareSelectionModel,omitempty"`
 	// FirmwareSource is the GUI dropdown selector: "custom" compiles from
 	// source (the expert path), "prebuilt" (or empty, for older payloads)
 	// flashes the tested prebuilt binary.

--- a/gui/web/src/components/FlashBoardComponent.test.tsx
+++ b/gui/web/src/components/FlashBoardComponent.test.tsx
@@ -1,0 +1,167 @@
+import {App} from "antd";
+import {cleanup, fireEvent, render, screen, waitFor} from "@testing-library/react";
+import type {ReactNode} from "react";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {ThemeProvider} from "../theme/ThemeContext.tsx";
+import {FlashBoardComponent} from "./FlashBoardComponent.tsx";
+
+const state = vi.hoisted(() => ({
+    savedConfig: "",
+    settingsModel: "YardForce500B" as string | undefined,
+    settingsError: false,
+}));
+
+vi.mock("../hooks/useApi.ts", () => ({
+    useApi: () => ({
+        config: {
+            keysGetCreate: vi.fn(() => Promise.resolve({
+                data: {"gui.firmware.config": state.savedConfig},
+            })),
+        },
+        settings: {
+            yamlList: vi.fn(() => {
+                if (state.settingsError) return Promise.reject(new Error("settings unavailable"));
+                return Promise.resolve({data: {mower_model: state.settingsModel}});
+            }),
+        },
+    }),
+}));
+
+vi.mock("@microsoft/fetch-event-source", () => ({
+    fetchEventSource: vi.fn(),
+}));
+
+vi.mock("react-terminal-ui", () => ({
+    ColorMode: {Dark: "dark"},
+    default: ({children}: {children: ReactNode}) => <div>{children}</div>,
+    TerminalOutput: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}));
+
+const renderComponent = (mowerModel?: string) => render(
+    <ThemeProvider>
+        <App>
+            <FlashBoardComponent mowerModel={mowerModel} onNext={vi.fn()} />
+        </App>
+    </ThemeProvider>,
+);
+
+const selectByIndex = (index: number) => {
+    const selects = document.querySelectorAll(".ant-select");
+    if (!selects[index]) throw new Error(`missing select ${index}`);
+    return selects[index] as HTMLElement;
+};
+
+const selectedLabel = (index: number) =>
+    selectByIndex(index).querySelector(".ant-select-selection-item")?.textContent ?? "";
+
+const chooseOption = async (index: number, option: string) => {
+    fireEvent.mouseDown(selectByIndex(index).querySelector(".ant-select-selector")!);
+    const optionNode = await screen.findByText(option, {exact: true});
+    fireEvent.click(optionNode);
+};
+
+describe("FlashBoardComponent model/default integration", () => {
+    beforeEach(() => {
+        state.savedConfig = "";
+        state.settingsModel = "YardForce500B";
+        state.settingsError = false;
+    });
+
+    it("fresh YardForce500B selects its canonical board and panel", async () => {
+        renderComponent("YardForce500B");
+
+        await waitFor(() => {
+            expect(selectedLabel(0)).toBe("Mowgli - YardForce 500 B Variant");
+            expect(selectedLabel(1)).toBe("YardForce 500B Classic");
+        });
+        expect(screen.getByRole("button", {name: /flash firmware/i})).toBeEnabled();
+    });
+
+    it("follows a model change while preserving an individual board override", async () => {
+        const view = renderComponent("YardForce500");
+        await waitFor(() => expect(selectedLabel(1)).toBe("YardForce 500 Classic"));
+
+        await chooseOption(0, "Vermut - YardForce 500 Classic");
+        expect(selectedLabel(0)).toBe("Vermut - YardForce 500 Classic");
+
+        view.rerender(
+            <ThemeProvider>
+                <App>
+                    <FlashBoardComponent mowerModel="YardForce500B" onNext={vi.fn()} />
+                </App>
+            </ThemeProvider>,
+        );
+        await waitFor(() => expect(selectedLabel(1)).toBe("YardForce 500B Classic"));
+        expect(selectedLabel(0)).toBe("Vermut - YardForce 500 Classic");
+    });
+
+    it("updates persisted automatic fields for the current model", async () => {
+        state.savedConfig = JSON.stringify({
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+            boardTypeOrigin: "auto",
+            panelTypeOrigin: "auto",
+            firmwareSelectionModel: "YardForce500",
+        });
+        renderComponent("YardForce500B");
+
+        await waitFor(() => {
+            expect(selectedLabel(0)).toBe("Mowgli - YardForce 500 B Variant");
+            expect(selectedLabel(1)).toBe("YardForce 500B Classic");
+        });
+    });
+
+    it("preserves legacy and manual persisted selections conservatively", async () => {
+        state.savedConfig = JSON.stringify({
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+        });
+        renderComponent("YardForce500B");
+        await waitFor(() => expect(selectedLabel(0)).toBe("Mowgli - YardForce 500 Classic"));
+        expect(selectedLabel(1)).toBe("YardForce 500 Classic");
+
+        // The component is remounted to exercise a separately persisted
+        // manual-board/automatic-panel configuration.
+        state.savedConfig = JSON.stringify({
+            boardType: "BOARD_VERMUT_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+            boardTypeOrigin: "manual",
+            panelTypeOrigin: "auto",
+            firmwareSelectionModel: "YardForce500",
+        });
+        cleanup();
+        renderComponent("YardForce500B");
+        await waitFor(() => expect(selectedLabel(0)).toBe("Vermut - YardForce 500 Classic"));
+        expect(selectedLabel(1)).toBe("YardForce 500B Classic");
+    });
+
+    it("restores a saved config when settings lookup fails", async () => {
+        state.settingsError = true;
+        state.settingsModel = undefined;
+        state.savedConfig = JSON.stringify({
+            boardType: "BOARD_YARDFORCE500B",
+            panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
+            boardTypeOrigin: "auto",
+            panelTypeOrigin: "auto",
+            firmwareSelectionModel: "YardForce500B",
+        });
+        renderComponent();
+
+        await waitFor(() => {
+            expect(selectedLabel(0)).toBe("Mowgli - YardForce 500 B Variant");
+            expect(selectedLabel(1)).toBe("YardForce 500B Classic");
+        });
+    });
+
+    it("blocks flashing until both board and panel are explicitly selected", async () => {
+        renderComponent("YardForce500");
+        await waitFor(() => expect(selectedLabel(1)).toBe("YardForce 500 Classic"));
+
+        const flashButton = screen.getByRole("button", {name: /flash firmware/i});
+        expect(flashButton).toBeDisabled();
+        expect(screen.getByText("Select a board and panel before flashing")).toBeInTheDocument();
+
+        await chooseOption(0, "Mowgli - YardForce 500 Classic");
+        await waitFor(() => expect(flashButton).toBeEnabled());
+    });
+});

--- a/gui/web/src/components/FlashBoardComponent.test.tsx
+++ b/gui/web/src/components/FlashBoardComponent.test.tsx
@@ -4,6 +4,7 @@ import type {ReactNode} from "react";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ThemeProvider} from "../theme/ThemeContext.tsx";
 import {FlashBoardComponent} from "./FlashBoardComponent.tsx";
+import {fetchEventSource} from "@microsoft/fetch-event-source";
 
 const state = vi.hoisted(() => ({
     savedConfig: "",
@@ -65,6 +66,7 @@ describe("FlashBoardComponent model/default integration", () => {
         state.savedConfig = "";
         state.settingsModel = "YardForce500B";
         state.settingsError = false;
+        vi.mocked(fetchEventSource).mockReset().mockResolvedValue(undefined);
     });
 
     it("fresh YardForce500B selects its canonical board and panel", async () => {
@@ -160,8 +162,42 @@ describe("FlashBoardComponent model/default integration", () => {
         const flashButton = screen.getByRole("button", {name: /flash firmware/i});
         expect(flashButton).toBeDisabled();
         expect(screen.getByText("Select a board and panel before flashing")).toBeInTheDocument();
+        expect(screen.queryByText("No prebuilt firmware for this model yet")).not.toBeInTheDocument();
 
         await chooseOption(0, "Mowgli - YardForce 500 Classic");
         await waitFor(() => expect(flashButton).toBeEnabled());
+    });
+
+    it("submits explicit provenance after a manual field change and confirmation", async () => {
+        renderComponent("YardForce500B");
+        await waitFor(() => {
+            expect(selectedLabel(0)).toBe("Mowgli - YardForce 500 B Variant");
+            expect(selectedLabel(1)).toBe("YardForce 500B Classic");
+        });
+
+        // The board is intentionally changed while the panel keeps following
+        // the YardForce500B automatic default.
+        await chooseOption(0, "Vermut - YardForce 500 Classic");
+        const flashButton = screen.getByRole("button", {name: /flash firmware/i});
+        await waitFor(() => expect(flashButton).toBeEnabled());
+        fireEvent.click(flashButton);
+
+        const confirmButton = await screen.findByRole("button", {name: /^Flash$/});
+        fireEvent.click(confirmButton);
+        await waitFor(() => expect(fetchEventSource).toHaveBeenCalledTimes(1));
+
+        const request = vi.mocked(fetchEventSource).mock.calls[0]?.[1] as {body?: string};
+        const payload = JSON.parse(request.body ?? "{}") as {
+            boardType?: string;
+            panelType?: string;
+            boardTypeOrigin?: string;
+            panelTypeOrigin?: string;
+            firmwareSelectionModel?: string;
+        };
+        expect(payload.boardType).toBe("BOARD_VERMUT_YARDFORCE500");
+        expect(payload.panelType).toBe("PANEL_TYPE_YARDFORCE_500B_CLASSIC");
+        expect(payload.boardTypeOrigin).toBe("manual");
+        expect(payload.panelTypeOrigin).toBe("auto");
+        expect(payload.firmwareSelectionModel).toBe("YardForce500B");
     });
 });

--- a/gui/web/src/components/FlashBoardComponent.tsx
+++ b/gui/web/src/components/FlashBoardComponent.tsx
@@ -21,7 +21,8 @@ import {useIsMobile} from "../hooks/useIsMobile";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
 import {
     applyFirmwareModelDefaults,
-    firmwareDefaultsForModel,
+    manualOverridesFromProvenance,
+    type FirmwareFieldOrigin,
     type FirmwareSelection,
 } from "./firmwareModelDefaults.ts";
 
@@ -63,6 +64,9 @@ type Config = {
     tickPerM: number,
     wheelBase: number
     perimeterWire: boolean
+    boardTypeOrigin?: FirmwareFieldOrigin
+    panelTypeOrigin?: FirmwareFieldOrigin
+    firmwareSelectionModel?: string
 }
 
 // Boards that flash WITHOUT compiling: Vermut has its own release-zip path, and
@@ -82,12 +86,13 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
     const {t} = useTranslation();
     const applyingModelDefaultsRef = useRef(false);
     const manualOverridesRef = useRef<Partial<Record<keyof FirmwareSelection, boolean>>>({});
-    const autoDefaultsRef = useRef<FirmwareSelection>({});
     const initializedModelRef = useRef(false);
+    const mowerModelRef = useRef(props.mowerModel);
     const [configuredMowerModel, setConfiguredMowerModel] = useState<string | undefined>(props.mowerModel);
     // Mirror the two fields that gate the default-vs-expert flash affordance into
     // React state so the button + guidance can react without a Formily observer.
-    const [selectedBoard, setSelectedBoard] = useState("BOARD_VERMUT_YARDFORCE500");
+    const [selectedBoard, setSelectedBoard] = useState("");
+    const [selectedPanel, setSelectedPanel] = useState("");
     const [isExpert, setIsExpert] = useState(false);
     const form = useMemo(() => createForm({
         validateFirst: true,
@@ -95,8 +100,8 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
             onFieldValueChange('boardType', (field) => {
                 setSelectedBoard(String(field.value));
                 if (initializedModelRef.current && !applyingModelDefaultsRef.current) {
-                    manualOverridesRef.current.boardType =
-                        field.value !== autoDefaultsRef.current.boardType;
+                    manualOverridesRef.current.boardType = true;
+                    form.setValues({boardTypeOrigin: 'manual'});
                 }
                 form.setFieldState('*(tickPerM,wheelBase,directory,branch,repository,disableEmergency,maxMps,maxChargeCurrent,limitVoltage150MA,maxChargeVoltage,batChargeCutoffVoltage,oneWheelLiftEmergencyMillis,bothWheelsLiftEmergencyMillis,tiltEmergencyMillis,stopButtonEmergencyMillis,playButtonClearEmergencyMillis,imuOnboardInclinationThreshold,externalImuAcceleration,externalImuAngular,perimeterWire)', (state) => {
                     state.display = field.value !== "BOARD_VERMUT_YARDFORCE500" ? "visible" : "hidden";
@@ -106,9 +111,10 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                 })
             })
             onFieldValueChange('panelType', (field) => {
+                setSelectedPanel(String(field.value ?? ""));
                 if (initializedModelRef.current && !applyingModelDefaultsRef.current) {
-                    manualOverridesRef.current.panelType =
-                        field.value !== autoDefaultsRef.current.panelType;
+                    manualOverridesRef.current.panelType = true;
+                    form.setValues({panelTypeOrigin: 'manual'});
                 }
             })
             onFieldValueChange('firmwareSource', (field) => {
@@ -129,6 +135,11 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
     const terminalRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
+        mowerModelRef.current = props.mowerModel;
+    }, [props.mowerModel]);
+
+    useEffect(() => {
+        let disposed = false;
         (async () => {
             try {
                 // Keep the existing firmware-config read independent from the
@@ -143,8 +154,9 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     // Model inference is best-effort; the normal manual form
                     // remains available if settings cannot be read.
                 }
+                if (disposed) return;
                 const jsonConfig = config.data["gui.firmware.config"]
-                const model = props.mowerModel ?? configuredModel;
+                const model = mowerModelRef.current ?? configuredModel;
                 setConfiguredMowerModel(model);
                 if (jsonConfig) {
                     const saved = JSON.parse(jsonConfig)
@@ -154,17 +166,24 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     if (saved.firmwareSource === undefined) {
                         saved.firmwareSource = saved.expertBuild ? "custom" : "prebuilt"
                     }
-                    // The backend persists this config only after a flash and
-                    // does not store whether board/panel came from a model
-                    // preset. Treat persisted values as deliberate overrides
-                    // so a returning expert configuration is never rewritten.
-                    manualOverridesRef.current = {
-                        boardType: saved.boardType !== undefined && saved.boardType !== "",
-                        panelType: saved.panelType !== undefined && saved.panelType !== "",
-                    };
-                    const seeded = applyFirmwareModelDefaults(model, saved, manualOverridesRef.current);
-                    autoDefaultsRef.current = firmwareDefaultsForModel(model) ?? {};
+                    // Provenance is persisted with the config after a flash.
+                    // Unknown/legacy configs are deliberately conservative:
+                    // preserve both saved fields instead of guessing a board.
+                    manualOverridesRef.current = manualOverridesFromProvenance(saved);
+                    // If the model/settings lookup is unavailable, restoring
+                    // the saved config must still work. In particular, do not
+                    // turn a previously known automatic value into an empty
+                    // value merely because the async settings request failed.
+                    const seeded = (model === undefined
+                        ? {...saved}
+                        : applyFirmwareModelDefaults(model, saved, manualOverridesRef.current)) as FirmwareSelection & Record<string, unknown>;
+                    seeded.firmwareSelectionModel = model;
+                    seeded.boardTypeOrigin = manualOverridesRef.current.boardType ?
+                        (saved.boardTypeOrigin ?? "legacy") : "auto";
+                    seeded.panelTypeOrigin = manualOverridesRef.current.panelType ?
+                        (saved.panelTypeOrigin ?? "legacy") : "auto";
                     setSelectedBoard(String(seeded.boardType ?? ""));
+                    setSelectedPanel(String(seeded.panelType ?? ""));
                     setIsExpert(seeded.firmwareSource === "custom");
                     applyingModelDefaultsRef.current = true;
                     form.setInitialValues(seeded);
@@ -172,8 +191,11 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     applyingModelDefaultsRef.current = false;
                 } else {
                     const seeded = applyFirmwareModelDefaults<FirmwareSelection>(model, {}, manualOverridesRef.current);
-                    autoDefaultsRef.current = firmwareDefaultsForModel(model) ?? {};
+                    seeded.firmwareSelectionModel = model;
+                    seeded.boardTypeOrigin = "auto";
+                    seeded.panelTypeOrigin = "auto";
                     setSelectedBoard(String(seeded.boardType ?? ""));
+                    setSelectedPanel(String(seeded.panelType ?? ""));
                     applyingModelDefaultsRef.current = true;
                     form.setInitialValues(seeded);
                     form.setValues(seeded);
@@ -188,6 +210,7 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
             }
         })()
         return () => {
+            disposed = true;
             if (abortControllerRef.current) {
                 abortControllerRef.current.abort();
             }
@@ -201,13 +224,16 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
         if (!initializedModelRef.current || props.mowerModel === undefined || props.mowerModel === configuredMowerModel) {
             return;
         }
-        const nextDefaults = firmwareDefaultsForModel(props.mowerModel) ?? {};
         const seeded = applyFirmwareModelDefaults(
             props.mowerModel,
             form.values as FirmwareSelection,
             manualOverridesRef.current,
         );
-        autoDefaultsRef.current = nextDefaults;
+        seeded.firmwareSelectionModel = props.mowerModel;
+        seeded.boardTypeOrigin = manualOverridesRef.current.boardType ?
+            (form.values as FirmwareSelection).boardTypeOrigin ?? "manual" : "auto";
+        seeded.panelTypeOrigin = manualOverridesRef.current.panelType ?
+            (form.values as FirmwareSelection).panelTypeOrigin ?? "manual" : "auto";
         applyingModelDefaultsRef.current = true;
         form.setValues(seeded);
         applyingModelDefaultsRef.current = false;
@@ -300,11 +326,29 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
     };
 
     const flashFirmware = (values: Config) => {
+        if (!values.boardType || !values.panelType) {
+            notification.error({
+                message: t('flashBoard.selectionRequiredTitle'),
+                description: t('flashBoard.selectionRequiredDesc'),
+            });
+            return;
+        }
         const isCustomBuild = values.firmwareSource === "custom";
         // Derive the backend's expert flag straight from the dropdown so the
         // payload can never disagree with what the user selected — selecting
         // "custom" is what routes the backend to compile-from-source.
-        const payload: Config = {...values, expertBuild: isCustomBuild};
+        const payload: Config = {
+            ...values,
+            expertBuild: isCustomBuild,
+            // Keep provenance explicit in the persisted payload even if a
+            // Formily version drops values for fields that are not rendered.
+            boardTypeOrigin: values.boardTypeOrigin ??
+                (manualOverridesRef.current.boardType ? "manual" : "auto"),
+            panelTypeOrigin: values.panelTypeOrigin ??
+                (manualOverridesRef.current.panelType ? "manual" : "auto"),
+            firmwareSelectionModel: values.firmwareSelectionModel ??
+                mowerModelRef.current ?? configuredMowerModel,
+        };
         // The prebuilt (default) path doesn't expose the charge/IMU params, so
         // its confirmation is a simple "flash the blessed binary" prompt. The
         // custom compile path keeps the detailed value-verification list.
@@ -407,7 +451,9 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     <SchemaField><SchemaField.String
                         name={"boardType"}
                         title={t('flashBoard.boardSelectionTitle')}
-                        default={"BOARD_VERMUT_YARDFORCE500"}
+                        // No board is safe as a generic fallback: YardForce
+                        // 500 identifies a chassis, not Vermut vs Mowgli.
+                        default={""}
                         enum={[{
                             label: "Vermut - YardForce 500 Classic",
                             value: "BOARD_VERMUT_YARDFORCE500"
@@ -427,7 +473,7 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     <SchemaField><SchemaField.String
                         name={"panelType"}
                         title={t('flashBoard.panelSelectionTitle')}
-                        default={"PANEL_TYPE_YARDFORCE_500_CLASSIC"}
+                        default={""}
                         enum={[
                             {label: "YardForce 500 Classic", value: "PANEL_TYPE_YARDFORCE_500_CLASSIC"},
                             {label: "YardForce LUV1000RI", value: "PANEL_TYPE_YARDFORCE_LUV1000RI"},
@@ -692,6 +738,15 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                 zIndex: 50,
             }}>
                 <div style={{width: "100%"}}>
+                    {(!selectedBoard || !selectedPanel) && (
+                        <Alert
+                            type="warning"
+                            showIcon
+                            style={{marginBottom: 8, textAlign: "left"}}
+                            message={t('flashBoard.selectionRequiredTitle')}
+                            description={t('flashBoard.selectionRequiredDesc')}
+                        />
+                    )}
                     {!isExpert && !PREBUILT_BOARDS.has(selectedBoard) && (
                         <Alert
                             type="warning"
@@ -704,7 +759,7 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     <FormButtonGroup>
                         <Button
                             type="primary"
-                            disabled={!isExpert && !PREBUILT_BOARDS.has(selectedBoard)}
+                            disabled={!selectedBoard || !selectedPanel || (!isExpert && !PREBUILT_BOARDS.has(selectedBoard))}
                             onClick={() => {
                                 form.submit(flashFirmware).catch((err: unknown) => {
                                     if (err instanceof Error) {

--- a/gui/web/src/components/FlashBoardComponent.tsx
+++ b/gui/web/src/components/FlashBoardComponent.tsx
@@ -19,6 +19,11 @@ import {createForm, onFieldValueChange} from "@formily/core";
 import {useApi} from "../hooks/useApi.ts";
 import {useIsMobile} from "../hooks/useIsMobile";
 import {useThemeMode} from "../theme/ThemeContext.tsx";
+import {
+    applyFirmwareModelDefaults,
+    firmwareDefaultsForModel,
+    type FirmwareSelection,
+} from "./firmwareModelDefaults.ts";
 
 const SchemaField = createSchemaField({
     components: {
@@ -71,10 +76,15 @@ const PREBUILT_BOARDS = new Set<string>([
     "BOARD_YARDFORCE500B",
 ]);
 
-export const FlashBoardComponent = (props: { onNext: () => void }) => {
+export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: string }) => {
     const isMobile = useIsMobile();
     const {colors} = useThemeMode();
     const {t} = useTranslation();
+    const applyingModelDefaultsRef = useRef(false);
+    const manualOverridesRef = useRef<Partial<Record<keyof FirmwareSelection, boolean>>>({});
+    const autoDefaultsRef = useRef<FirmwareSelection>({});
+    const initializedModelRef = useRef(false);
+    const [configuredMowerModel, setConfiguredMowerModel] = useState<string | undefined>(props.mowerModel);
     // Mirror the two fields that gate the default-vs-expert flash affordance into
     // React state so the button + guidance can react without a Formily observer.
     const [selectedBoard, setSelectedBoard] = useState("BOARD_VERMUT_YARDFORCE500");
@@ -84,12 +94,22 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
         effects: (form) => {
             onFieldValueChange('boardType', (field) => {
                 setSelectedBoard(String(field.value));
+                if (initializedModelRef.current && !applyingModelDefaultsRef.current) {
+                    manualOverridesRef.current.boardType =
+                        field.value !== autoDefaultsRef.current.boardType;
+                }
                 form.setFieldState('*(tickPerM,wheelBase,directory,branch,repository,disableEmergency,maxMps,maxChargeCurrent,limitVoltage150MA,maxChargeVoltage,batChargeCutoffVoltage,oneWheelLiftEmergencyMillis,bothWheelsLiftEmergencyMillis,tiltEmergencyMillis,stopButtonEmergencyMillis,playButtonClearEmergencyMillis,imuOnboardInclinationThreshold,externalImuAcceleration,externalImuAngular,perimeterWire)', (state) => {
                     state.display = field.value !== "BOARD_VERMUT_YARDFORCE500" ? "visible" : "hidden";
                 })
                 form.setFieldState('*(version,file)', (state) => {
                     state.display = field.value === "BOARD_VERMUT_YARDFORCE500" ? "visible" : "hidden";
                 })
+            })
+            onFieldValueChange('panelType', (field) => {
+                if (initializedModelRef.current && !applyingModelDefaultsRef.current) {
+                    manualOverridesRef.current.panelType =
+                        field.value !== autoDefaultsRef.current.panelType;
+                }
             })
             onFieldValueChange('firmwareSource', (field) => {
                 // The Firmware source dropdown is the single control that enables
@@ -111,10 +131,21 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
     useEffect(() => {
         (async () => {
             try {
-                const config = await guiApi.config.keysGetCreate({
-                    "gui.firmware.config": ""
-                })
+                // Keep the existing firmware-config read independent from the
+                // settings read: a settings endpoint failure must not prevent
+                // returning users from restoring their flash configuration.
+                const config = await guiApi.config.keysGetCreate({"gui.firmware.config": ""});
+                let configuredModel: string | undefined;
+                try {
+                    const settings = await guiApi.settings.yamlList();
+                    configuredModel = settings.data?.mower_model;
+                } catch {
+                    // Model inference is best-effort; the normal manual form
+                    // remains available if settings cannot be read.
+                }
                 const jsonConfig = config.data["gui.firmware.config"]
+                const model = props.mowerModel ?? configuredModel;
+                setConfiguredMowerModel(model);
                 if (jsonConfig) {
                     const saved = JSON.parse(jsonConfig)
                     // Back-compat: a config saved before the Firmware source
@@ -123,8 +154,32 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
                     if (saved.firmwareSource === undefined) {
                         saved.firmwareSource = saved.expertBuild ? "custom" : "prebuilt"
                     }
-                    form.setInitialValues(saved)
+                    // The backend persists this config only after a flash and
+                    // does not store whether board/panel came from a model
+                    // preset. Treat persisted values as deliberate overrides
+                    // so a returning expert configuration is never rewritten.
+                    manualOverridesRef.current = {
+                        boardType: saved.boardType !== undefined && saved.boardType !== "",
+                        panelType: saved.panelType !== undefined && saved.panelType !== "",
+                    };
+                    const seeded = applyFirmwareModelDefaults(model, saved, manualOverridesRef.current);
+                    autoDefaultsRef.current = firmwareDefaultsForModel(model) ?? {};
+                    setSelectedBoard(String(seeded.boardType ?? ""));
+                    setIsExpert(seeded.firmwareSource === "custom");
+                    applyingModelDefaultsRef.current = true;
+                    form.setInitialValues(seeded);
+                    form.setValues(seeded);
+                    applyingModelDefaultsRef.current = false;
+                } else {
+                    const seeded = applyFirmwareModelDefaults<FirmwareSelection>(model, {}, manualOverridesRef.current);
+                    autoDefaultsRef.current = firmwareDefaultsForModel(model) ?? {};
+                    setSelectedBoard(String(seeded.boardType ?? ""));
+                    applyingModelDefaultsRef.current = true;
+                    form.setInitialValues(seeded);
+                    form.setValues(seeded);
+                    applyingModelDefaultsRef.current = false;
                 }
+                initializedModelRef.current = true;
             } catch (e: any) {
                 notification.error({
                     message: t('flashBoard.errorRetrievingConfig'),
@@ -138,6 +193,26 @@ export const FlashBoardComponent = (props: { onNext: () => void }) => {
             }
         };
     }, []);
+
+    // The onboarding wizard keeps the selected mower model in local state. If
+    // it changes while this step is mounted, update only fields still following
+    // automatic defaults; explicit board/panel overrides remain intact.
+    useEffect(() => {
+        if (!initializedModelRef.current || props.mowerModel === undefined || props.mowerModel === configuredMowerModel) {
+            return;
+        }
+        const nextDefaults = firmwareDefaultsForModel(props.mowerModel) ?? {};
+        const seeded = applyFirmwareModelDefaults(
+            props.mowerModel,
+            form.values as FirmwareSelection,
+            manualOverridesRef.current,
+        );
+        autoDefaultsRef.current = nextDefaults;
+        applyingModelDefaultsRef.current = true;
+        form.setValues(seeded);
+        applyingModelDefaultsRef.current = false;
+        setConfiguredMowerModel(props.mowerModel);
+    }, [props.mowerModel, configuredMowerModel, form]);
 
     // Auto-scroll terminal to bottom
     useEffect(() => {

--- a/gui/web/src/components/FlashBoardComponent.tsx
+++ b/gui/web/src/components/FlashBoardComponent.tsx
@@ -166,7 +166,8 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                     if (saved.firmwareSource === undefined) {
                         saved.firmwareSource = saved.expertBuild ? "custom" : "prebuilt"
                     }
-                    // Provenance is persisted with the config after a flash.
+                    // Provenance is persisted with the config when the flash
+                    // request is submitted (including failed flash attempts).
                     // Unknown/legacy configs are deliberately conservative:
                     // preserve both saved fields instead of guessing a board.
                     manualOverridesRef.current = manualOverridesFromProvenance(saved);
@@ -747,7 +748,7 @@ export const FlashBoardComponent = (props: { onNext: () => void; mowerModel?: st
                             description={t('flashBoard.selectionRequiredDesc')}
                         />
                     )}
-                    {!isExpert && !PREBUILT_BOARDS.has(selectedBoard) && (
+                    {selectedBoard && !isExpert && !PREBUILT_BOARDS.has(selectedBoard) && (
                         <Alert
                             type="warning"
                             showIcon

--- a/gui/web/src/components/firmwareModelDefaults.test.ts
+++ b/gui/web/src/components/firmwareModelDefaults.test.ts
@@ -2,12 +2,12 @@ import {describe, expect, it} from "vitest";
 import {
     applyFirmwareModelDefaults,
     firmwareDefaultsForModel,
+    manualOverridesFromProvenance,
 } from "./firmwareModelDefaults.ts";
 
 describe("firmware model defaults", () => {
     it("maps the canonical YardForce 500 permutation", () => {
         expect(firmwareDefaultsForModel("YardForce500")).toEqual({
-            boardType: "BOARD_YARDFORCE500",
             panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
         });
     });
@@ -63,5 +63,22 @@ describe("firmware model defaults", () => {
             boardType: "BOARD_YARDFORCE500B",
             panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
         });
+    });
+
+    it("treats missing provenance as a legacy manual selection", () => {
+        expect(manualOverridesFromProvenance({
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+        })).toEqual({boardType: true, panelType: true});
+    });
+
+    it("keeps only explicitly automatic fields following model changes", () => {
+        expect(manualOverridesFromProvenance({
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+            boardTypeOrigin: "manual",
+            panelTypeOrigin: "auto",
+            firmwareSelectionModel: "YardForce500",
+        })).toEqual({boardType: true, panelType: false});
     });
 });

--- a/gui/web/src/components/firmwareModelDefaults.test.ts
+++ b/gui/web/src/components/firmwareModelDefaults.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from "vitest";
+import {
+    applyFirmwareModelDefaults,
+    firmwareDefaultsForModel,
+} from "./firmwareModelDefaults.ts";
+
+describe("firmware model defaults", () => {
+    it("maps the canonical YardForce 500 permutation", () => {
+        expect(firmwareDefaultsForModel("YardForce500")).toEqual({
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+        });
+    });
+
+    it("maps the canonical YardForce 500B permutation", () => {
+        expect(firmwareDefaultsForModel("YardForce500B")).toEqual({
+            boardType: "BOARD_YARDFORCE500B",
+            panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
+        });
+    });
+
+    it.each(["CUSTOM", "LUV1000RI", "unknown", undefined])(
+        "does not guess for unsupported model %s",
+        (model) => {
+            expect(firmwareDefaultsForModel(model)).toBeUndefined();
+            expect(applyFirmwareModelDefaults(model, {
+                boardType: "BOARD_YARDFORCE500",
+                panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+            })).toEqual({boardType: "", panelType: ""});
+        },
+    );
+
+    it("keeps manual board and panel overrides across model changes", () => {
+        const manual = {
+            boardType: "BOARD_LUV1000RI",
+            panelType: "PANEL_TYPE_YARDFORCE_900_ECO",
+        };
+        expect(applyFirmwareModelDefaults("YardForce500B", manual, {
+            boardType: true,
+            panelType: true,
+        })).toEqual(manual);
+    });
+
+    it("updates the model-following field when only the other field is overridden", () => {
+        expect(applyFirmwareModelDefaults("YardForce500B", {
+            boardType: "BOARD_LUV1000RI",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+        }, {boardType: true})).toEqual({
+            boardType: "BOARD_LUV1000RI",
+            panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
+        });
+    });
+
+    it("updates only automatic fields and preserves unrelated firmware settings", () => {
+        const current = {
+            boardType: "BOARD_YARDFORCE500",
+            panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+            repository: "https://example.test/mowgli",
+            maxMps: 0.7,
+        };
+        expect(applyFirmwareModelDefaults("YardForce500B", current)).toEqual({
+            ...current,
+            boardType: "BOARD_YARDFORCE500B",
+            panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
+        });
+    });
+});

--- a/gui/web/src/components/firmwareModelDefaults.ts
+++ b/gui/web/src/components/firmwareModelDefaults.ts
@@ -1,0 +1,51 @@
+/**
+ * Firmware targets that are safe to infer from the selected mower model.
+ *
+ * Keep this list aligned with firmware/scripts/package_release.py's
+ * PERMUTATIONS. Models without an unambiguous published permutation are
+ * intentionally absent: the firmware flashing UI must not guess for them.
+ */
+export type FirmwareSelection = {
+    boardType?: string;
+    panelType?: string;
+};
+
+export type FirmwareModelDefaults = Readonly<Required<FirmwareSelection>>;
+
+export const FIRMWARE_MODEL_DEFAULTS: Readonly<Record<string, FirmwareModelDefaults>> = {
+    YardForce500: {
+        boardType: "BOARD_YARDFORCE500",
+        panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
+    },
+    YardForce500B: {
+        boardType: "BOARD_YARDFORCE500B",
+        panelType: "PANEL_TYPE_YARDFORCE_500B_CLASSIC",
+    },
+};
+
+export const firmwareDefaultsForModel = (
+    mowerModel: unknown,
+): FirmwareModelDefaults | undefined => {
+    if (typeof mowerModel !== "string") return undefined;
+    return FIRMWARE_MODEL_DEFAULTS[mowerModel];
+};
+
+/**
+ * Apply only inferred board/panel fields. Other firmware settings are returned
+ * untouched, and a field marked as manually overridden is left untouched even
+ * when the mower model changes.
+ */
+export const applyFirmwareModelDefaults = <T extends FirmwareSelection>(
+    mowerModel: unknown,
+    selection: T,
+    manualOverrides: Partial<Record<keyof FirmwareSelection, boolean>> = {},
+): T => {
+    const defaults = firmwareDefaultsForModel(mowerModel);
+    return {
+        ...selection,
+        // An empty string is deliberate: it overrides Formily's static
+        // defaults and leaves an unsupported model visibly unselected.
+        ...(manualOverrides.boardType ? {} : {boardType: defaults?.boardType ?? ""}),
+        ...(manualOverrides.panelType ? {} : {panelType: defaults?.panelType ?? ""}),
+    } as T;
+};

--- a/gui/web/src/components/firmwareModelDefaults.ts
+++ b/gui/web/src/components/firmwareModelDefaults.ts
@@ -1,9 +1,10 @@
 /**
  * Firmware targets that are safe to infer from the selected mower model.
  *
- * Keep this list aligned with firmware/scripts/package_release.py's
- * PERMUTATIONS. Models without an unambiguous published permutation are
- * intentionally absent: the firmware flashing UI must not guess for them.
+ * These are only the fields that can be safely inferred from the published
+ * firmware permutations in firmware/scripts/package_release.py. Models
+ * without an unambiguous published mapping are intentionally absent: the
+ * firmware flashing UI must not guess for them.
  */
 export type FirmwareSelection = {
     boardType?: string;

--- a/gui/web/src/components/firmwareModelDefaults.ts
+++ b/gui/web/src/components/firmwareModelDefaults.ts
@@ -8,13 +8,22 @@
 export type FirmwareSelection = {
     boardType?: string;
     panelType?: string;
+    /** Persisted provenance for the two independently editable fields. */
+    boardTypeOrigin?: FirmwareFieldOrigin;
+    panelTypeOrigin?: FirmwareFieldOrigin;
+    /** Mower model whose automatic defaults were last applied. */
+    firmwareSelectionModel?: string;
 };
 
-export type FirmwareModelDefaults = Readonly<Required<FirmwareSelection>>;
+export type FirmwareFieldOrigin = "auto" | "manual" | "legacy";
+
+export type FirmwareModelDefaults = Readonly<Pick<FirmwareSelection, "boardType" | "panelType">>;
 
 export const FIRMWARE_MODEL_DEFAULTS: Readonly<Record<string, FirmwareModelDefaults>> = {
     YardForce500: {
-        boardType: "BOARD_YARDFORCE500",
+        // YardForce500 is shared by the Vermut and Mowgli controller variants;
+        // the mechanical mower model does not identify the board. The panel
+        // is common to both classic variants and is safe to infer.
         panelType: "PANEL_TYPE_YARDFORCE_500_CLASSIC",
     },
     YardForce500B: {
@@ -49,3 +58,15 @@ export const applyFirmwareModelDefaults = <T extends FirmwareSelection>(
         ...(manualOverrides.panelType ? {} : {panelType: defaults?.panelType ?? ""}),
     } as T;
 };
+
+/**
+ * Convert persisted field provenance to the conservative override policy used
+ * by the form. Missing/unknown provenance is treated as legacy, so a saved
+ * value is never silently replaced with a guessed firmware target.
+ */
+export const manualOverridesFromProvenance = (
+    selection: FirmwareSelection,
+): Partial<Record<"boardType" | "panelType", boolean>> => ({
+    boardType: selection.boardTypeOrigin !== "auto",
+    panelType: selection.panelTypeOrigin !== "auto",
+});

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -221,6 +221,8 @@
     "prebuiltInfoDesc": "Pick your board and panel above, keep Firmware source on 'Prebuilt image', then Flash. The matching prebuilt, checksum-verified binary is downloaded and written — no compiling needed. Only choose 'Custom' if you know you need to build from source.",
     "noPrebuiltTitle": "No prebuilt firmware for this model yet",
     "noPrebuiltDesc": "There's no tested prebuilt binary for the selected board. Set Firmware source to 'Custom — compile from source' and fill in the expert section below to compile and flash it instead.",
+    "selectionRequiredTitle": "Select a board and panel before flashing",
+    "selectionRequiredDesc": "The mower model may not identify the controller board. Choose the exact board and panel for your hardware; flashing stays disabled until both are selected.",
     "expertBuildLabel": "Expert: custom build parameters",
     "expertBuildAlertMessage": "Only used when Firmware source is 'Custom'",
     "expertBuildAlertDescription": "These settings compile firmware from source instead of flashing the tested prebuilt binary. Wrong values here can damage the battery or disable physical safety. They only take effect when Firmware source above is set to 'Custom — compile from source'.",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -221,6 +221,8 @@
     "prebuiltInfoDesc": "Choisissez votre carte et votre panneau ci-dessus, laissez Source du firmware sur « Image précompilée », puis cliquez sur Flasher. Le binaire précompilé correspondant, vérifié par somme de contrôle, est téléchargé et écrit — aucune compilation nécessaire. Ne choisissez « Personnalisé » que si vous avez besoin de compiler depuis les sources.",
     "noPrebuiltTitle": "Pas encore de firmware précompilé pour ce modèle",
     "noPrebuiltDesc": "Aucun binaire précompilé testé n'existe pour la carte sélectionnée. Réglez Source du firmware sur « Personnalisé — compiler depuis les sources » et renseignez la section experte ci-dessous pour le compiler et le flasher.",
+    "selectionRequiredTitle": "Sélectionnez une carte et un panneau avant de flasher",
+    "selectionRequiredDesc": "Le modèle de tondeuse n'identifie pas toujours la carte contrôleur. Choisissez la carte et le panneau exacts de votre matériel ; le flashage reste désactivé tant que les deux ne sont pas sélectionnés.",
     "expertBuildLabel": "Expert : paramètres du build personnalisé",
     "expertBuildAlertMessage": "Utilisé uniquement quand Source du firmware est « Personnalisé »",
     "expertBuildAlertDescription": "Ces réglages compilent le firmware depuis les sources au lieu de flasher le binaire précompilé testé. De mauvaises valeurs peuvent endommager la batterie ou désactiver une sécurité physique. Ils ne prennent effet que lorsque Source du firmware ci-dessus est réglé sur « Personnalisé — compiler depuis les sources ».",

--- a/gui/web/src/pages/OnboardingPage.tsx
+++ b/gui/web/src/pages/OnboardingPage.tsx
@@ -886,7 +886,7 @@ const ImuYawStep: React.FC<RobotModelStepProps> = ({values, onChange}) => {
 
 // ── Step 5: Firmware ────────────────────────────────────────────────────
 
-const FirmwareStep: React.FC<{ onNext: () => void; autoFlash?: boolean }> = ({ onNext, autoFlash = false }) => {
+const FirmwareStep: React.FC<{ onNext: () => void; autoFlash?: boolean; mowerModel?: string }> = ({ onNext, autoFlash = false, mowerModel }) => {
     const { t } = useTranslation();
     const { colors } = useThemeMode();
     // `autoFlash` (set by the dashboard deep-link when firmware is incompatible)
@@ -898,7 +898,7 @@ const FirmwareStep: React.FC<{ onNext: () => void; autoFlash?: boolean }> = ({ o
     if (showFlash) {
         return (
             <Card title={t("onboardingPage.flashFirmware")}>
-                <FlashBoardComponent onNext={onNext} />
+                <FlashBoardComponent onNext={onNext} mowerModel={mowerModel} />
             </Card>
         );
     }
@@ -1136,7 +1136,7 @@ const OnboardingWizard: React.FC = () => {
         <>
             {currentStep === 0 && <WelcomeStep onNext={handleNext} />}
             {currentStep === 1 && <RobotModelStep values={localValues} onChange={handleChange} />}
-            {currentStep === 2 && <FirmwareStep onNext={handleNext} autoFlash={autoFlash} />}
+            {currentStep === 2 && <FirmwareStep onNext={handleNext} autoFlash={autoFlash} mowerModel={localValues.mower_model} />}
             {currentStep === 3 && <NtripStep values={localValues} onChange={handleChange} />}
             {currentStep === 4 && (
                 <GpsStep

--- a/gui/web/yarn.lock
+++ b/gui/web/yarn.lock
@@ -44,9 +44,9 @@
     "@babel/runtime" "^7.24.7"
 
 "@ant-design/icons-svg@^4.4.0":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz#ed2be7fb4d82ac7e1d45a54a5b06d6cecf8be6f6"
-  integrity sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.6.0.tgz#5f7ebfe2a6b7c871920f73db095bd4ab50d7764d"
+  integrity sha512-PRomU725ABMf/lnQp5HiB7my1kjEbFY0D10N4lXYxK6TIB1gKjIVD5MRThpDaezLgw1D774J8eOeeDB0M6wHrQ==
 
 "@ant-design/icons@^5.0.0", "@ant-design/icons@^5.6.1":
   version "5.6.1"


### PR DESCRIPTION
## Summary

Implements #187 with safe, model-aware firmware preselection and explicit persisted provenance.

## Firmware selection policy

- YardForce500B automatically selects BOARD_YARDFORCE500B and PANEL_TYPE_YARDFORCE_500B_CLASSIC.
- YardForce500 selects only the shared Classic panel. Its board remains unselected because the chassis can use either Vermut (RP2040) or Mowgli (STM32); the user must choose the installed controller.
- All other, custom, unknown, and unsupported models leave board/panel unselected. No generic Vermut or Mowgli fallback is applied.
- Flashing is disabled until both board and panel are selected, with an equivalent submit-time guard.

## Persistence and migration

The gui.firmware.config payload stores independent boardTypeOrigin and panelTypeOrigin values (auto or manual), plus the model that supplied automatic values. On a later model change, only automatic fields update. Missing or unknown provenance is treated as legacy/manual and is restored unchanged, avoiding silent hardware guesses.

## Verification

- Added component-level state-transition tests for fresh defaults, live model changes, per-field overrides, persisted automatic/manual/legacy configurations, settings lookup failure, and empty-selection blocking.
- Added focused helper coverage for mappings, unsupported models, and provenance migration.
- Updated the lockfile from the broken @ant-design/icons-svg 4.4.2 archive to 4.6.0 within the existing ^4.4.0 range so clean installs build and test reliably.
- Local checks: 355/355 Vitest tests, TypeScript no-emit, ESLint (0 errors; existing warnings only), production build, and git diff --check all pass.