### PR TITLE
fix(gui): IrriSense saves via the page Save button; dashboard warns when the garden is wet

### DIFF
--- a/gui/web/src/components/dashboard/SoilWetBanner.test.tsx
+++ b/gui/web/src/components/dashboard/SoilWetBanner.test.tsx
@@ -1,0 +1,41 @@
+import {describe, expect, it, vi} from "vitest";
+import {render, screen} from "@testing-library/react";
+import {SoilWetBanner} from "./SoilWetBanner.tsx";
+import type {SoilStatus} from "../../types/irrisense.ts";
+
+const requestMock = vi.fn();
+vi.mock("../../hooks/useApi.ts", () => ({
+    useApi: () => ({request: requestMock}),
+}));
+
+function status(overrides: Partial<SoilStatus>): SoilStatus {
+    return {
+        enabled: true, configured: true, gateScheduler: true,
+        fresh: true, wet: false, unknown: false, reason: "", zones: [],
+        ...overrides,
+    };
+}
+
+describe("SoilWetBanner", () => {
+    it("warns with the reason and the scheduler suspension when the garden is wet", () => {
+        render(<SoilWetBanner status={status({wet: true, reason: "zone Lawn: deficit 0.8 mm"})}/>);
+        const banner = screen.getByTestId("soil-wet-banner");
+        expect(banner).toHaveTextContent(/garden is wet/i);
+        expect(banner).toHaveTextContent("zone Lawn: deficit 0.8 mm");
+        expect(banner).toHaveTextContent(/scheduled mows are suspended/i);
+    });
+
+    it("does not mention the scheduler when the gate is off", () => {
+        render(<SoilWetBanner status={status({wet: true, gateScheduler: false})}/>);
+        expect(screen.getByTestId("soil-wet-banner")).not.toHaveTextContent(/suspended/i);
+    });
+
+    it("renders nothing when dry, unknown, or disabled", () => {
+        const {rerender} = render(<SoilWetBanner status={status({wet: false})}/>);
+        expect(screen.queryByTestId("soil-wet-banner")).not.toBeInTheDocument();
+        rerender(<SoilWetBanner status={status({wet: true, unknown: true, fresh: false})}/>);
+        expect(screen.queryByTestId("soil-wet-banner")).not.toBeInTheDocument();
+        rerender(<SoilWetBanner status={status({wet: true, enabled: false})}/>);
+        expect(screen.queryByTestId("soil-wet-banner")).not.toBeInTheDocument();
+    });
+});

--- a/gui/web/src/components/dashboard/SoilWetBanner.tsx
+++ b/gui/web/src/components/dashboard/SoilWetBanner.tsx
@@ -1,0 +1,51 @@
+import {motion, type Variants} from "framer-motion";
+import {Droplets} from "lucide-react";
+import {useTranslation} from "react-i18next";
+import {useSoilStatus} from "../../hooks/useSoilStatus.ts";
+import {soilVerdict, type SoilStatus} from "../../types/irrisense.ts";
+
+interface SoilWetBannerProps {
+    /** Injected for tests; the dashboard lets the hook fetch it. */
+    status?: SoilStatus | null;
+    variants?: Variants;
+}
+
+/**
+ * Dashboard warning shown while IrriSense Cloud reports the garden as WET.
+ * Renders nothing when the integration is off, the verdict is dry, or the
+ * status is unknown (fail-open: an outage must not look like a warning).
+ */
+export function SoilWetBanner({status: injected, variants}: SoilWetBannerProps) {
+    const {t} = useTranslation();
+    const polled = useSoilStatus({enabled: injected === undefined});
+    const status = injected === undefined ? polled.status : injected;
+    if (!status || !status.enabled || soilVerdict(status) !== "wet") return null;
+    const details = [
+        status.reason,
+        status.gateScheduler ? t("mowgliNextPage.soilWetBlocking") : null,
+    ].filter(Boolean).join(" · ");
+    return (
+        <motion.div
+            variants={variants}
+            role="status"
+            data-testid="soil-wet-banner"
+            style={{
+                display: "flex", alignItems: "center", gap: 12,
+                padding: "12px 16px", marginBottom: 14, borderRadius: 14,
+                background: "rgba(96,176,255,0.10)",
+                border: "1px solid rgba(96,176,255,0.35)",
+                boxShadow: "0 0 18px rgba(96,176,255,0.12)",
+            }}
+        >
+            <Droplets size={18} style={{color: "var(--sky, #60B0FF)", flexShrink: 0}}/>
+            <div style={{minWidth: 0}}>
+                <div style={{fontSize: 13, fontWeight: 600, color: "var(--ink, #ECFFF4)"}}>
+                    {t("mowgliNextPage.soilWetTitle")}
+                </div>
+                {details && (
+                    <div style={{fontSize: 11, color: "rgba(236,255,244,0.6)"}}>{details}</div>
+                )}
+            </div>
+        </motion.div>
+    );
+}

--- a/gui/web/src/components/settings/IrriSenseSection.test.tsx
+++ b/gui/web/src/components/settings/IrriSenseSection.test.tsx
@@ -1,8 +1,9 @@
 import {App} from "antd";
-import {render, screen, waitFor} from "@testing-library/react";
+import {act, render, screen, waitFor} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {IrriSenseSection} from "./IrriSenseSection.tsx";
+import type {ExternalSaver} from "../../hooks/useSettingsManager.ts";
 import type {IrriSenseSettings, SoilStatus} from "../../types/irrisense.ts";
 
 const requestMock = vi.fn();
@@ -59,10 +60,20 @@ const putCalls = () => requestMock.mock.calls
     .map(([req]) => req as Req)
     .filter((req) => req.path === "/irrisense/settings" && req.method === "PUT");
 
+// The section has no Save button of its own: it registers with the settings
+// page (useSettingsManager) and the page's single Save button calls it.
+let savers: Record<string, ExternalSaver> = {};
+const registerSaver = (id: string, saver: ExternalSaver) => { savers[id] = saver; };
+const unregisterSaver = (id: string) => { delete savers[id]; };
+async function saveViaPage() {
+    await act(async () => { await savers["irrisense"].save(); });
+}
+
 function renderSection() {
+    savers = {};
     return render(
         <App>
-            <IrriSenseSection/>
+            <IrriSenseSection registerSaver={registerSaver} unregisterSaver={unregisterSaver}/>
         </App>,
     );
 }
@@ -79,7 +90,8 @@ describe("IrriSenseSection", () => {
         const toggle = await screen.findByRole("switch", {name: /IrriSense Cloud soil moisture/i});
         expect(toggle).not.toBeChecked();
         expect(screen.queryByLabelText(/Read-only API token/i)).not.toBeInTheDocument();
-        expect(screen.getByRole("button", {name: /Save IrriSense settings/i})).toBeDisabled();
+        expect(screen.queryByRole("button", {name: /Save IrriSense settings/i})).not.toBeInTheDocument();
+        expect(savers["irrisense"]?.dirtyCount ?? 0).toBe(0);
     });
 
     it("stores a pasted token on save without ever echoing it", async () => {
@@ -92,7 +104,7 @@ describe("IrriSenseSection", () => {
         await user.click(screen.getByRole("button", {name: /^Set$/i}));
         expect(screen.getByTestId("irrisense-token-state")).toHaveTextContent(/stored on save/i);
 
-        await user.click(screen.getByRole("button", {name: /Save IrriSense settings/i}));
+        await saveViaPage();
 
         await waitFor(() => expect(putCalls()).toHaveLength(1));
         expect(putCalls()[0].body).toMatchObject({enabled: true, token: "irs_secret_token_123"});
@@ -108,7 +120,7 @@ describe("IrriSenseSection", () => {
 
         expect(await screen.findByTestId("irrisense-token-state")).toHaveTextContent("irs_••••••••");
         await user.click(screen.getByRole("button", {name: /^Clear$/i}));
-        await user.click(screen.getByRole("button", {name: /Save IrriSense settings/i}));
+        await saveViaPage();
 
         await waitFor(() => expect(putCalls()).toHaveLength(1));
         expect(putCalls()[0].body).toMatchObject({clearToken: true});

--- a/gui/web/src/components/settings/IrriSenseSection.tsx
+++ b/gui/web/src/components/settings/IrriSenseSection.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from "react";
-import {Alert, App, Button, Card, Spin, Switch, Typography} from "antd";
-import {CloudSyncOutlined, SaveOutlined} from "@ant-design/icons";
+import {Alert, App, Card, Spin, Switch, Typography} from "antd";
+import {CloudSyncOutlined} from "@ant-design/icons";
 import {useTranslation} from "react-i18next";
 import {useApi} from "../../hooks/useApi.ts";
 import {useSoilStatus} from "../../hooks/useSoilStatus.ts";
@@ -13,6 +13,15 @@ import {
 import {IrriSenseConnectionCard} from "./IrriSenseConnectionCard.tsx";
 import {IrriSenseRuleCard} from "./IrriSenseRuleCard.tsx";
 import {IrriSenseStatusLine} from "./IrriSenseStatusLine.tsx";
+import type {ExternalSaver} from "../../hooks/useSettingsManager.ts";
+
+const SAVER_ID = "irrisense";
+
+export interface IrriSenseSectionProps {
+    /** Hook into the settings page's single Save / Revert buttons. */
+    registerSaver?: (id: string, saver: ExternalSaver) => void;
+    unregisterSaver?: (id: string) => void;
+}
 
 const {Text, Paragraph} = Typography;
 
@@ -22,10 +31,11 @@ const STATUS_REFRESH_AFTER_SAVE_MS = 1500;
 /**
  * IrriSense Cloud soil-moisture integration. Unlike the yaml-backed sections
  * this one owns its own load/save: the settings (token included) live in the
- * GUI's key-value DB, never in mowgli_robot.yaml, so it does not go through
- * useSettingsManager.
+ * GUI's key-value DB, never in mowgli_robot.yaml — but it registers itself
+ * with useSettingsManager as an external saver so the page's ONE Save button
+ * (and Revert) covers it; there is no section-local Save button.
  */
-export function IrriSenseSection() {
+export function IrriSenseSection({registerSaver, unregisterSaver}: IrriSenseSectionProps = {}) {
     const {t} = useTranslation();
     const guiApi = useApi();
     const {notification} = App.useApp();
@@ -33,7 +43,6 @@ export function IrriSenseSection() {
     const [draft, setDraft] = useState<IrriSenseSettingsUpdate>({});
     const [gardens, setGardens] = useState<IrriSenseGardenSummary[]>([]);
     const [loadError, setLoadError] = useState<string | null>(null);
-    const [saving, setSaving] = useState(false);
     const [testing, setTesting] = useState(false);
     const {status, refresh: refreshStatus} = useSoilStatus();
 
@@ -56,7 +65,6 @@ export function IrriSenseSection() {
 
     const save = useCallback(async (): Promise<boolean> => {
         if (!isDirty) return true;
-        setSaving(true);
         try {
             const res = await guiApi.request<IrriSenseSettings>({
                 path: "/irrisense/settings", method: "PUT", body: draft, format: "json",
@@ -69,10 +77,18 @@ export function IrriSenseSection() {
         } catch (e: unknown) {
             notification.error({message: t("settingsIrriSense.saveFailed"), description: apiErrorMessage(e)});
             return false;
-        } finally {
-            setSaving(false);
         }
     }, [draft, guiApi, isDirty, notification, refreshStatus, t]);
+
+    // Keep the page-level Save button informed of our pending edits.
+    useEffect(() => {
+        registerSaver?.(SAVER_ID, {
+            dirtyCount: Object.keys(draft).length,
+            save,
+            revert: () => setDraft({}),
+        });
+    }, [draft, registerSaver, save]);
+    useEffect(() => () => unregisterSaver?.(SAVER_ID), [unregisterSaver]);
 
     const testConnection = useCallback(async () => {
         setTesting(true);
@@ -149,15 +165,6 @@ export function IrriSenseSection() {
                 </>
             )}
 
-            <Button
-                type="primary"
-                icon={<SaveOutlined/>}
-                onClick={() => void save()}
-                loading={saving}
-                disabled={!isDirty || saving}
-            >
-                {t("settingsIrriSense.save")}
-            </Button>
         </div>
     );
 }

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -8,6 +8,16 @@ import { getQuaternionFromHeading } from "../utils/map.tsx";
 import { ContentType } from "../api/Api.ts";
 import { valuesMatch } from "../utils/settingsValues.ts";
 
+/** A section that saves outside mowgli_robot.yaml but wants the page's Save button. */
+export interface ExternalSaver {
+    /** Number of pending edits (0 = clean). Feeds the Save button count. */
+    dirtyCount: number;
+    /** Persist; resolve true on success, false after showing its own error. */
+    save: () => Promise<boolean>;
+    /** Drop pending edits (page-level Revert). */
+    revert?: () => void;
+}
+
 export type SettingsSection =
     | "appearance"
     | "hardware"
@@ -359,12 +369,39 @@ export const useSettingsManager = () => {
         return dirty;
     }, [localValues, savedValues]);
 
-    const isDirty = dirtyKeys.size > 0;
+    // External savers: sections whose settings do not live in mowgli_robot.yaml
+    // (IrriSense keeps its token in the GUI DB) register here so the page's
+    // ONE Save button covers them too. Refs hold the callbacks (no stale
+    // closure in persistSettings); the state mirror only drives rendering.
+    const externalSaversRef = useRef<Record<string, ExternalSaver>>({});
+    const [externalDirtyCounts, setExternalDirtyCounts] = useState<Record<string, number>>({});
+    const registerExternalSaver = useCallback((id: string, saver: ExternalSaver) => {
+        externalSaversRef.current[id] = saver;
+        setExternalDirtyCounts((prev) =>
+            prev[id] === saver.dirtyCount ? prev : { ...prev, [id]: saver.dirtyCount }
+        );
+    }, []);
+    const unregisterExternalSaver = useCallback((id: string) => {
+        delete externalSaversRef.current[id];
+        setExternalDirtyCounts((prev) => {
+            if (!(id in prev)) return prev;
+            const next = { ...prev };
+            delete next[id];
+            return next;
+        });
+    }, []);
+    const externalDirtyCount = useMemo(
+        () => Object.values(externalDirtyCounts).reduce((a, b) => a + b, 0),
+        [externalDirtyCounts]
+    );
+    const dirtyCount = dirtyKeys.size + externalDirtyCount;
+    const isDirty = dirtyCount > 0;
 
     const isSectionDirty = useCallback(
         (sectionId: SettingsSection): boolean => {
             const section = SECTION_DEFINITIONS.find((s) => s.id === sectionId);
             if (!section) return false;
+            if ((externalDirtyCounts[section.id] ?? 0) > 0) return true;
             if (section.id === "advanced") {
                 // Advanced section: any key not in other sections
                 const knownKeys = new Set(
@@ -377,7 +414,7 @@ export const useSettingsManager = () => {
             }
             return section.keys.some((k) => dirtyKeys.has(k));
         },
-        [dirtyKeys]
+        [dirtyKeys, externalDirtyCounts]
     );
 
     const persistSettings = useCallback(async (options?: { forceGpsRestart?: boolean }) => {
@@ -400,7 +437,8 @@ export const useSettingsManager = () => {
             const liveHardwareKeys = ["ticks_per_meter", ...driveKeys];
             const liveHardwareDirty = liveHardwareKeys.some((k) => dirtyKeys.has(k));
             const hasDirtyChanges = dirtyKeys.size > 0;
-            if (!hasDirtyChanges && !shouldRestartGps) {
+            const externalSavers = Object.values(externalSaversRef.current).filter((x) => x.dirtyCount > 0);
+            if (!hasDirtyChanges && !shouldRestartGps && externalSavers.length === 0) {
                 notification.info({
                     message: t("settingsSections.toasts.noChanges"),
                 });
@@ -442,6 +480,11 @@ export const useSettingsManager = () => {
                 notification.info({
                     message: t("settingsSections.toasts.restartingGps"),
                 });
+            }
+            // Sections that persist outside the yaml (IrriSense) save through
+            // their own endpoint; each reports its own toast on failure.
+            for (const saver of externalSavers) {
+                if (!(await saver.save())) return;
             }
             // Auto-restart the GPS container when GPS/NTRIP fields changed —
             // ROS2 keeps running, the user just sees RTCM stop briefly. This
@@ -592,6 +635,9 @@ export const useSettingsManager = () => {
 
     const revert = useCallback(() => {
         setLocalValues({ ...savedValues });
+        for (const saver of Object.values(externalSaversRef.current)) {
+            saver.revert?.();
+        }
     }, [savedValues]);
 
     // Get keys that don't belong to any defined section.
@@ -662,6 +708,9 @@ export const useSettingsManager = () => {
         gpsRestarting: gpsRestart.pending,
         isDirty,
         dirtyKeys,
+        dirtyCount,
+        registerExternalSaver,
+        unregisterExternalSaver,
         restartRequired,
         searchQuery,
         advancedKeys,

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -694,7 +694,9 @@
     "firmwareVersion": "v{{version}}",
     "firmwareReflash": "v{{version}} — reflash firmware to mow",
     "firmwareFlashCta": "Flash firmware",
-    "coverageToday": "Coverage today · {{pct}} %"
+    "coverageToday": "Coverage today · {{pct}} %",
+    "soilWetTitle": "Careful: the garden is wet (IrriSense)",
+    "soilWetBlocking": "scheduled mows are suspended"
   },
   "onboardingPage": {
     "preview": "Preview",
@@ -1910,10 +1912,18 @@
         "tooltip": "Motion model the receiver assumes for RTK. UAV is the kinematic engine that fixes fast and holds lock while the mower moves; Survey Mow is tuned for near-static surveying (slower to fix, can drop lock under motion); Rover is the generic fallback.",
         "helpText": "Auto uses the per-model default (UM980 defaults to UAV). Choose UAV if your receiver is slow to reach RTK-Fixed or loses fix while mowing.",
         "option": {
-          "auto": { "label": "Auto (per-model default)" },
-          "uav": { "label": "UAV (kinematic — recommended)" },
-          "survey_mow": { "label": "Survey Mow" },
-          "rover": { "label": "Rover (generic)" }
+          "auto": {
+            "label": "Auto (per-model default)"
+          },
+          "uav": {
+            "label": "UAV (kinematic — recommended)"
+          },
+          "survey_mow": {
+            "label": "Survey Mow"
+          },
+          "rover": {
+            "label": "Rover (generic)"
+          }
         }
       },
       "pvtAlgorithm": {
@@ -3007,7 +3017,6 @@
     "fetchedAt": "fetched {{value}}",
     "neverFetched": "no data fetched yet",
     "refresh": "Refresh",
-    "save": "Save IrriSense settings",
     "saved": "IrriSense settings saved",
     "saveFailed": "Failed to save IrriSense settings",
     "loadFailed": "Failed to load IrriSense settings"

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -694,7 +694,9 @@
     "coverageProgress": "Couverture de la zone · {{pct}} %",
     "bladesOff": "arrêt",
     "areaN": "Zone {{number}}",
-    "actionFailed": "Échec de la commande"
+    "actionFailed": "Échec de la commande",
+    "soilWetTitle": "Attention : le jardin est humide (IrriSense)",
+    "soilWetBlocking": "tontes planifiées suspendues"
   },
   "onboardingPage": {
     "preview": "Aperçu",
@@ -1906,10 +1908,18 @@
         "tooltip": "Modèle de mouvement que le récepteur suppose pour le RTK. UAV est le moteur cinématique qui fixe rapidement et conserve le verrouillage pendant que la tondeuse se déplace ; Survey Mow est optimisé pour un relevé quasi statique (plus lent à fixer, peut perdre le verrouillage en mouvement) ; Rover est le repli générique.",
         "helpText": "Auto utilise la valeur par défaut selon le modèle (le UM980 utilise UAV par défaut). Choisissez UAV si votre récepteur est lent à atteindre le RTK-Fixe ou perd le fix pendant la tonte.",
         "option": {
-          "auto": { "label": "Auto (défaut selon le modèle)" },
-          "uav": { "label": "UAV (cinématique — recommandé)" },
-          "survey_mow": { "label": "Survey Mow" },
-          "rover": { "label": "Rover (générique)" }
+          "auto": {
+            "label": "Auto (défaut selon le modèle)"
+          },
+          "uav": {
+            "label": "UAV (cinématique — recommandé)"
+          },
+          "survey_mow": {
+            "label": "Survey Mow"
+          },
+          "rover": {
+            "label": "Rover (générique)"
+          }
         }
       },
       "pvtAlgorithm": {
@@ -3003,7 +3013,6 @@
     "fetchedAt": "lu le {{value}}",
     "neverFetched": "aucune donnée lue pour l'instant",
     "refresh": "Actualiser",
-    "save": "Enregistrer les réglages IrriSense",
     "saved": "Réglages IrriSense enregistrés",
     "saveFailed": "Échec de l'enregistrement des réglages IrriSense",
     "loadFailed": "Échec du chargement des réglages IrriSense"

--- a/gui/web/src/pages/MowgliNextPage.tsx
+++ b/gui/web/src/pages/MowgliNextPage.tsx
@@ -30,6 +30,7 @@ import {ActionCluster} from "../concept/components/ActionCluster.tsx";
 import {LiveMapMini} from "../concept/components/LiveMapMini.tsx";
 import type {MiniArea, MiniProgress} from "../concept/components/LiveMapMini.tsx";
 import {ProgressRibbon} from "../concept/components/ProgressRibbon.tsx";
+import {SoilWetBanner} from "../components/dashboard/SoilWetBanner.tsx";
 import {WeatherChip} from "../concept/components/WeatherChip.tsx";
 import {useWeather} from "../hooks/useWeather.ts";
 import {NoiseTexture} from "../concept/components/NoiseTexture.tsx";
@@ -318,6 +319,9 @@ export const MowgliNextPage = () => {
             label={data.isMoving ? t('mowgliNextPage.orbMowing') : data.charging ? t('mowgliNextPage.orbCharging') : data.emergency ? t('mowgliNextPage.orbAlert') : t('mowgliNextPage.orbIdle')}
           />
         </motion.header>
+
+        {/* IrriSense: the garden is wet — warn before anyone starts a mow */}
+        <SoilWetBanner variants={riseFade}/>
 
         {/* layout */}
         {isMobile ? (

--- a/gui/web/src/pages/SettingsPage.tsx
+++ b/gui/web/src/pages/SettingsPage.tsx
@@ -50,6 +50,9 @@ export const SettingsPage = () => {
         loading,
         saving,
         isDirty,
+        dirtyCount,
+        registerExternalSaver,
+        unregisterExternalSaver,
         dirtyKeys,
         restartRequired,
         searchQuery,
@@ -228,7 +231,12 @@ export const SettingsPage = () => {
                     />
                 );
             case "irrisense":
-                return <IrriSenseSection />;
+                return (
+                    <IrriSenseSection
+                        registerSaver={registerExternalSaver}
+                        unregisterSaver={unregisterExternalSaver}
+                    />
+                );
             case "advanced":
                 return <AdvancedSection values={values} advancedKeys={advancedKeys} onChange={handleChange} />;
             default:
@@ -391,7 +399,7 @@ export const SettingsPage = () => {
                     loading={saving}
                     disabled={!isDirty}
                 >
-                    {isDirty ? t("settingsPage.saveWithCount", {count: dirtyKeys.size}) : t("settingsPage.saved")}
+                    {isDirty ? t("settingsPage.saveWithCount", {count: dirtyCount}) : t("settingsPage.saved")}
                 </Button>
                 {isDirty && (
                     <Button


### PR DESCRIPTION
## What

1. **One Save button.** The IrriSense settings section no longer has its own "Save IrriSense settings" button. It registers with `useSettingsManager` as an *external saver* (`{dirtyCount, save, revert}`), so the page's single **Save** button (with its edit count) persists the IrriSense draft through `PUT /api/irrisense/settings`, the section shows the dirty dot in the nav, and **Revert** drops the draft. "Test connection" still saves pending edits first, as before.
2. **Dashboard warning.** `MowgliNextPage` shows a wet-garden banner under the greeting while IrriSense reports the soil as wet: the reason (zone, deficit, last watering) and "scheduled mows are suspended" when the gate is on. Hidden when dry, unknown (fail-open) or when the integration is off — an outage never looks like a warning.

## How

`useSettingsManager`: `ExternalSaver` interface, `registerExternalSaver/unregisterExternalSaver`, `dirtyCount` (yaml keys + external), `isDirty`/`isSectionDirty` include external sections, `persistSettings` runs external savers after the yaml save, `revert` calls their `revert`. Callbacks live in a ref (no stale closure); a state mirror only drives rendering.

## Tests

- `IrriSenseSection.test.tsx`: saves now go through the registered saver; asserts the section-local button is gone and the clean dirty count is 0.
- `SoilWetBanner.test.tsx` (new): wet with reason + suspension text; gate off; hidden when dry / unknown / disabled.
- `tsc --noEmit` clean, `vitest` 351/351, `yarn build` OK, eslint 0 errors (remaining warnings pre-existing in `useSettingsManager.ts`).

Follow-up to #525.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ