### PR TITLE
fix(safety): reject non-finite velocity commands end-to-end

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -61,6 +61,23 @@ jobs:
         run: pio run -e ${{ matrix.environment }}
         working-directory: firmware/stm32/ros_usbnode
 
+  test:
+    name: Firmware safety unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Run native firmware unit tests
+        run: pio test -e native
+        working-directory: firmware/stm32/ros_usbnode
+
   # ─── Publish prebuilt binaries on a version tag ────────────────────────────
   # Phase 1 of the precompiled-firmware plan. On a `v*.*.*` tag, build every
   # default permutation and attach the stamped, checksummed .bin/.elf plus a

--- a/firmware/stm32/ros_usbnode/platformio.ini
+++ b/firmware/stm32/ros_usbnode/platformio.ini
@@ -16,6 +16,12 @@ build_src_filter =
 	-<ros/ros_lib/**>
 	-<ros/ros_lib>
 
+[env:native]
+platform = native
+framework =
+test_build_src = false
+build_flags = -Isrc/ros/ros_custom
+
 [env:Yardforce500]
 board = genericSTM32F103VC
 platform_packages =

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cmd_vel_safety.hpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cmd_vel_safety.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace mowgli_cmd_vel
+{
+
+struct SafetyState
+{
+  float cmd_wz;
+  float left_target_mps;
+  float right_target_mps;
+  uint32_t last_valid_tick;
+};
+
+/// Accept only finite wire values; invalid input clears targets but preserves
+/// the last-valid timestamp so it cannot refresh the motion watchdog.
+inline bool apply_safety(float vx, float wz, uint32_t tick, SafetyState &state)
+{
+  if (!std::isfinite(vx) || !std::isfinite(wz)) {
+    state.cmd_wz = 0.0f;
+    state.left_target_mps = 0.0f;
+    state.right_target_mps = 0.0f;
+    return false;
+  }
+  state.cmd_wz = wz;
+  state.last_valid_tick = tick;
+  return true;
+}
+
+}  // namespace mowgli_cmd_vel

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -40,6 +40,7 @@
 // COBS protocol (replaces rosserial)
 #include "mowgli_comms.h"
 #include "mowgli_protocol.h"
+#include "cmd_vel_safety.hpp"
 
 // Math
 #include <cmath>
@@ -410,14 +411,28 @@ static void on_cmd_vel(const uint8_t *data, size_t len) {
 
   const pkt_cmd_vel_t *pkt = reinterpret_cast<const pkt_cmd_vel_t *>(data);
 
-  last_cmd_vel_tick = HAL_GetTick();
+  const float vx = pkt->linear_x;
+  const float wz = pkt->angular_z;
+
+  /* Firmware is the final safety authority.  Validate before refreshing the
+   * watchdog: NaN defeats ordinary >/< clamps, and an invalid packet must
+   * never preserve or refresh a motion target.  Clear all command state so a
+   * malformed packet deterministically stops the next motor cycle. */
+  mowgli_cmd_vel::SafetyState safety_state{
+      cmd_wz, left_target_mps, right_target_mps, last_cmd_vel_tick};
+  if (!mowgli_cmd_vel::apply_safety(vx, wz, HAL_GetTick(), safety_state)) {
+    cmd_wz = safety_state.cmd_wz;
+    left_target_mps = safety_state.left_target_mps;
+    right_target_mps = safety_state.right_target_mps;
+    return;
+  }
+
+  /* Only a validated command is a new cmd_vel heartbeat. */
+  last_cmd_vel_tick = safety_state.last_valid_tick;
 
   if (main_eOpenmowerStatus == OPENMOWER_STATUS_IDLE) {
     return;
   }
-
-  const float vx = pkt->linear_x;
-  const float wz = pkt->angular_z;
 
   /* Commanded yaw rate for the firmware yaw-rate loop (Option C), read in the
    * motor timebase by motors_handler. Stored raw (pre-IK) so the loop tracks

--- a/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
+++ b/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
@@ -1,4 +1,3 @@
-#include <cmath>
 #include <limits>
 
 #include <unity.h>
@@ -13,11 +12,14 @@ static void test_finite_and_zero_are_accepted()
   SafetyState state{3.0f, 1.0f, -1.0f, 10u};
   TEST_ASSERT_TRUE(apply_safety(0.25f, -0.8f, 20u, state));
   TEST_ASSERT_FLOAT_WITHIN(0.0f, -0.8f, state.cmd_wz);
-  TEST_ASSERT_TRUE(std::isfinite(state.left_target_mps));
-  TEST_ASSERT_TRUE(std::isfinite(state.right_target_mps));
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, 1.0f, state.left_target_mps);
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, -1.0f, state.right_target_mps);
   TEST_ASSERT_EQUAL_UINT32(20u, state.last_valid_tick);
   TEST_ASSERT_TRUE(apply_safety(0.0f, 0.0f, 30u, state));
   TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.cmd_wz);
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, 1.0f, state.left_target_mps);
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, -1.0f, state.right_target_mps);
+  TEST_ASSERT_EQUAL_UINT32(30u, state.last_valid_tick);
 }
 
 static void test_nonfinite_commands_clear_targets_without_refresh()

--- a/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
+++ b/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
@@ -1,0 +1,75 @@
+#include <cmath>
+#include <limits>
+
+#include <unity.h>
+
+#include "cmd_vel_safety.hpp"
+
+using mowgli_cmd_vel::SafetyState;
+using mowgli_cmd_vel::apply_safety;
+
+static void test_finite_and_zero_are_accepted()
+{
+  SafetyState state{3.0f, 1.0f, -1.0f, 10u};
+  TEST_ASSERT_TRUE(apply_safety(0.25f, -0.8f, 20u, state));
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, -0.8f, state.cmd_wz);
+  TEST_ASSERT_TRUE(std::isfinite(state.left_target_mps));
+  TEST_ASSERT_TRUE(std::isfinite(state.right_target_mps));
+  TEST_ASSERT_EQUAL_UINT32(20u, state.last_valid_tick);
+  TEST_ASSERT_TRUE(apply_safety(0.0f, 0.0f, 30u, state));
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.cmd_wz);
+}
+
+static void test_nonfinite_commands_clear_targets_without_refresh()
+{
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+  const float inf = std::numeric_limits<float>::infinity();
+  const float values[] = {nan, inf, -inf};
+  for (float vx : values) {
+    SafetyState state{0.7f, 0.4f, -0.4f, 77u};
+    TEST_ASSERT_FALSE(apply_safety(vx, 0.0f, 99u, state));
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.cmd_wz);
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.left_target_mps);
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.right_target_mps);
+    TEST_ASSERT_EQUAL_UINT32(77u, state.last_valid_tick);
+  }
+  for (float wz : values) {
+    SafetyState state{0.7f, 0.4f, -0.4f, 77u};
+    TEST_ASSERT_FALSE(apply_safety(0.0f, wz, 99u, state));
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.cmd_wz);
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.left_target_mps);
+    TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.right_target_mps);
+    TEST_ASSERT_EQUAL_UINT32(77u, state.last_valid_tick);
+  }
+  for (float vx : values) {
+    for (float wz : values) {
+      SafetyState state{0.7f, 0.4f, -0.4f, 77u};
+      TEST_ASSERT_FALSE(apply_safety(vx, wz, 99u, state));
+      TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.cmd_wz);
+      TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.left_target_mps);
+      TEST_ASSERT_FLOAT_WITHIN(0.0f, 0.0f, state.right_target_mps);
+      TEST_ASSERT_EQUAL_UINT32(77u, state.last_valid_tick);
+    }
+  }
+}
+
+static void test_valid_command_after_invalid_is_normal()
+{
+  SafetyState state{0.0f, 0.0f, 0.0f, 11u};
+  TEST_ASSERT_FALSE(apply_safety(
+      std::numeric_limits<float>::quiet_NaN(), 0.0f, 12u, state));
+  TEST_ASSERT_TRUE(apply_safety(0.3f, -0.2f, 13u, state));
+  TEST_ASSERT_FLOAT_WITHIN(0.0f, -0.2f, state.cmd_wz);
+  TEST_ASSERT_EQUAL_UINT32(13u, state.last_valid_tick);
+}
+
+void setup()
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_finite_and_zero_are_accepted);
+  RUN_TEST(test_nonfinite_commands_clear_targets_without_refresh);
+  RUN_TEST(test_valid_command_after_invalid_is_normal);
+  UNITY_END();
+}
+
+void loop() {}

--- a/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
+++ b/firmware/stm32/ros_usbnode/test/test_cmd_vel_safety.cpp
@@ -63,13 +63,11 @@ static void test_valid_command_after_invalid_is_normal()
   TEST_ASSERT_EQUAL_UINT32(13u, state.last_valid_tick);
 }
 
-void setup()
+int main()
 {
   UNITY_BEGIN();
   RUN_TEST(test_finite_and_zero_are_accepted);
   RUN_TEST(test_nonfinite_commands_clear_targets_without_refresh);
   RUN_TEST(test_valid_command_after_invalid_is_normal);
-  UNITY_END();
+  return UNITY_END();
 }
-
-void loop() {}

--- a/ros2/src/mowgli_hardware/CMakeLists.txt
+++ b/ros2/src/mowgli_hardware/CMakeLists.txt
@@ -206,6 +206,15 @@ if(BUILD_TESTING)
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../firmware/stm32/ros_usbnode/include
   )
+
+  # ---- test_cmd_vel_validation ----
+  ament_add_gtest(test_cmd_vel_validation
+    test/test_cmd_vel_validation.cpp
+  )
+  target_include_directories(test_cmd_vel_validation
+    PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  )
 endif()
 
 # ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/cmd_vel_validation.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/cmd_vel_validation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 
 namespace mowgli_hardware
 {
@@ -10,6 +11,17 @@ namespace mowgli_hardware
 inline bool is_finite_velocity_command(double linear_x, double angular_z)
 {
   return std::isfinite(linear_x) && std::isfinite(angular_z);
+}
+
+/// A velocity command can be narrowed to the float32 wire format only when
+/// both finite double values are within float32's finite range.  This check
+/// must happen before the floating-point conversion.
+inline bool is_float32_representable_velocity_command(double linear_x, double angular_z)
+{
+  constexpr double kMaxFiniteFloat = static_cast<double>(std::numeric_limits<float>::max());
+  return is_finite_velocity_command(linear_x, angular_z) && linear_x >= -kMaxFiniteFloat &&
+         linear_x <= kMaxFiniteFloat && angular_z >= -kMaxFiniteFloat &&
+         angular_z <= kMaxFiniteFloat;
 }
 
 }  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/cmd_vel_validation.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/cmd_vel_validation.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cmath>
+
+namespace mowgli_hardware
+{
+
+/// A velocity command is usable only when both values are IEEE-754 finite.
+/// In particular, comparisons against limits do not reject NaN.
+inline bool is_finite_velocity_command(double linear_x, double angular_z)
+{
+  return std::isfinite(linear_x) && std::isfinite(angular_z);
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -3106,20 +3106,25 @@ private:
   void send_cmd_vel_packet(double vx, double wz)
   {
     // Keep this final construction boundary defensive as well: callers such
-    // as the bounded dig escape pass doubles, and a value that is finite as a
-    // double can become Inf when narrowed to the wire's float32 format.
-    const float wire_vx = static_cast<float>(vx);
-    const float wire_wz = static_cast<float>(wz);
-    if (!mowgli_hardware::is_finite_velocity_command(wire_vx, wire_wz))
+    // as the bounded dig escape pass doubles.  Check float32 representability
+    // before narrowing: converting an out-of-range double is not a safe way
+    // to detect wire overflow.
+    if (!mowgli_hardware::is_float32_representable_velocity_command(vx, wz))
     {
       RCLCPP_WARN_THROTTLE(get_logger(),
                            *get_clock(),
                            5000,
-                           "Refusing non-finite LlCmdVel wire values (linear.x=%f, angular.z=%f).",
+                           "Refusing non-finite or out-of-range LlCmdVel values "
+                           "(linear.x=%f, angular.z=%f).",
                            vx,
                            wz);
       return;
     }
+
+    // The pre-check establishes that both conversions are within float32's
+    // finite range.
+    const float wire_vx = static_cast<float>(vx);
+    const float wire_wz = static_cast<float>(wz);
 
     LlCmdVel pkt{};
     pkt.type = PACKET_ID_LL_CMD_VEL;

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -61,8 +61,8 @@
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "mowgli_hardware/blade_gate.hpp"
-#include "mowgli_hardware/cmd_vel_validation.hpp"
 #include "mowgli_hardware/clock_fit.hpp"
+#include "mowgli_hardware/cmd_vel_validation.hpp"
 #include "mowgli_hardware/dig_detector.hpp"
 #include "mowgli_hardware/dig_escalation.hpp"
 #include "mowgli_hardware/gnss_hardware_status.hpp"
@@ -2725,9 +2725,12 @@ private:
     if (!mowgli_hardware::is_finite_velocity_command(vx, wz))
     {
       RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 5000,
-        "Rejecting non-finite cmd_vel (linear.x=%f, angular.z=%f); command discarded.",
-        vx, wz);
+          get_logger(),
+          *get_clock(),
+          5000,
+          "Rejecting non-finite cmd_vel (linear.x=%f, angular.z=%f); command discarded.",
+          vx,
+          wz);
       return;
     }
 
@@ -3109,10 +3112,12 @@ private:
     const float wire_wz = static_cast<float>(wz);
     if (!mowgli_hardware::is_finite_velocity_command(wire_vx, wire_wz))
     {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 5000,
-        "Refusing non-finite LlCmdVel wire values (linear.x=%f, angular.z=%f).",
-        vx, wz);
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "Refusing non-finite LlCmdVel wire values (linear.x=%f, angular.z=%f).",
+                           vx,
+                           wz);
       return;
     }
 

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -61,6 +61,7 @@
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "mowgli_hardware/blade_gate.hpp"
+#include "mowgli_hardware/cmd_vel_validation.hpp"
 #include "mowgli_hardware/clock_fit.hpp"
 #include "mowgli_hardware/dig_detector.hpp"
 #include "mowgli_hardware/dig_escalation.hpp"
@@ -2716,6 +2717,20 @@ private:
     double vx = msg->twist.linear.x;
     double wz = msg->twist.angular.z;
 
+    // Reject non-finite input before any shaping, mode inference, or state
+    // bookkeeping.  Discarding it lets the firmware's existing 200 ms
+    // cmd_vel watchdog deterministically stop the mower without refreshing
+    // the valid-command heartbeat.  The warning is throttled because this
+    // callback runs at command rate.
+    if (!mowgli_hardware::is_finite_velocity_command(vx, wz))
+    {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "Rejecting non-finite cmd_vel (linear.x=%f, angular.z=%f); command discarded.",
+        vx, wz);
+      return;
+    }
+
     // The firmware ignores cmd_vel when mode is IDLE.  When velocity commands
     // arrive before the BT publishes any high-level state, ensure the firmware
     // is not left in NULL/transition mode.
@@ -3087,10 +3102,24 @@ private:
   /// Single point where a velocity command reaches the firmware.
   void send_cmd_vel_packet(double vx, double wz)
   {
+    // Keep this final construction boundary defensive as well: callers such
+    // as the bounded dig escape pass doubles, and a value that is finite as a
+    // double can become Inf when narrowed to the wire's float32 format.
+    const float wire_vx = static_cast<float>(vx);
+    const float wire_wz = static_cast<float>(wz);
+    if (!mowgli_hardware::is_finite_velocity_command(wire_vx, wire_wz))
+    {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "Refusing non-finite LlCmdVel wire values (linear.x=%f, angular.z=%f).",
+        vx, wz);
+      return;
+    }
+
     LlCmdVel pkt{};
     pkt.type = PACKET_ID_LL_CMD_VEL;
-    pkt.linear_x = static_cast<float>(vx);
-    pkt.angular_z = static_cast<float>(wz);
+    pkt.linear_x = wire_vx;
+    pkt.angular_z = wire_wz;
 
     send_raw_packet(reinterpret_cast<const uint8_t*>(&pkt), sizeof(LlCmdVel) - sizeof(uint16_t));
   }

--- a/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
+++ b/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
@@ -10,6 +10,8 @@ TEST(CmdVelValidation, AcceptsFiniteCommands)
 {
   EXPECT_TRUE(is_finite_velocity_command(0.25, -0.8));
   EXPECT_TRUE(is_finite_velocity_command(0.0, 0.0));
+  EXPECT_TRUE(is_finite_velocity_command(-0.0, 0.0));
+  EXPECT_TRUE(is_finite_velocity_command(0.0, -0.0));
 }
 
 TEST(CmdVelValidation, RejectsNonFiniteLinearVelocity)
@@ -34,7 +36,14 @@ TEST(CmdVelValidation, RejectsBothNonFinite)
 
 TEST(CmdVelValidation, RejectsValuesNonFiniteAfterFloatWireConversion)
 {
-  const double too_large_for_float = std::numeric_limits<float>::max() * 2.0;
-  EXPECT_FALSE(is_finite_velocity_command(static_cast<float>(too_large_for_float), 0.0f));
-  EXPECT_FALSE(is_finite_velocity_command(0.0f, static_cast<float>(-too_large_for_float)));
+  const double positive_overflow = std::numeric_limits<double>::max();
+  const double negative_overflow = -std::numeric_limits<double>::max();
+  EXPECT_FALSE(is_finite_velocity_command(static_cast<float>(positive_overflow), 0.0f));
+  EXPECT_FALSE(is_finite_velocity_command(0.0f, static_cast<float>(negative_overflow)));
+}
+
+TEST(CmdVelValidation, AcceptsMaximumFiniteFloatWireValue)
+{
+  const float largest_finite_float = std::numeric_limits<float>::max();
+  EXPECT_TRUE(is_finite_velocity_command(largest_finite_float, -largest_finite_float));
 }

--- a/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
+++ b/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
@@ -1,0 +1,41 @@
+#include <cmath>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "mowgli_hardware/cmd_vel_validation.hpp"
+
+using mowgli_hardware::is_finite_velocity_command;
+
+TEST(CmdVelValidation, AcceptsFiniteCommands)
+{
+  EXPECT_TRUE(is_finite_velocity_command(0.25, -0.8));
+  EXPECT_TRUE(is_finite_velocity_command(0.0, 0.0));
+}
+
+TEST(CmdVelValidation, RejectsNonFiniteLinearVelocity)
+{
+  EXPECT_FALSE(is_finite_velocity_command(std::numeric_limits<double>::quiet_NaN(), 0.0));
+  EXPECT_FALSE(is_finite_velocity_command(std::numeric_limits<double>::infinity(), 0.0));
+  EXPECT_FALSE(is_finite_velocity_command(-std::numeric_limits<double>::infinity(), 0.0));
+}
+
+TEST(CmdVelValidation, RejectsNonFiniteAngularVelocity)
+{
+  EXPECT_FALSE(is_finite_velocity_command(0.0, std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_FALSE(is_finite_velocity_command(0.0, std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(is_finite_velocity_command(0.0, -std::numeric_limits<double>::infinity()));
+}
+
+TEST(CmdVelValidation, RejectsBothNonFinite)
+{
+  EXPECT_FALSE(is_finite_velocity_command(
+    std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity()));
+}
+
+TEST(CmdVelValidation, RejectsValuesNonFiniteAfterFloatWireConversion)
+{
+  const double too_large_for_float = std::numeric_limits<float>::max() * 2.0;
+  EXPECT_FALSE(is_finite_velocity_command(static_cast<float>(too_large_for_float), 0.0f));
+  EXPECT_FALSE(is_finite_velocity_command(0.0f, static_cast<float>(-too_large_for_float)));
+}

--- a/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
+++ b/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 using mowgli_hardware::is_finite_velocity_command;
+using mowgli_hardware::is_float32_representable_velocity_command;
 
 TEST(CmdVelValidation, AcceptsFiniteCommands)
 {
@@ -34,16 +35,31 @@ TEST(CmdVelValidation, RejectsBothNonFinite)
                                           std::numeric_limits<double>::infinity()));
 }
 
-TEST(CmdVelValidation, RejectsValuesNonFiniteAfterFloatWireConversion)
+TEST(CmdVelValidation, RejectsValuesOutsideFloatWireRangeBeforeNarrowing)
 {
-  const double positive_overflow = std::numeric_limits<double>::max();
-  const double negative_overflow = -std::numeric_limits<double>::max();
-  EXPECT_FALSE(is_finite_velocity_command(static_cast<float>(positive_overflow), 0.0f));
-  EXPECT_FALSE(is_finite_velocity_command(0.0f, static_cast<float>(negative_overflow)));
+  const double max_wire_float = static_cast<double>(std::numeric_limits<float>::max());
+  const double above_max_wire_float =
+      std::nextafter(max_wire_float, std::numeric_limits<double>::infinity());
+  const double below_min_wire_float =
+      std::nextafter(-max_wire_float, -std::numeric_limits<double>::infinity());
+
+  EXPECT_FALSE(is_float32_representable_velocity_command(std::numeric_limits<double>::max(), 0.0));
+  EXPECT_FALSE(is_float32_representable_velocity_command(-std::numeric_limits<double>::max(), 0.0));
+  EXPECT_FALSE(is_float32_representable_velocity_command(above_max_wire_float, 0.0));
+  EXPECT_FALSE(is_float32_representable_velocity_command(0.0, below_min_wire_float));
 }
 
 TEST(CmdVelValidation, AcceptsMaximumFiniteFloatWireValue)
 {
-  const float largest_finite_float = std::numeric_limits<float>::max();
-  EXPECT_TRUE(is_finite_velocity_command(largest_finite_float, -largest_finite_float));
+  const double max_wire_float = static_cast<double>(std::numeric_limits<float>::max());
+  EXPECT_TRUE(is_float32_representable_velocity_command(max_wire_float, -max_wire_float));
+  EXPECT_TRUE(is_float32_representable_velocity_command(0.0, -0.0));
+}
+
+TEST(CmdVelValidation, RejectsNonFiniteFloatWireValues)
+{
+  EXPECT_FALSE(is_float32_representable_velocity_command(
+      std::numeric_limits<double>::quiet_NaN(), 0.0));
+  EXPECT_FALSE(is_float32_representable_velocity_command(
+      0.0, std::numeric_limits<double>::infinity()));
 }

--- a/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
+++ b/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
@@ -58,8 +58,8 @@ TEST(CmdVelValidation, AcceptsMaximumFiniteFloatWireValue)
 
 TEST(CmdVelValidation, RejectsNonFiniteFloatWireValues)
 {
-  EXPECT_FALSE(is_float32_representable_velocity_command(
-      std::numeric_limits<double>::quiet_NaN(), 0.0));
-  EXPECT_FALSE(is_float32_representable_velocity_command(
-      0.0, std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(
+      is_float32_representable_velocity_command(std::numeric_limits<double>::quiet_NaN(), 0.0));
+  EXPECT_FALSE(
+      is_float32_representable_velocity_command(0.0, std::numeric_limits<double>::infinity()));
 }

--- a/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
+++ b/ros2/src/mowgli_hardware/test/test_cmd_vel_validation.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
 #include <limits>
 
-#include <gtest/gtest.h>
-
 #include "mowgli_hardware/cmd_vel_validation.hpp"
+#include <gtest/gtest.h>
 
 using mowgli_hardware::is_finite_velocity_command;
 
@@ -29,8 +28,8 @@ TEST(CmdVelValidation, RejectsNonFiniteAngularVelocity)
 
 TEST(CmdVelValidation, RejectsBothNonFinite)
 {
-  EXPECT_FALSE(is_finite_velocity_command(
-    std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(is_finite_velocity_command(std::numeric_limits<double>::quiet_NaN(),
+                                          std::numeric_limits<double>::infinity()));
 }
 
 TEST(CmdVelValidation, RejectsValuesNonFiniteAfterFloatWireConversion)


### PR DESCRIPTION
## Summary

Reject non-finite `cmd_vel` values (`NaN`, `+Inf`, `-Inf`) at both safety boundaries without changing finite-command shaping, PID gains, velocity limits, teleop cadence, twist_mux, or blade/e-stop behaviour.

## Root cause

`hardware_bridge_node` previously forwarded `linear.x` and `angular.z` to the float32 `LlCmdVel` packet without a finite check. STM32 refreshed `last_cmd_vel_tick` before validating either field and then relied on ordinary `>`/`<` clamps. `NaN` compares false to both bounds, so those clamps cannot catch it; a value could contaminate `cmd_wz` and wheel targets while an invalid packet refreshed the watchdog.

## Safety contract (before / after)

Before, a non-finite host message or valid-CRC raw wire packet could enter the motion path. After:

- The ROS2 callback rejects non-finite commands before mode inference, shaping, or host-state bookkeeping. It throttles diagnostics and discards the packet; it does **not** send a synthetic zero, because that would refresh the firmware's valid-command watchdog.
- The final `LlCmdVel` construction boundary independently requires finite `double` inputs within the finite float32 range **before** narrowing. Thus the `double → float` cast only occurs after representability is established; this avoids relying on an out-of-range floating conversion to produce `Inf`.
- Firmware independently validates both wire fields before touching `last_cmd_vel_tick`. Invalid packets zero yaw and both wheel targets, preserve the last valid timestamp, and return before inverse kinematics. A following finite command is accepted normally.

This is defense in depth: ROS2 protects the normal publisher path and host state; firmware remains the final authority for malformed/direct wire traffic and future host regressions. The wire layout and protocol version are unchanged.

## Motion-path review

All production `LlCmdVel` construction sites were searched; the bridge packet boundary is the sole constructor. Firmware's receive handler is separately guarded. Invalid direct-wire input clears targets before the next motor-control snapshot; the established wheel PI/yaw zero-command behavior performs bounded closed-loop deceleration/reset handling, with no stale command retained. No `-ffast-math` or `-ffinite-math-only` production flag is present.

## Tests

- ROS2 gtest covers finite commands, `+0`/`-0`, zero, NaN, `+Inf`, and `-Inf` for each axis; both axes non-finite; `DBL_MAX`/`-DBL_MAX`; exact `+/-FLT_MAX`; and the immediately out-of-range `std::nextafter` values. Rejected values are never cast to float.
- Firmware-native Unity test covers all NaN/+Inf/-Inf axis combinations, immediate target clearing, no watchdog timestamp refresh, zero, preservation of existing wheel targets on the helper's valid path, and valid-after-invalid behavior.
- Firmware CI runs the native test on Linux plus Yardforce500 and Yardforce500B builds.
- The complete ROS2 CI runs formatting, cppcheck, config drift, workspace build, `colcon test`, and the external GNSS launch contract.

No physical mower is needed to verify this logic. Physical actuation and watchdog timing remain separate hardware-level validation before field deployment.

## Remaining risk

Host-discarded invalid input relies on the established 200 ms firmware watchdog; direct-wire invalid input also zeros targets immediately. This PR remains Draft until the full CI result for the final commit is green.