### PR TITLE
fix(hardware): harden runtime parameters and battery-state semantics

### DIFF
--- a/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
+++ b/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
@@ -312,7 +312,7 @@ typedef struct {
   float v_charge;                       /**< Charge input voltage [V] */
   float v_system;                       /**< Battery / system voltage [V] */
   float charging_current;               /**< Charging current [A] */
-  uint8_t batt_percentage;              /**< Battery state of charge [0-100] */
+  uint8_t batt_percentage;              /**< Reserved until a verified SoC provider exists; currently 0. */
   uint16_t crc; /**< CRC-16 CCITT over preceding bytes */
 } pkt_status_t;
 

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -1337,7 +1337,10 @@ extern "C" void broadcast_handler() {
     status_pkt.v_charge = charge_voltage;
     status_pkt.v_system = battery_voltage;
     status_pkt.charging_current = current;
-    status_pkt.batt_percentage = 0; // TODO: compute from voltage curve
+    // No verified SoC source exists.  Keep the legacy byte for wire
+    // compatibility; the ROS bridge publishes percentage as unknown (NaN),
+    // not 0 %.  Do not infer SoC from voltage here.
+    status_pkt.batt_percentage = 0;
 
     pkt_reset_cause_t reset_pkt;
     reset_pkt.type = PKT_ID_RESET_CAUSE;

--- a/ros2/scripts/mow_session_monitor.py
+++ b/ros2/scripts/mow_session_monitor.py
@@ -549,7 +549,10 @@ class MowSessionMonitor(Node):
     def _battery_cb(self, msg: BatteryState) -> None:
         with self.state_lock:
             self.state.battery_voltage = float(msg.voltage)
-            self.state.battery_percentage = float(msg.percentage)
+            percentage = float(msg.percentage)
+            # ROS uses NaN for an unmeasured BatteryState percentage; JSON does
+            # not have a NaN value, so preserve that meaning as JSON null.
+            self.state.battery_percentage = percentage if math.isfinite(percentage) else None
 
     def _cmd_vel_nav_cb(self, msg: TwistStamped) -> None:
         with self.state_lock:

--- a/ros2/src/mowgli_hardware/CMakeLists.txt
+++ b/ros2/src/mowgli_hardware/CMakeLists.txt
@@ -233,6 +233,30 @@ if(BUILD_TESTING)
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
+
+  # ---- test_hardware_bridge_parameters ----
+  # Includes the node implementation to exercise ROS's actual read-only
+  # parameter contract while a missing serial device keeps the test hardware-free.
+  ament_add_gtest(test_hardware_bridge_parameters
+    test/test_hardware_bridge_parameters.cpp
+    src/odometry_publisher.cpp
+  )
+  target_link_libraries(test_hardware_bridge_parameters
+    mowgli_hardware_core
+  )
+  target_include_directories(test_hardware_bridge_parameters
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+  ament_target_dependencies(test_hardware_bridge_parameters
+    rclcpp
+    std_msgs
+    std_srvs
+    sensor_msgs
+    geometry_msgs
+    nav_msgs
+    mowgli_interfaces
+  )
 endif()
 
 # ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_hardware/CMakeLists.txt
+++ b/ros2/src/mowgli_hardware/CMakeLists.txt
@@ -215,6 +215,24 @@ if(BUILD_TESTING)
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
+
+  # ---- test_battery_state_semantics ----
+  ament_add_gtest(test_battery_state_semantics
+    test/test_battery_state_semantics.cpp
+  )
+  target_include_directories(test_battery_state_semantics
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
+
+  # ---- test_timer_period ----
+  ament_add_gtest(test_timer_period
+    test/test_timer_period.cpp
+  )
+  target_include_directories(test_timer_period
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
 endif()
 
 # ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/battery_state_semantics.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/battery_state_semantics.hpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace mowgli_hardware
+{
+
+/**
+ * Convert the firmware status packet's legacy battery percentage field to the
+ * sensor_msgs/BatteryState percentage convention.
+ *
+ * Firmware currently writes zero to this field because it has no state-of-
+ * charge provider.  Zero is therefore not a measurement: it must not be
+ * exposed as 0 %.  BatteryState specifies NaN for an unmeasured percentage.
+ *
+ * Keep the raw argument so a future firmware protocol which supplies a
+ * verified SoC source has one explicit migration point.  Until then, every
+ * raw value is intentionally unknown; this avoids inventing a voltage-to-SoC
+ * estimate or treating the legacy zero as a legitimate empty battery.
+ */
+inline float battery_percentage_from_firmware(uint8_t /*raw_percentage*/)
+{
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/ll_datatypes.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/ll_datatypes.hpp
@@ -199,7 +199,9 @@ struct LlStatus
   float v_charge;  ///< Charge voltage [V]
   float v_system;  ///< System/battery voltage [V]
   float charging_current;  ///< Charging current [A]
-  uint8_t batt_percentage;  ///< Battery charge percentage [0-100]
+  // Legacy/reserved: firmware has no verified SoC provider and emits 0.
+  // The host must publish BatteryState.percentage as NaN (unknown), not 0 %.
+  uint8_t batt_percentage;
   uint16_t crc;  ///< CRC-16 CCITT over all preceding bytes
 };
 

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
@@ -55,6 +55,11 @@ inline double minimum_timer_rate_hz()
   return std::nextafter(exact, std::numeric_limits<double>::infinity());
 }
 
+inline constexpr double maximum_timer_rate_hz()
+{
+  return 1.0e9;
+}
+
 /**
  * Convert a timer cadence in Hz to a positive, representable wall-timer
  * duration. Nanoseconds preserve sub-millisecond cadence. Rates whose period
@@ -63,9 +68,10 @@ inline double minimum_timer_rate_hz()
  */
 inline TimerDuration timer_period_from_rate_hz(double rate_hz)
 {
-  if (!std::isfinite(rate_hz) || rate_hz <= 0.0)
+  if (!std::isfinite(rate_hz) || rate_hz < minimum_timer_rate_hz() ||
+      rate_hz > maximum_timer_rate_hz())
   {
-    throw std::invalid_argument("timer rate must be finite and positive");
+    throw std::invalid_argument("timer rate must be finite and within the representable range");
   }
 
   const long double period_ns = 1.0e9L / static_cast<long double>(rate_hz);

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
@@ -60,6 +60,17 @@ inline constexpr double maximum_timer_rate_hz()
   return 1.0e9;
 }
 
+inline void require_operational_timer_rate(double rate_hz,
+                                           const char* name,
+                                           double minimum_hz,
+                                           double maximum_hz)
+{
+  if (!std::isfinite(rate_hz) || rate_hz < minimum_hz || rate_hz > maximum_hz)
+  {
+    throw std::invalid_argument(std::string(name) + " must be within its operational range");
+  }
+}
+
 /**
  * Convert a timer cadence in Hz to a positive, representable wall-timer
  * duration. Nanoseconds preserve sub-millisecond cadence. Rates whose period

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
@@ -1,0 +1,67 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace mowgli_hardware
+{
+
+using TimerDuration = std::chrono::nanoseconds;
+
+inline void require_finite_positive(double value, const char* name)
+{
+  if (!std::isfinite(value) || value <= 0.0)
+  {
+    throw std::invalid_argument(std::string{name} + " must be finite and positive");
+  }
+}
+
+inline void require_finite_nonnegative_timeout(double value, const char* name)
+{
+  if (!std::isfinite(value) || value < 0.0)
+  {
+    throw std::invalid_argument(std::string{name} + " must be finite and non-negative");
+  }
+}
+
+/** Lowest positive rate whose reciprocal is representable as TimerDuration. */
+inline constexpr double minimum_timer_rate_hz()
+{
+  return 1.0e9 / static_cast<double>(TimerDuration::max().count());
+}
+
+/**
+ * Convert a timer cadence in Hz to a positive, representable wall-timer
+ * duration.  Nanoseconds preserve sub-millisecond cadence.  Rates faster than
+ * one tick per nanosecond intentionally saturate at one nanosecond rather
+ * than producing a zero-duration busy loop.
+ */
+inline TimerDuration timer_period_from_rate_hz(double rate_hz)
+{
+  if (!std::isfinite(rate_hz) || rate_hz < minimum_timer_rate_hz())
+  {
+    throw std::invalid_argument(
+        "timer rate must be finite, positive, and have a representable period");
+  }
+
+  const long double period_ns = 1.0e9L / static_cast<long double>(rate_hz);
+  if (period_ns <= 1.0L)
+  {
+    return TimerDuration{1};
+  }
+
+  // The lower-rate bound above makes the cast representable.  Truncation is
+  // deliberate: it preserves the historic exact periods for integral-ms
+  // defaults while allowing sub-millisecond rates.
+  return TimerDuration{static_cast<TimerDuration::rep>(period_ns)};
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
@@ -16,6 +16,12 @@ namespace mowgli_hardware
 
 using TimerDuration = std::chrono::nanoseconds;
 
+// Mirrors the firmware's PKT_ID_SET_KINEMATICS wheel-base clamp. Keeping the
+// host in this range prevents host odometry and firmware inverse kinematics
+// from silently using different geometry.
+inline constexpr double kMinRuntimeWheelTrackM = 0.15;
+inline constexpr double kMaxRuntimeWheelTrackM = 0.60;
+
 inline void require_finite_positive(double value, const char* name)
 {
   if (!std::isfinite(value) || value <= 0.0)
@@ -32,35 +38,46 @@ inline void require_finite_nonnegative_timeout(double value, const char* name)
   }
 }
 
-/** Lowest positive rate whose reciprocal is representable as TimerDuration. */
-inline constexpr double minimum_timer_rate_hz()
+inline void require_runtime_wheel_track(double value)
 {
-  return 1.0e9 / static_cast<double>(TimerDuration::max().count());
+  if (!std::isfinite(value) || value < kMinRuntimeWheelTrackM || value > kMaxRuntimeWheelTrackM)
+  {
+    throw std::invalid_argument("wheel_track must be finite and within [0.15, 0.60] m");
+  }
+}
+
+/** Lowest positive rate whose reciprocal is representable as TimerDuration. */
+inline double minimum_timer_rate_hz()
+{
+  // Round upward so the descriptor cannot admit a rate whose reciprocal is
+  // already outside the int64 nanosecond range after floating-point rounding.
+  const double exact = 1.0e9 / static_cast<double>(TimerDuration::max().count());
+  return std::nextafter(exact, std::numeric_limits<double>::infinity());
 }
 
 /**
  * Convert a timer cadence in Hz to a positive, representable wall-timer
- * duration.  Nanoseconds preserve sub-millisecond cadence.  Rates faster than
- * one tick per nanosecond intentionally saturate at one nanosecond rather
- * than producing a zero-duration busy loop.
+ * duration. Nanoseconds preserve sub-millisecond cadence. Rates whose period
+ * is outside the representable [1 ns, nanoseconds::max()] interval are
+ * rejected rather than creating a zero-duration or CPU-hammering timer.
  */
 inline TimerDuration timer_period_from_rate_hz(double rate_hz)
 {
-  if (!std::isfinite(rate_hz) || rate_hz < minimum_timer_rate_hz())
+  if (!std::isfinite(rate_hz) || rate_hz <= 0.0)
   {
-    throw std::invalid_argument(
-        "timer rate must be finite, positive, and have a representable period");
+    throw std::invalid_argument("timer rate must be finite and positive");
   }
 
   const long double period_ns = 1.0e9L / static_cast<long double>(rate_hz);
-  if (period_ns <= 1.0L)
+  const long double max_period_ns = static_cast<long double>(TimerDuration::max().count());
+  if (period_ns < 1.0L || period_ns > max_period_ns)
   {
-    return TimerDuration{1};
+    throw std::invalid_argument("timer rate must have a representable period in [1 ns, max]");
   }
 
-  // The lower-rate bound above makes the cast representable.  Truncation is
-  // deliberate: it preserves the historic exact periods for integral-ms
-  // defaults while allowing sub-millisecond rates.
+  // Bounds were checked as long doubles before this conversion. Truncation
+  // preserves historic exact periods for integral-ms defaults while allowing
+  // sub-millisecond rates.
   return TimerDuration{static_cast<TimerDuration::rep>(period_ns)};
 }
 

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/timer_period.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -22,6 +23,20 @@ using TimerDuration = std::chrono::nanoseconds;
 inline constexpr double kMinRuntimeWheelTrackM = 0.15;
 inline constexpr double kMaxRuntimeWheelTrackM = 0.60;
 
+struct TimerRateRange
+{
+  double minimum_hz;
+  double maximum_hz;
+};
+
+// Preferred cadences keep each periodic task within the rate it was designed
+// and tested for. They are operational limits, not validity limits: usable
+// requests outside a range are clamped at startup with a warning.
+inline constexpr TimerRateRange kHeartbeatRateRange{1.0, 50.0};
+inline constexpr TimerRateRange kPublishRateRange{10.0, 500.0};
+inline constexpr TimerRateRange kHighLevelRateRange{1.0, 20.0};
+inline constexpr TimerRateRange kDigMonitorRateRange{1.0, 50.0};
+
 inline void require_finite_positive(double value, const char* name)
 {
   if (!std::isfinite(value) || value <= 0.0)
@@ -38,12 +53,13 @@ inline void require_finite_nonnegative_timeout(double value, const char* name)
   }
 }
 
-inline void require_runtime_wheel_track(double value)
+inline double normalize_runtime_wheel_track(double value)
 {
-  if (!std::isfinite(value) || value < kMinRuntimeWheelTrackM || value > kMaxRuntimeWheelTrackM)
+  if (!std::isfinite(value))
   {
-    throw std::invalid_argument("wheel_track must be finite and within [0.15, 0.60] m");
+    throw std::invalid_argument("wheel_track must be finite");
   }
+  return std::clamp(value, kMinRuntimeWheelTrackM, kMaxRuntimeWheelTrackM);
 }
 
 /** Lowest positive rate whose reciprocal is representable as TimerDuration. */
@@ -58,17 +74,6 @@ inline double minimum_timer_rate_hz()
 inline constexpr double maximum_timer_rate_hz()
 {
   return 1.0e9;
-}
-
-inline void require_operational_timer_rate(double rate_hz,
-                                           const char* name,
-                                           double minimum_hz,
-                                           double maximum_hz)
-{
-  if (!std::isfinite(rate_hz) || rate_hz < minimum_hz || rate_hz > maximum_hz)
-  {
-    throw std::invalid_argument(std::string(name) + " must be within its operational range");
-  }
 }
 
 /**
@@ -96,6 +101,15 @@ inline TimerDuration timer_period_from_rate_hz(double rate_hz)
   // preserves historic exact periods for integral-ms defaults while allowing
   // sub-millisecond rates.
   return TimerDuration{static_cast<TimerDuration::rep>(period_ns)};
+}
+
+inline double normalize_operational_timer_rate(double rate_hz, TimerRateRange range)
+{
+  // This conversion is the validity check: it rejects non-finite, non-positive,
+  // unrepresentable and zero-duration timer rates before clamping policy is
+  // applied.
+  (void)timer_period_from_rate_hz(rate_hz);
+  return std::clamp(rate_hz, range.minimum_hz, range.maximum_hz);
 }
 
 }  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -349,7 +349,7 @@ private:
       desc.read_only = true;
       desc.floating_point_range.resize(1);
       desc.floating_point_range[0].from_value = minimum_timer_rate_hz();
-      desc.floating_point_range[0].to_value = std::numeric_limits<double>::max();
+      desc.floating_point_range[0].to_value = maximum_timer_rate_hz();
       return declare_parameter<double>(name, default_val, desc);
     };
     auto bounded_startup_double =

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -60,6 +60,7 @@
 
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
+#include "mowgli_hardware/battery_state_semantics.hpp"
 #include "mowgli_hardware/blade_gate.hpp"
 #include "mowgli_hardware/clock_fit.hpp"
 #include "mowgli_hardware/cmd_vel_validation.hpp"
@@ -71,6 +72,7 @@
 #include "mowgli_hardware/odometry_publisher.hpp"
 #include "mowgli_hardware/packet_handler.hpp"
 #include "mowgli_hardware/serial_port.hpp"
+#include "mowgli_hardware/timer_period.hpp"
 
 // High-level mode constants — must match HighLevelStatus.msg and the
 // HL_MODE_* defines in firmware/mowgli_protocol.h. Declared locally to
@@ -310,6 +312,7 @@ public:
       : Node("hardware_bridge", options), odometry_publisher_(*this)
   {
     declare_parameters();
+    validate_timer_parameters();
     create_publishers();
     create_subscribers();
     create_services();
@@ -336,8 +339,31 @@ private:
   {
     serial_port_path_ = declare_parameter<std::string>("serial_port", "/dev/mowgli");
     baud_rate_ = declare_parameter<int>("baud_rate", 115200);
-    heartbeat_rate_ = declare_parameter<double>("heartbeat_rate", 4.0);
-    publish_rate_ = declare_parameter<double>("publish_rate", 100.0);
+    // Cadence is read once at startup.  The descriptor rejects invalid startup
+    // overrides; validate_timer_parameters() also rejects non-finite values.
+    auto timer_rate = [this](const std::string& name, double default_val) -> double
+    {
+      rcl_interfaces::msg::ParameterDescriptor desc;
+      desc.description = "Finite positive timer cadence in Hz (read at startup).";
+      desc.read_only = true;
+      desc.floating_point_range.resize(1);
+      desc.floating_point_range[0].from_value = minimum_timer_rate_hz();
+      desc.floating_point_range[0].to_value = std::numeric_limits<double>::max();
+      return declare_parameter<double>(name, default_val, desc);
+    };
+    auto bounded_startup_double =
+        [this](const std::string& name, double default_val, double min, double max) -> double
+    {
+      rcl_interfaces::msg::ParameterDescriptor desc;
+      desc.description = "Finite bounded value read at startup.";
+      desc.read_only = true;
+      desc.floating_point_range.resize(1);
+      desc.floating_point_range[0].from_value = min;
+      desc.floating_point_range[0].to_value = max;
+      return declare_parameter<double>(name, default_val, desc);
+    };
+    heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0);
+    publish_rate_ = timer_rate("publish_rate", 100.0);
     // Serial-link watchdog: if no bytes arrive for this long while the port is
     // open, treat the link as dead and reopen it. The STM32 streams status
     // (~4 Hz) + odom (~20 Hz) + IMU (~50-100 Hz) continuously whenever it is
@@ -346,8 +372,9 @@ private:
     // OS leaves the stale fd "open" (reads just return nothing), so without
     // this the bridge would sit forever writing into a dead fd. Reopening
     // re-resolves /dev/mowgli to the new ttyACM.
-    serial_rx_timeout_s_ = declare_parameter<double>("serial_rx_timeout_s", 2.0);
-    high_level_rate_ = declare_parameter<double>("high_level_rate", 2.0);
+    serial_rx_timeout_s_ =
+        bounded_startup_double("serial_rx_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
+    high_level_rate_ = timer_rate("high_level_rate", 2.0);
     dock_x_ = declare_parameter<double>("dock_pose_x", 0.0);
     dock_y_ = declare_parameter<double>("dock_pose_y", 0.0);
     dock_yaw_ = declare_parameter<double>("dock_pose_yaw", 0.0);
@@ -359,7 +386,10 @@ private:
     // centre drive-wheel distance; ticks_per_meter is the runtime encoder
     // scale used by this bridge for host-side odometry and re-sent to the
     // STM32 so the firmware wheel PI / odom share the same tuned value.
-    wheel_track_ = declare_parameter<double>("wheel_track", 0.325);
+    wheel_track_ = bounded_startup_double("wheel_track",
+                                          0.325,
+                                          std::numeric_limits<double>::min(),
+                                          static_cast<double>(std::numeric_limits<float>::max()));
     // Helper for declaring doubles with a floating_point_range descriptor so
     // ros2 param set rejects out-of-bounds values at the framework level before
     // the set-parameters callback fires. Ranges mirror the firmware validation.
@@ -682,16 +712,20 @@ private:
     // RTK-Float the map pose cannot distinguish slip from GNSS noise, and a
     // false dig would hard-stop a perfectly healthy robot mid-mow.
     dig_cfg_.max_pos_sigma = declare_parameter<double>("dig_max_pos_sigma", 0.10);
-    dig_gnss_timeout_s_ = declare_parameter<double>("dig_gnss_timeout_s", 2.0);
+    dig_gnss_timeout_s_ = bounded_startup_double(
+        "dig_gnss_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
     dig_cfg_.max_yaw_rate = declare_parameter<double>("dig_max_yaw_rate", 0.20);
-    dig_gyro_timeout_s_ = declare_parameter<double>("dig_gyro_timeout_s", 0.5);
+    dig_gyro_timeout_s_ = bounded_startup_double(
+        "dig_gyro_timeout_s", 0.5, 0.0, std::numeric_limits<double>::max());
     dig_escape_cfg_.reverse_speed = declare_parameter<double>("dig_reverse_speed", 0.12);
     dig_escape_cfg_.reverse_dist = declare_parameter<double>("dig_reverse_dist", 0.30);
-    dig_escape_cfg_.timeout_s = declare_parameter<double>("dig_reverse_timeout_s", 4.0);
-    dig_monitor_rate_ = declare_parameter<double>("dig_monitor_rate", 10.0);
+    dig_escape_cfg_.timeout_s = bounded_startup_double(
+        "dig_reverse_timeout_s", 4.0, 0.0, std::numeric_limits<double>::max());
+    dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0);
     // Fused pose older than this is treated as absent (detector stands down)
     // rather than compared against stale coordinates.
-    dig_pose_timeout_s_ = declare_parameter<double>("dig_pose_timeout_s", 1.0);
+    dig_pose_timeout_s_ = bounded_startup_double(
+        "dig_pose_timeout_s", 1.0, 0.0, std::numeric_limits<double>::max());
     dig_cfg_.enabled = dig_detect_enabled_;
 
     // ── Repeat-dig escalation (see mowgli_hardware/dig_escalation.hpp) ─────
@@ -717,6 +751,23 @@ private:
                 heartbeat_rate_,
                 publish_rate_,
                 high_level_rate_);
+  }
+
+  void validate_timer_parameters() const
+  {
+    // Descriptors provide ROS-facing bounds.  Converting each value here adds
+    // the finite check which range descriptors alone cannot express and fails
+    // before serial I/O or timer creation if an override is nonsensical.
+    (void)timer_period_from_rate_hz(heartbeat_rate_);
+    (void)timer_period_from_rate_hz(publish_rate_);
+    (void)timer_period_from_rate_hz(high_level_rate_);
+    (void)timer_period_from_rate_hz(dig_monitor_rate_);
+    require_finite_nonnegative_timeout(serial_rx_timeout_s_, "serial_rx_timeout_s");
+    require_finite_positive(wheel_track_, "wheel_track");
+    require_finite_nonnegative_timeout(dig_gnss_timeout_s_, "dig_gnss_timeout_s");
+    require_finite_nonnegative_timeout(dig_gyro_timeout_s_, "dig_gyro_timeout_s");
+    require_finite_nonnegative_timeout(dig_escape_cfg_.timeout_s, "dig_reverse_timeout_s");
+    require_finite_nonnegative_timeout(dig_pose_timeout_s_, "dig_pose_timeout_s");
   }
 
   void create_publishers()
@@ -937,17 +988,17 @@ private:
   void create_timers()
   {
     // Serial read / packet dispatch.
-    const auto read_period_ms = std::chrono::milliseconds(static_cast<int>(1000.0 / publish_rate_));
-    timer_read_ = create_wall_timer(read_period_ms,
+    const auto read_period = timer_period_from_rate_hz(publish_rate_);
+    timer_read_ = create_wall_timer(read_period,
                                     [this]()
                                     {
                                       read_serial_tick();
                                     });
 
     // Heartbeat.
-    const auto hb_period_ms = std::chrono::milliseconds(static_cast<int>(1000.0 / heartbeat_rate_));
+    const auto hb_period = timer_period_from_rate_hz(heartbeat_rate_);
     timer_heartbeat_ =
-        create_wall_timer(hb_period_ms,
+        create_wall_timer(hb_period,
                           [this]()
                           {
                             // On startup, send emergency release for the first few
@@ -993,9 +1044,8 @@ private:
                           });
 
     // High-level state.
-    const auto hl_period_ms =
-        std::chrono::milliseconds(static_cast<int>(1000.0 / high_level_rate_));
-    timer_high_level_ = create_wall_timer(hl_period_ms,
+    const auto hl_period = timer_period_from_rate_hz(high_level_rate_);
+    timer_high_level_ = create_wall_timer(hl_period,
                                           [this]()
                                           {
                                             send_high_level_state();
@@ -1008,9 +1058,8 @@ private:
     // still sitting in the hole it dug).
     if (dig_detect_enabled_)
     {
-      const auto dig_period_ms =
-          std::chrono::milliseconds(static_cast<int>(1000.0 / std::max(1.0, dig_monitor_rate_)));
-      timer_dig_monitor_ = create_wall_timer(dig_period_ms,
+      const auto dig_period = timer_period_from_rate_hz(dig_monitor_rate_);
+      timer_dig_monitor_ = create_wall_timer(dig_period,
                                              [this]()
                                              {
                                                dig_monitor_tick();
@@ -1474,7 +1523,7 @@ private:
       // 0.0 when not charging so hasStoppedCharging() detects the
       // transition after undocking.
       msg.current = is_charging_ ? std::abs(pkt.charging_current) : 0.0f;
-      msg.percentage = static_cast<float>(pkt.batt_percentage) / 100.0f;
+      msg.percentage = battery_percentage_from_firmware(pkt.batt_percentage);
       msg.power_supply_status =
           is_charging_ ? sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_CHARGING
                        : sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_DISCHARGING;

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -360,7 +360,8 @@ private:
           name,
           default_val,
           "Finite startup-only timer cadence in Hz with a representable period of at least 1 ns. "
-          "Usable values outside the preferred [" + std::to_string(preferred_range.minimum_hz) + ", " +
+          "Usable values outside the preferred [" +
+              std::to_string(preferred_range.minimum_hz) + ", " +
               std::to_string(preferred_range.maximum_hz) + "] Hz range are clamped at startup.");
     };
     heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0, kHeartbeatRateRange);
@@ -376,7 +377,9 @@ private:
     // Zero intentionally disables the RX watchdog; non-finite and negative
     // values have no useful or safe watchdog meaning.
     serial_rx_timeout_s_ = startup_double(
-        "serial_rx_timeout_s", 2.0, "Finite non-negative startup-only RX watchdog timeout in seconds; zero disables it.");
+        "serial_rx_timeout_s",
+        2.0,
+        "Finite non-negative startup-only RX watchdog timeout in seconds; zero disables it.");
     high_level_rate_ = timer_rate("high_level_rate", 2.0, kHighLevelRateRange);
     dock_x_ = declare_parameter<double>("dock_pose_x", 0.0);
     dock_y_ = declare_parameter<double>("dock_pose_y", 0.0);
@@ -389,10 +392,11 @@ private:
     // centre drive-wheel distance; ticks_per_meter is the runtime encoder
     // scale used by this bridge for host-side odometry and re-sent to the
     // STM32 so the firmware wheel PI / odom share the same tuned value.
-    wheel_track_ = startup_double("wheel_track",
-                                  0.325,
-                                  "Finite startup-only wheel track in metres. Values outside the firmware "
-                                  "range [0.15, 0.60] are clamped at startup.");
+    wheel_track_ =
+        startup_double("wheel_track",
+                       0.325,
+                       "Finite startup-only wheel track in metres. Values outside the firmware "
+                       "range [0.15, 0.60] are clamped at startup.");
     // Helper for declaring doubles with a floating_point_range descriptor so
     // ros2 param set rejects out-of-bounds values at the framework level before
     // the set-parameters callback fires. Ranges mirror the firmware validation.
@@ -719,19 +723,27 @@ private:
     // zero escape timeout would suppress its reverse manoeuvre. Require each
     // dig timeout to be strictly positive instead.
     dig_gnss_timeout_s_ = startup_double(
-        "dig_gnss_timeout_s", 2.0, "Finite strictly-positive startup-only dig GNSS freshness timeout in seconds.");
+        "dig_gnss_timeout_s",
+        2.0,
+        "Finite strictly-positive startup-only dig GNSS freshness timeout in seconds.");
     dig_cfg_.max_yaw_rate = declare_parameter<double>("dig_max_yaw_rate", 0.20);
     dig_gyro_timeout_s_ = startup_double(
-        "dig_gyro_timeout_s", 0.5, "Finite strictly-positive startup-only dig gyro freshness timeout in seconds.");
+        "dig_gyro_timeout_s",
+        0.5,
+        "Finite strictly-positive startup-only dig gyro freshness timeout in seconds.");
     dig_escape_cfg_.reverse_speed = declare_parameter<double>("dig_reverse_speed", 0.12);
     dig_escape_cfg_.reverse_dist = declare_parameter<double>("dig_reverse_dist", 0.30);
-    dig_escape_cfg_.timeout_s = startup_double(
-        "dig_reverse_timeout_s", 4.0, "Finite strictly-positive startup-only dig reverse timeout in seconds.");
+    dig_escape_cfg_.timeout_s =
+        startup_double("dig_reverse_timeout_s",
+                       4.0,
+                       "Finite strictly-positive startup-only dig reverse timeout in seconds.");
     dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0, kDigMonitorRateRange);
     // Fused pose older than this is treated as absent (detector stands down)
     // rather than compared against stale coordinates.
     dig_pose_timeout_s_ = startup_double(
-        "dig_pose_timeout_s", 1.0, "Finite strictly-positive startup-only dig pose freshness timeout in seconds.");
+        "dig_pose_timeout_s",
+        1.0,
+        "Finite strictly-positive startup-only dig pose freshness timeout in seconds.");
     dig_cfg_.enabled = dig_detect_enabled_;
 
     // ── Repeat-dig escalation (see mowgli_hardware/dig_escalation.hpp) ─────

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -339,35 +339,32 @@ private:
   {
     serial_port_path_ = declare_parameter<std::string>("serial_port", "/dev/mowgli");
     baud_rate_ = declare_parameter<int>("baud_rate", 115200);
-    // Cadence is read once at startup.  The descriptor rejects invalid startup
-    // overrides; validate_startup_parameters() also rejects non-finite values.
-    auto timer_rate = [this](const std::string& name,
-                             double default_val,
-                             double minimum_hz,
-                             double maximum_hz) -> double
+    // These values are consumed only while constructing the timers and
+    // kinematics, so ROS must reject runtime updates. Invalid startup values
+    // are checked explicitly below; descriptors cannot express finite-only or
+    // an open strictly-positive interval without a misleading pseudo-bound.
+    auto startup_double = [this](const std::string& name,
+                                 double default_val,
+                                 const std::string& description) -> double
     {
       rcl_interfaces::msg::ParameterDescriptor desc;
-      desc.description =
-          "Finite startup-only timer cadence in Hz with a representable period of at least 1 ns.";
+      desc.description = description;
       desc.read_only = true;
-      desc.floating_point_range.resize(1);
-      desc.floating_point_range[0].from_value = minimum_hz;
-      desc.floating_point_range[0].to_value = maximum_hz;
       return declare_parameter<double>(name, default_val, desc);
     };
-    auto bounded_startup_double =
-        [this](const std::string& name, double default_val, double min, double max) -> double
+    auto timer_rate = [&startup_double](const std::string& name,
+                                        double default_val,
+                                        TimerRateRange preferred_range) -> double
     {
-      rcl_interfaces::msg::ParameterDescriptor desc;
-      desc.description = "Finite bounded startup-only value.";
-      desc.read_only = true;
-      desc.floating_point_range.resize(1);
-      desc.floating_point_range[0].from_value = min;
-      desc.floating_point_range[0].to_value = max;
-      return declare_parameter<double>(name, default_val, desc);
+      return startup_double(
+          name,
+          default_val,
+          "Finite startup-only timer cadence in Hz with a representable period of at least 1 ns. "
+          "Usable values outside the preferred [" + std::to_string(preferred_range.minimum_hz) + ", " +
+              std::to_string(preferred_range.maximum_hz) + "] Hz range are clamped at startup.");
     };
-    heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0, 1.0, 50.0);
-    publish_rate_ = timer_rate("publish_rate", 100.0, 10.0, 500.0);
+    heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0, kHeartbeatRateRange);
+    publish_rate_ = timer_rate("publish_rate", 100.0, kPublishRateRange);
     // Serial-link watchdog: if no bytes arrive for this long while the port is
     // open, treat the link as dead and reopen it. The STM32 streams status
     // (~4 Hz) + odom (~20 Hz) + IMU (~50-100 Hz) continuously whenever it is
@@ -378,9 +375,9 @@ private:
     // re-resolves /dev/mowgli to the new ttyACM.
     // Zero intentionally disables the RX watchdog; non-finite and negative
     // values have no useful or safe watchdog meaning.
-    serial_rx_timeout_s_ =
-        bounded_startup_double("serial_rx_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
-    high_level_rate_ = timer_rate("high_level_rate", 2.0, 1.0, 20.0);
+    serial_rx_timeout_s_ = startup_double(
+        "serial_rx_timeout_s", 2.0, "Finite non-negative startup-only RX watchdog timeout in seconds; zero disables it.");
+    high_level_rate_ = timer_rate("high_level_rate", 2.0, kHighLevelRateRange);
     dock_x_ = declare_parameter<double>("dock_pose_x", 0.0);
     dock_y_ = declare_parameter<double>("dock_pose_y", 0.0);
     dock_yaw_ = declare_parameter<double>("dock_pose_yaw", 0.0);
@@ -392,10 +389,10 @@ private:
     // centre drive-wheel distance; ticks_per_meter is the runtime encoder
     // scale used by this bridge for host-side odometry and re-sent to the
     // STM32 so the firmware wheel PI / odom share the same tuned value.
-    wheel_track_ = bounded_startup_double("wheel_track",
-                                          0.325,
-                                          kMinRuntimeWheelTrackM,
-                                          kMaxRuntimeWheelTrackM);
+    wheel_track_ = startup_double("wheel_track",
+                                  0.325,
+                                  "Finite startup-only wheel track in metres. Values outside the firmware "
+                                  "range [0.15, 0.60] are clamped at startup.");
     // Helper for declaring doubles with a floating_point_range descriptor so
     // ros2 param set rejects out-of-bounds values at the framework level before
     // the set-parameters callback fires. Ranges mirror the firmware validation.
@@ -721,28 +718,20 @@ private:
     // Zero freshness windows would permanently stand the detector down, and a
     // zero escape timeout would suppress its reverse manoeuvre. Require each
     // dig timeout to be strictly positive instead.
-    dig_gnss_timeout_s_ = bounded_startup_double("dig_gnss_timeout_s",
-                                                 2.0,
-                                                 std::numeric_limits<double>::min(),
-                                                 std::numeric_limits<double>::max());
+    dig_gnss_timeout_s_ = startup_double(
+        "dig_gnss_timeout_s", 2.0, "Finite strictly-positive startup-only dig GNSS freshness timeout in seconds.");
     dig_cfg_.max_yaw_rate = declare_parameter<double>("dig_max_yaw_rate", 0.20);
-    dig_gyro_timeout_s_ = bounded_startup_double("dig_gyro_timeout_s",
-                                                 0.5,
-                                                 std::numeric_limits<double>::min(),
-                                                 std::numeric_limits<double>::max());
+    dig_gyro_timeout_s_ = startup_double(
+        "dig_gyro_timeout_s", 0.5, "Finite strictly-positive startup-only dig gyro freshness timeout in seconds.");
     dig_escape_cfg_.reverse_speed = declare_parameter<double>("dig_reverse_speed", 0.12);
     dig_escape_cfg_.reverse_dist = declare_parameter<double>("dig_reverse_dist", 0.30);
-    dig_escape_cfg_.timeout_s = bounded_startup_double("dig_reverse_timeout_s",
-                                                       4.0,
-                                                       std::numeric_limits<double>::min(),
-                                                       std::numeric_limits<double>::max());
-    dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0, 1.0, 50.0);
+    dig_escape_cfg_.timeout_s = startup_double(
+        "dig_reverse_timeout_s", 4.0, "Finite strictly-positive startup-only dig reverse timeout in seconds.");
+    dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0, kDigMonitorRateRange);
     // Fused pose older than this is treated as absent (detector stands down)
     // rather than compared against stale coordinates.
-    dig_pose_timeout_s_ = bounded_startup_double("dig_pose_timeout_s",
-                                                 1.0,
-                                                 std::numeric_limits<double>::min(),
-                                                 std::numeric_limits<double>::max());
+    dig_pose_timeout_s_ = startup_double(
+        "dig_pose_timeout_s", 1.0, "Finite strictly-positive startup-only dig pose freshness timeout in seconds.");
     dig_cfg_.enabled = dig_detect_enabled_;
 
     // ── Repeat-dig escalation (see mowgli_hardware/dig_escalation.hpp) ─────
@@ -770,21 +759,35 @@ private:
                 high_level_rate_);
   }
 
-  void validate_startup_parameters() const
+  void validate_startup_parameters()
   {
-    // Descriptors provide ROS-facing bounds.  Converting each value here adds
-    // the finite check which range descriptors alone cannot express and fails
-    // before serial I/O or timer creation if an override is nonsensical.
-    (void)timer_period_from_rate_hz(heartbeat_rate_);
-    (void)timer_period_from_rate_hz(publish_rate_);
-    (void)timer_period_from_rate_hz(high_level_rate_);
-    (void)timer_period_from_rate_hz(dig_monitor_rate_);
-    require_operational_timer_rate(heartbeat_rate_, "heartbeat_rate", 1.0, 50.0);
-    require_operational_timer_rate(publish_rate_, "publish_rate", 10.0, 500.0);
-    require_operational_timer_rate(high_level_rate_, "high_level_rate", 1.0, 20.0);
-    require_operational_timer_rate(dig_monitor_rate_, "dig_monitor_rate", 1.0, 50.0);
+    auto normalize_timer = [this](const char* name, double& requested, TimerRateRange range)
+    {
+      const double effective = normalize_operational_timer_rate(requested, range);
+      if (effective != requested)
+      {
+        RCLCPP_WARN(get_logger(),
+                    "%s requested %.17g Hz is outside the preferred range; using %.17g Hz",
+                    name,
+                    requested,
+                    effective);
+        requested = effective;
+      }
+    };
+    normalize_timer("heartbeat_rate", heartbeat_rate_, kHeartbeatRateRange);
+    normalize_timer("publish_rate", publish_rate_, kPublishRateRange);
+    normalize_timer("high_level_rate", high_level_rate_, kHighLevelRateRange);
+    normalize_timer("dig_monitor_rate", dig_monitor_rate_, kDigMonitorRateRange);
+    const double effective_wheel_track = normalize_runtime_wheel_track(wheel_track_);
+    if (effective_wheel_track != wheel_track_)
+    {
+      RCLCPP_WARN(get_logger(),
+                  "wheel_track requested %.17g m is outside the firmware range; using %.17g m",
+                  wheel_track_,
+                  effective_wheel_track);
+      wheel_track_ = effective_wheel_track;
+    }
     require_finite_nonnegative_timeout(serial_rx_timeout_s_, "serial_rx_timeout_s");
-    require_runtime_wheel_track(wheel_track_);
     require_finite_positive(dig_gnss_timeout_s_, "dig_gnss_timeout_s");
     require_finite_positive(dig_gyro_timeout_s_, "dig_gyro_timeout_s");
     require_finite_positive(dig_escape_cfg_.timeout_s, "dig_reverse_timeout_s");

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -341,15 +341,18 @@ private:
     baud_rate_ = declare_parameter<int>("baud_rate", 115200);
     // Cadence is read once at startup.  The descriptor rejects invalid startup
     // overrides; validate_startup_parameters() also rejects non-finite values.
-    auto timer_rate = [this](const std::string& name, double default_val) -> double
+    auto timer_rate = [this](const std::string& name,
+                             double default_val,
+                             double minimum_hz,
+                             double maximum_hz) -> double
     {
       rcl_interfaces::msg::ParameterDescriptor desc;
       desc.description =
           "Finite startup-only timer cadence in Hz with a representable period of at least 1 ns.";
       desc.read_only = true;
       desc.floating_point_range.resize(1);
-      desc.floating_point_range[0].from_value = minimum_timer_rate_hz();
-      desc.floating_point_range[0].to_value = maximum_timer_rate_hz();
+      desc.floating_point_range[0].from_value = minimum_hz;
+      desc.floating_point_range[0].to_value = maximum_hz;
       return declare_parameter<double>(name, default_val, desc);
     };
     auto bounded_startup_double =
@@ -363,8 +366,8 @@ private:
       desc.floating_point_range[0].to_value = max;
       return declare_parameter<double>(name, default_val, desc);
     };
-    heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0);
-    publish_rate_ = timer_rate("publish_rate", 100.0);
+    heartbeat_rate_ = timer_rate("heartbeat_rate", 4.0, 1.0, 50.0);
+    publish_rate_ = timer_rate("publish_rate", 100.0, 10.0, 500.0);
     // Serial-link watchdog: if no bytes arrive for this long while the port is
     // open, treat the link as dead and reopen it. The STM32 streams status
     // (~4 Hz) + odom (~20 Hz) + IMU (~50-100 Hz) continuously whenever it is
@@ -377,7 +380,7 @@ private:
     // values have no useful or safe watchdog meaning.
     serial_rx_timeout_s_ =
         bounded_startup_double("serial_rx_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
-    high_level_rate_ = timer_rate("high_level_rate", 2.0);
+    high_level_rate_ = timer_rate("high_level_rate", 2.0, 1.0, 20.0);
     dock_x_ = declare_parameter<double>("dock_pose_x", 0.0);
     dock_y_ = declare_parameter<double>("dock_pose_y", 0.0);
     dock_yaw_ = declare_parameter<double>("dock_pose_yaw", 0.0);
@@ -733,7 +736,7 @@ private:
                                                        4.0,
                                                        std::numeric_limits<double>::min(),
                                                        std::numeric_limits<double>::max());
-    dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0);
+    dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0, 1.0, 50.0);
     // Fused pose older than this is treated as absent (detector stands down)
     // rather than compared against stale coordinates.
     dig_pose_timeout_s_ = bounded_startup_double("dig_pose_timeout_s",
@@ -776,6 +779,10 @@ private:
     (void)timer_period_from_rate_hz(publish_rate_);
     (void)timer_period_from_rate_hz(high_level_rate_);
     (void)timer_period_from_rate_hz(dig_monitor_rate_);
+    require_operational_timer_rate(heartbeat_rate_, "heartbeat_rate", 1.0, 50.0);
+    require_operational_timer_rate(publish_rate_, "publish_rate", 10.0, 500.0);
+    require_operational_timer_rate(high_level_rate_, "high_level_rate", 1.0, 20.0);
+    require_operational_timer_rate(dig_monitor_rate_, "dig_monitor_rate", 1.0, 50.0);
     require_finite_nonnegative_timeout(serial_rx_timeout_s_, "serial_rx_timeout_s");
     require_runtime_wheel_track(wheel_track_);
     require_finite_positive(dig_gnss_timeout_s_, "dig_gnss_timeout_s");

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -312,7 +312,7 @@ public:
       : Node("hardware_bridge", options), odometry_publisher_(*this)
   {
     declare_parameters();
-    validate_timer_parameters();
+    validate_startup_parameters();
     create_publishers();
     create_subscribers();
     create_services();
@@ -340,11 +340,12 @@ private:
     serial_port_path_ = declare_parameter<std::string>("serial_port", "/dev/mowgli");
     baud_rate_ = declare_parameter<int>("baud_rate", 115200);
     // Cadence is read once at startup.  The descriptor rejects invalid startup
-    // overrides; validate_timer_parameters() also rejects non-finite values.
+    // overrides; validate_startup_parameters() also rejects non-finite values.
     auto timer_rate = [this](const std::string& name, double default_val) -> double
     {
       rcl_interfaces::msg::ParameterDescriptor desc;
-      desc.description = "Finite positive timer cadence in Hz (read at startup).";
+      desc.description =
+          "Finite startup-only timer cadence in Hz with a representable period of at least 1 ns.";
       desc.read_only = true;
       desc.floating_point_range.resize(1);
       desc.floating_point_range[0].from_value = minimum_timer_rate_hz();
@@ -355,7 +356,7 @@ private:
         [this](const std::string& name, double default_val, double min, double max) -> double
     {
       rcl_interfaces::msg::ParameterDescriptor desc;
-      desc.description = "Finite bounded value read at startup.";
+      desc.description = "Finite bounded startup-only value.";
       desc.read_only = true;
       desc.floating_point_range.resize(1);
       desc.floating_point_range[0].from_value = min;
@@ -372,6 +373,8 @@ private:
     // OS leaves the stale fd "open" (reads just return nothing), so without
     // this the bridge would sit forever writing into a dead fd. Reopening
     // re-resolves /dev/mowgli to the new ttyACM.
+    // Zero intentionally disables the RX watchdog; non-finite and negative
+    // values have no useful or safe watchdog meaning.
     serial_rx_timeout_s_ =
         bounded_startup_double("serial_rx_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
     high_level_rate_ = timer_rate("high_level_rate", 2.0);
@@ -388,8 +391,8 @@ private:
     // STM32 so the firmware wheel PI / odom share the same tuned value.
     wheel_track_ = bounded_startup_double("wheel_track",
                                           0.325,
-                                          std::numeric_limits<double>::min(),
-                                          static_cast<double>(std::numeric_limits<float>::max()));
+                                          kMinRuntimeWheelTrackM,
+                                          kMaxRuntimeWheelTrackM);
     // Helper for declaring doubles with a floating_point_range descriptor so
     // ros2 param set rejects out-of-bounds values at the framework level before
     // the set-parameters callback fires. Ranges mirror the firmware validation.
@@ -712,20 +715,31 @@ private:
     // RTK-Float the map pose cannot distinguish slip from GNSS noise, and a
     // false dig would hard-stop a perfectly healthy robot mid-mow.
     dig_cfg_.max_pos_sigma = declare_parameter<double>("dig_max_pos_sigma", 0.10);
-    dig_gnss_timeout_s_ = bounded_startup_double(
-        "dig_gnss_timeout_s", 2.0, 0.0, std::numeric_limits<double>::max());
+    // Zero freshness windows would permanently stand the detector down, and a
+    // zero escape timeout would suppress its reverse manoeuvre. Require each
+    // dig timeout to be strictly positive instead.
+    dig_gnss_timeout_s_ = bounded_startup_double("dig_gnss_timeout_s",
+                                                 2.0,
+                                                 std::numeric_limits<double>::min(),
+                                                 std::numeric_limits<double>::max());
     dig_cfg_.max_yaw_rate = declare_parameter<double>("dig_max_yaw_rate", 0.20);
-    dig_gyro_timeout_s_ = bounded_startup_double(
-        "dig_gyro_timeout_s", 0.5, 0.0, std::numeric_limits<double>::max());
+    dig_gyro_timeout_s_ = bounded_startup_double("dig_gyro_timeout_s",
+                                                 0.5,
+                                                 std::numeric_limits<double>::min(),
+                                                 std::numeric_limits<double>::max());
     dig_escape_cfg_.reverse_speed = declare_parameter<double>("dig_reverse_speed", 0.12);
     dig_escape_cfg_.reverse_dist = declare_parameter<double>("dig_reverse_dist", 0.30);
-    dig_escape_cfg_.timeout_s = bounded_startup_double(
-        "dig_reverse_timeout_s", 4.0, 0.0, std::numeric_limits<double>::max());
+    dig_escape_cfg_.timeout_s = bounded_startup_double("dig_reverse_timeout_s",
+                                                       4.0,
+                                                       std::numeric_limits<double>::min(),
+                                                       std::numeric_limits<double>::max());
     dig_monitor_rate_ = timer_rate("dig_monitor_rate", 10.0);
     // Fused pose older than this is treated as absent (detector stands down)
     // rather than compared against stale coordinates.
-    dig_pose_timeout_s_ = bounded_startup_double(
-        "dig_pose_timeout_s", 1.0, 0.0, std::numeric_limits<double>::max());
+    dig_pose_timeout_s_ = bounded_startup_double("dig_pose_timeout_s",
+                                                 1.0,
+                                                 std::numeric_limits<double>::min(),
+                                                 std::numeric_limits<double>::max());
     dig_cfg_.enabled = dig_detect_enabled_;
 
     // ── Repeat-dig escalation (see mowgli_hardware/dig_escalation.hpp) ─────
@@ -753,7 +767,7 @@ private:
                 high_level_rate_);
   }
 
-  void validate_timer_parameters() const
+  void validate_startup_parameters() const
   {
     // Descriptors provide ROS-facing bounds.  Converting each value here adds
     // the finite check which range descriptors alone cannot express and fails
@@ -763,11 +777,11 @@ private:
     (void)timer_period_from_rate_hz(high_level_rate_);
     (void)timer_period_from_rate_hz(dig_monitor_rate_);
     require_finite_nonnegative_timeout(serial_rx_timeout_s_, "serial_rx_timeout_s");
-    require_finite_positive(wheel_track_, "wheel_track");
-    require_finite_nonnegative_timeout(dig_gnss_timeout_s_, "dig_gnss_timeout_s");
-    require_finite_nonnegative_timeout(dig_gyro_timeout_s_, "dig_gyro_timeout_s");
-    require_finite_nonnegative_timeout(dig_escape_cfg_.timeout_s, "dig_reverse_timeout_s");
-    require_finite_nonnegative_timeout(dig_pose_timeout_s_, "dig_pose_timeout_s");
+    require_runtime_wheel_track(wheel_track_);
+    require_finite_positive(dig_gnss_timeout_s_, "dig_gnss_timeout_s");
+    require_finite_positive(dig_gyro_timeout_s_, "dig_gyro_timeout_s");
+    require_finite_positive(dig_escape_cfg_.timeout_s, "dig_reverse_timeout_s");
+    require_finite_positive(dig_pose_timeout_s_, "dig_pose_timeout_s");
   }
 
   void create_publishers()

--- a/ros2/src/mowgli_hardware/test/test_battery_state_semantics.cpp
+++ b/ros2/src/mowgli_hardware/test/test_battery_state_semantics.cpp
@@ -5,9 +5,8 @@
 #include <cmath>
 #include <cstdint>
 
-#include <gtest/gtest.h>
-
 #include "mowgli_hardware/battery_state_semantics.hpp"
+#include <gtest/gtest.h>
 
 namespace mowgli_hardware
 {

--- a/ros2/src/mowgli_hardware/test/test_battery_state_semantics.cpp
+++ b/ros2/src/mowgli_hardware/test/test_battery_state_semantics.cpp
@@ -1,0 +1,29 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#include <cmath>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "mowgli_hardware/battery_state_semantics.hpp"
+
+namespace mowgli_hardware
+{
+
+TEST(BatteryStateSemantics, LegacyFirmwarePercentageIsUnknown)
+{
+  // Firmware currently emits 0 while no SoC source exists.  BatteryState uses
+  // NaN, rather than 0.0, for an unmeasured percentage.
+  EXPECT_TRUE(std::isnan(battery_percentage_from_firmware(0)));
+}
+
+TEST(BatteryStateSemantics, UnimplementedFieldCannotMasqueradeAsMeasurement)
+{
+  // The status-packet field is reserved for a future verified SoC provider;
+  // until then even an arbitrary byte is not a valid 0..1 measurement.
+  EXPECT_TRUE(std::isnan(battery_percentage_from_firmware(UINT8_C(75))));
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/test/test_hardware_bridge_parameters.cpp
+++ b/ros2/src/mowgli_hardware/test/test_hardware_bridge_parameters.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+// The bridge is intentionally a single executable. Rename its main while
+// including the implementation so this test exercises the real parameter
+// descriptors instead of duplicating their behaviour in a helper.
+#define main hardware_bridge_node_main_for_test
+#include "../src/hardware_bridge_node.cpp"
+#undef main
+
+namespace mowgli_hardware
+{
+
+class HardwareBridgeParametersTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(HardwareBridgeParametersTest, PublishRateRejectsRuntimeUpdate)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("serial_port", "/definitely/not/a/serial/device")});
+  auto node = std::make_shared<HardwareBridgeNode>(options);
+
+  const auto result = node->set_parameter(rclcpp::Parameter("publish_rate", 5.0));
+
+  EXPECT_FALSE(result.successful);
+}
+
+TEST_F(HardwareBridgeParametersTest, UsableOutOfRangePublishRateStarts)
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("serial_port", "/definitely/not/a/serial/device"),
+                               rclcpp::Parameter("publish_rate", 5.0)});
+
+  EXPECT_NO_THROW(std::make_shared<HardwareBridgeNode>(options));
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/test/test_hardware_bridge_parameters.cpp
+++ b/ros2/src/mowgli_hardware/test/test_hardware_bridge_parameters.cpp
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0
 
-#include <gtest/gtest.h>
-
 #include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
 
 // The bridge is intentionally a single executable. Rename its main while
 // including the implementation so this test exercises the real parameter
@@ -33,7 +33,8 @@ protected:
 TEST_F(HardwareBridgeParametersTest, PublishRateRejectsRuntimeUpdate)
 {
   rclcpp::NodeOptions options;
-  options.parameter_overrides({rclcpp::Parameter("serial_port", "/definitely/not/a/serial/device")});
+  options.parameter_overrides(
+      {rclcpp::Parameter("serial_port", "/definitely/not/a/serial/device")});
   auto node = std::make_shared<HardwareBridgeNode>(options);
 
   const auto result = node->set_parameter(rclcpp::Parameter("publish_rate", 5.0));

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -5,9 +5,8 @@
 #include <limits>
 #include <stdexcept>
 
-#include <gtest/gtest.h>
-
 #include "mowgli_hardware/timer_period.hpp"
+#include <gtest/gtest.h>
 
 namespace mowgli_hardware
 {
@@ -28,28 +27,56 @@ TEST(TimerPeriod, RejectsZeroNegativeAndNonFiniteRates)
                std::invalid_argument);
   EXPECT_THROW(timer_period_from_rate_hz(std::numeric_limits<double>::infinity()),
                std::invalid_argument);
-}
-
-TEST(TimerPeriod, VeryHighFiniteRateCannotCreateZeroDuration)
-{
-  EXPECT_EQ(timer_period_from_rate_hz(std::numeric_limits<double>::max()).count(), 1);
-}
-
-TEST(TimerPeriod, RejectsRateWithUnrepresentablyLongPeriod)
-{
-  EXPECT_THROW(timer_period_from_rate_hz(minimum_timer_rate_hz() / 2.0),
+  EXPECT_THROW(timer_period_from_rate_hz(-std::numeric_limits<double>::infinity()),
                std::invalid_argument);
+}
+
+TEST(TimerPeriod, OneNanosecondPeriodIsTheFastestAcceptedCadence)
+{
+  EXPECT_EQ(timer_period_from_rate_hz(1.0e9).count(), 1);
+  EXPECT_THROW(timer_period_from_rate_hz(std::numeric_limits<double>::max()),
+               std::invalid_argument);
+}
+
+TEST(TimerPeriod, HandlesRepresentablePeriodBoundaryWithoutOverflow)
+{
+  const double minimum = minimum_timer_rate_hz();
+  EXPECT_GT(timer_period_from_rate_hz(minimum).count(), 0);
+  EXPECT_LE(timer_period_from_rate_hz(minimum), TimerDuration::max());
+  EXPECT_NO_THROW(
+      timer_period_from_rate_hz(std::nextafter(minimum, std::numeric_limits<double>::infinity())));
+  EXPECT_THROW(timer_period_from_rate_hz(std::nextafter(minimum, 0.0)), std::invalid_argument);
 }
 
 TEST(TimerPeriod, RejectsInvalidDivisorsAndTimeouts)
 {
-  EXPECT_THROW(require_finite_positive(0.0, "wheel_track"), std::invalid_argument);
-  EXPECT_THROW(require_finite_positive(std::numeric_limits<double>::quiet_NaN(), "wheel_track"),
+  EXPECT_NO_THROW(require_runtime_wheel_track(0.325));
+  EXPECT_THROW(require_runtime_wheel_track(0.0), std::invalid_argument);
+  EXPECT_THROW(require_runtime_wheel_track(-0.325), std::invalid_argument);
+  EXPECT_THROW(require_runtime_wheel_track(std::numeric_limits<double>::quiet_NaN()),
                std::invalid_argument);
+  EXPECT_THROW(require_runtime_wheel_track(std::numeric_limits<double>::infinity()),
+               std::invalid_argument);
+  EXPECT_THROW(require_runtime_wheel_track(kMinRuntimeWheelTrackM / 2.0), std::invalid_argument);
+  EXPECT_THROW(require_runtime_wheel_track(kMaxRuntimeWheelTrackM * 2.0), std::invalid_argument);
+
+  EXPECT_NO_THROW(require_finite_nonnegative_timeout(0.0, "serial_rx_timeout_s"));
+  EXPECT_NO_THROW(require_finite_positive(1.0, "dig_pose_timeout_s"));
   EXPECT_THROW(require_finite_nonnegative_timeout(-1.0, "serial_rx_timeout_s"),
                std::invalid_argument);
   EXPECT_THROW(require_finite_nonnegative_timeout(std::numeric_limits<double>::quiet_NaN(),
                                                   "serial_rx_timeout_s"),
+               std::invalid_argument);
+  EXPECT_THROW(require_finite_nonnegative_timeout(std::numeric_limits<double>::infinity(),
+                                                  "serial_rx_timeout_s"),
+               std::invalid_argument);
+  EXPECT_THROW(require_finite_positive(0.0, "dig_pose_timeout_s"), std::invalid_argument);
+  EXPECT_THROW(require_finite_positive(-1.0, "dig_pose_timeout_s"), std::invalid_argument);
+  EXPECT_THROW(require_finite_positive(std::numeric_limits<double>::quiet_NaN(),
+                                       "dig_pose_timeout_s"),
+               std::invalid_argument);
+  EXPECT_THROW(require_finite_positive(std::numeric_limits<double>::infinity(),
+                                       "dig_pose_timeout_s"),
                std::invalid_argument);
 }
 

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0
+
+#include <limits>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "mowgli_hardware/timer_period.hpp"
+
+namespace mowgli_hardware
+{
+
+TEST(TimerPeriod, NormalHardwareBridgeDefaultsKeepTheirPeriods)
+{
+  EXPECT_EQ(timer_period_from_rate_hz(4.0), std::chrono::milliseconds(250));
+  EXPECT_EQ(timer_period_from_rate_hz(100.0), std::chrono::milliseconds(10));
+  EXPECT_EQ(timer_period_from_rate_hz(2.0), std::chrono::milliseconds(500));
+  EXPECT_EQ(timer_period_from_rate_hz(10.0), std::chrono::milliseconds(100));
+}
+
+TEST(TimerPeriod, RejectsZeroNegativeAndNonFiniteRates)
+{
+  EXPECT_THROW(timer_period_from_rate_hz(0.0), std::invalid_argument);
+  EXPECT_THROW(timer_period_from_rate_hz(-1.0), std::invalid_argument);
+  EXPECT_THROW(timer_period_from_rate_hz(std::numeric_limits<double>::quiet_NaN()),
+               std::invalid_argument);
+  EXPECT_THROW(timer_period_from_rate_hz(std::numeric_limits<double>::infinity()),
+               std::invalid_argument);
+}
+
+TEST(TimerPeriod, VeryHighFiniteRateCannotCreateZeroDuration)
+{
+  EXPECT_EQ(timer_period_from_rate_hz(std::numeric_limits<double>::max()).count(), 1);
+}
+
+TEST(TimerPeriod, RejectsRateWithUnrepresentablyLongPeriod)
+{
+  EXPECT_THROW(timer_period_from_rate_hz(minimum_timer_rate_hz() / 2.0),
+               std::invalid_argument);
+}
+
+TEST(TimerPeriod, RejectsInvalidDivisorsAndTimeouts)
+{
+  EXPECT_THROW(require_finite_positive(0.0, "wheel_track"), std::invalid_argument);
+  EXPECT_THROW(require_finite_positive(std::numeric_limits<double>::quiet_NaN(), "wheel_track"),
+               std::invalid_argument);
+  EXPECT_THROW(require_finite_nonnegative_timeout(-1.0, "serial_rx_timeout_s"),
+               std::invalid_argument);
+  EXPECT_THROW(require_finite_nonnegative_timeout(std::numeric_limits<double>::quiet_NaN(),
+                                                  "serial_rx_timeout_s"),
+               std::invalid_argument);
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -51,29 +51,36 @@ TEST(TimerPeriod, HandlesRepresentablePeriodBoundaryWithoutOverflow)
   EXPECT_THROW(timer_period_from_rate_hz(std::nextafter(minimum, 0.0)), std::invalid_argument);
 }
 
-TEST(TimerPeriod, EnforcesOperationalTimerRateBounds)
+TEST(TimerPeriod, ClampsOperationalTimerRateBounds)
 {
-  EXPECT_NO_THROW(require_operational_timer_rate(4.0, "heartbeat_rate", 1.0, 50.0));
-  EXPECT_NO_THROW(require_operational_timer_rate(100.0, "publish_rate", 10.0, 500.0));
-  EXPECT_NO_THROW(require_operational_timer_rate(2.0, "high_level_rate", 1.0, 20.0));
-  EXPECT_NO_THROW(require_operational_timer_rate(10.0, "dig_monitor_rate", 1.0, 50.0));
-  EXPECT_THROW(require_operational_timer_rate(0.99, "dig_monitor_rate", 1.0, 50.0),
-               std::invalid_argument);
-  EXPECT_THROW(require_operational_timer_rate(501.0, "publish_rate", 10.0, 500.0),
-               std::invalid_argument);
+  EXPECT_EQ(normalize_operational_timer_rate(4.0, kHeartbeatRateRange), 4.0);
+  EXPECT_EQ(normalize_operational_timer_rate(100.0, kPublishRateRange), 100.0);
+  EXPECT_EQ(normalize_operational_timer_rate(2.0, kHighLevelRateRange), 2.0);
+  EXPECT_EQ(normalize_operational_timer_rate(10.0, kDigMonitorRateRange), 10.0);
+  EXPECT_EQ(normalize_operational_timer_rate(5.0, kPublishRateRange),
+            kPublishRateRange.minimum_hz);
+  EXPECT_EQ(normalize_operational_timer_rate(501.0, kPublishRateRange),
+            kPublishRateRange.maximum_hz);
 }
 
 TEST(TimerPeriod, RejectsInvalidDivisorsAndTimeouts)
 {
-  EXPECT_NO_THROW(require_runtime_wheel_track(0.325));
-  EXPECT_THROW(require_runtime_wheel_track(0.0), std::invalid_argument);
-  EXPECT_THROW(require_runtime_wheel_track(-0.325), std::invalid_argument);
-  EXPECT_THROW(require_runtime_wheel_track(std::numeric_limits<double>::quiet_NaN()),
+  EXPECT_EQ(normalize_runtime_wheel_track(0.325), 0.325);
+  EXPECT_EQ(normalize_runtime_wheel_track(0.14), kMinRuntimeWheelTrackM);
+  EXPECT_EQ(normalize_runtime_wheel_track(0.61), kMaxRuntimeWheelTrackM);
+  EXPECT_THROW(normalize_runtime_wheel_track(std::numeric_limits<double>::quiet_NaN()),
                std::invalid_argument);
-  EXPECT_THROW(require_runtime_wheel_track(std::numeric_limits<double>::infinity()),
+  EXPECT_THROW(normalize_runtime_wheel_track(std::numeric_limits<double>::infinity()),
                std::invalid_argument);
-  EXPECT_THROW(require_runtime_wheel_track(kMinRuntimeWheelTrackM / 2.0), std::invalid_argument);
-  EXPECT_THROW(require_runtime_wheel_track(kMaxRuntimeWheelTrackM * 2.0), std::invalid_argument);
+
+  EXPECT_THROW(normalize_operational_timer_rate(0.0, kPublishRateRange), std::invalid_argument);
+  EXPECT_THROW(normalize_operational_timer_rate(-1.0, kPublishRateRange), std::invalid_argument);
+  EXPECT_THROW(normalize_operational_timer_rate(std::numeric_limits<double>::quiet_NaN(),
+                                                kPublishRateRange),
+               std::invalid_argument);
+  EXPECT_THROW(normalize_operational_timer_rate(std::numeric_limits<double>::infinity(),
+                                                kPublishRateRange),
+               std::invalid_argument);
 
   EXPECT_NO_THROW(require_finite_nonnegative_timeout(0.0, "serial_rx_timeout_s"));
   EXPECT_NO_THROW(require_finite_positive(1.0, "dig_pose_timeout_s"));

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -34,6 +34,9 @@ TEST(TimerPeriod, RejectsZeroNegativeAndNonFiniteRates)
 TEST(TimerPeriod, OneNanosecondPeriodIsTheFastestAcceptedCadence)
 {
   EXPECT_EQ(timer_period_from_rate_hz(1.0e9).count(), 1);
+  EXPECT_THROW(timer_period_from_rate_hz(std::nextafter(maximum_timer_rate_hz(),
+                                                        std::numeric_limits<double>::infinity())),
+               std::invalid_argument);
   EXPECT_THROW(timer_period_from_rate_hz(std::numeric_limits<double>::max()),
                std::invalid_argument);
 }

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -57,8 +57,7 @@ TEST(TimerPeriod, ClampsOperationalTimerRateBounds)
   EXPECT_EQ(normalize_operational_timer_rate(100.0, kPublishRateRange), 100.0);
   EXPECT_EQ(normalize_operational_timer_rate(2.0, kHighLevelRateRange), 2.0);
   EXPECT_EQ(normalize_operational_timer_rate(10.0, kDigMonitorRateRange), 10.0);
-  EXPECT_EQ(normalize_operational_timer_rate(5.0, kPublishRateRange),
-            kPublishRateRange.minimum_hz);
+  EXPECT_EQ(normalize_operational_timer_rate(5.0, kPublishRateRange), kPublishRateRange.minimum_hz);
   EXPECT_EQ(normalize_operational_timer_rate(501.0, kPublishRateRange),
             kPublishRateRange.maximum_hz);
 }

--- a/ros2/src/mowgli_hardware/test/test_timer_period.cpp
+++ b/ros2/src/mowgli_hardware/test/test_timer_period.cpp
@@ -51,6 +51,18 @@ TEST(TimerPeriod, HandlesRepresentablePeriodBoundaryWithoutOverflow)
   EXPECT_THROW(timer_period_from_rate_hz(std::nextafter(minimum, 0.0)), std::invalid_argument);
 }
 
+TEST(TimerPeriod, EnforcesOperationalTimerRateBounds)
+{
+  EXPECT_NO_THROW(require_operational_timer_rate(4.0, "heartbeat_rate", 1.0, 50.0));
+  EXPECT_NO_THROW(require_operational_timer_rate(100.0, "publish_rate", 10.0, 500.0));
+  EXPECT_NO_THROW(require_operational_timer_rate(2.0, "high_level_rate", 1.0, 20.0));
+  EXPECT_NO_THROW(require_operational_timer_rate(10.0, "dig_monitor_rate", 1.0, 50.0));
+  EXPECT_THROW(require_operational_timer_rate(0.99, "dig_monitor_rate", 1.0, 50.0),
+               std::invalid_argument);
+  EXPECT_THROW(require_operational_timer_rate(501.0, "publish_rate", 10.0, 500.0),
+               std::invalid_argument);
+}
+
 TEST(TimerPeriod, RejectsInvalidDivisorsAndTimeouts)
 {
   EXPECT_NO_THROW(require_runtime_wheel_track(0.325));


### PR DESCRIPTION
## Summary

- Harden startup-only hardware parameters. Timer rates and wheel track now remain read-only after declaration; runtime mutation is rejected because timers and kinematics are constructed only at startup.
- Timer cadence uses `std::chrono::nanoseconds`. Non-finite, non-positive, unrepresentable, and zero-duration timer rates are rejected. Finite, representable rates outside each task's preferred operating range are clamped at startup with a warning that states the parameter, requested value, and effective value. Defaults still yield 250 ms (heartbeat), 10 ms (publish), 500 ms (high-level), and 100 ms (dig monitor).
- `wheel_track` is finite-only and clamped to `[0.15, 0.60]` m, matching the STM32 firmware clamp. The effective value is used by both host odometry and the firmware configuration packet.
- `serial_rx_timeout_s = 0` deliberately disables its watchdog. Dig freshness/escape timeouts are explicitly finite and strictly positive; their descriptors do not claim a pseudo-operational `double::min()` floor.
- Publish real-firmware `BatteryState.percentage` as `NaN` while no verified state-of-charge source exists, and serialize that unknown value as JSON `null` in the session monitor. Voltage, current/charging state, packet layout, and status publishing are unchanged.

## Validation

- Added tests for representable timer boundaries/defaults, operational clamps, invalid rates, wheel-track clamp bounds, timeout contracts, battery unknown semantics, and actual ROS rejection of a runtime `publish_rate` update.
- Rebased onto current `dev` (`14e8ca26`).
- `git diff --check` and Python syntax checking pass locally. This Windows host lacks the ROS/clang-format toolchain and Docker's Linux engine, so the post-push GitHub Actions run is the authoritative build/test verification.