### PR TITLE
fix(safety): make emergency stop dominate release

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'ros2/**'
       - 'tools/motor/**'
       - 'install/config/mowgli/**'
+      - 'firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp'
       - '.github/workflows/ros2-ci.yml'
   # NOTE: deliberately NO `paths:` filter here, and `dev` is included alongside
   # `main`. Two bugs used to hide in this block:
@@ -74,6 +75,7 @@ jobs:
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD -- \
             'ros2/**' 'tools/motor/**' 'install/config/mowgli/**' \
+            'firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp' \
             '.github/workflows/ros2-ci.yml')
           if [ -n "$CHANGED" ]; then
             echo "ROS2-relevant changes:"; echo "$CHANGED"

--- a/firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp
+++ b/firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp
@@ -1,0 +1,45 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Pure heartbeat emergency policy.  Keep this independent of hardware so the
+// host/firmware boundary's stop-over-release invariant is unit-testable.
+
+#ifndef HEARTBEAT_EMERGENCY_POLICY_HPP
+#define HEARTBEAT_EMERGENCY_POLICY_HPP
+
+enum class HeartbeatEmergencyAction {
+  Unchanged,
+  Assert,
+  Release,
+  AutoClearWatchdog,
+};
+
+struct HeartbeatEmergencyDecision {
+  HeartbeatEmergencyAction action;
+  bool clear_heartbeat_only_latch;
+};
+
+// STOP ALWAYS DOMINATES RELEASE. A watchdog-only latch may still auto-clear on
+// a normal heartbeat, but never when that heartbeat explicitly requests STOP.
+constexpr HeartbeatEmergencyDecision decide_heartbeat_emergency(
+    const bool emergency_requested, const bool emergency_release_requested,
+    const bool physical_emergency, const bool heartbeat_only_latch) {
+  return emergency_requested
+             ? HeartbeatEmergencyDecision{HeartbeatEmergencyAction::Assert,
+                                          true}
+         : heartbeat_only_latch
+             ? (physical_emergency
+                    ? HeartbeatEmergencyDecision{HeartbeatEmergencyAction::
+                                                     Unchanged,
+                                                 true}
+                    : HeartbeatEmergencyDecision{HeartbeatEmergencyAction::
+                                                     AutoClearWatchdog,
+                                                 true})
+         : emergency_release_requested && !physical_emergency
+             ? HeartbeatEmergencyDecision{HeartbeatEmergencyAction::Release,
+                                          true}
+             : HeartbeatEmergencyDecision{HeartbeatEmergencyAction::Unchanged,
+                                          false};
+}
+
+#endif // HEARTBEAT_EMERGENCY_POLICY_HPP

--- a/firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp
+++ b/firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp
@@ -16,6 +16,9 @@ enum class HeartbeatEmergencyAction {
 
 struct HeartbeatEmergencyDecision {
   HeartbeatEmergencyAction action;
+  // This is consumed after every action by the firmware handler. It discards
+  // watchdog-only provenance once the emergency is asserted, released,
+  // auto-cleared, or found to have become physical.
   bool clear_heartbeat_only_latch;
 };
 
@@ -23,11 +26,11 @@ struct HeartbeatEmergencyDecision {
 // a normal heartbeat, but never when that heartbeat explicitly requests STOP.
 constexpr HeartbeatEmergencyDecision decide_heartbeat_emergency(
     const bool emergency_requested, const bool emergency_release_requested,
-    const bool physical_emergency, const bool heartbeat_only_latch) {
+    const bool physical_emergency, const bool watchdog_latch_active) {
   return emergency_requested
              ? HeartbeatEmergencyDecision{HeartbeatEmergencyAction::Assert,
                                           true}
-         : heartbeat_only_latch
+         : watchdog_latch_active
              ? (physical_emergency
                     ? HeartbeatEmergencyDecision{HeartbeatEmergencyAction::
                                                      Unchanged,

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -26,6 +26,7 @@
 #include "charger.h"
 #include "drivemotor.h"
 #include "emergency.h"
+#include "heartbeat_emergency_policy.hpp"
 #include "nbt.h"
 #include "panel.h"
 #include "pid.hpp"
@@ -362,37 +363,47 @@ static void on_heartbeat(const uint8_t *data, size_t len) {
 
   last_heartbeat_tick = HAL_GetTick();
 
-  /* Comms restored. If the active emergency was a PURE comms-loss watchdog latch
-   * (no physical trigger) and no sensor is asserted now, auto-clear it so a brief
-   * host/USB stall doesn't strand the robot until a manual reset. A physical
-   * trigger that appeared in the meantime asserts a sensor (handled below) and
-   * clears heartbeat_only_latch, so this never auto-clears a physical e-stop. */
-  if (heartbeat_only_latch && Emergency_State()) {
-    if (!any_physical_emergency()) {
+  const bool emergency_requested = pkt->emergency_requested != 0u;
+  const bool emergency_release_requested =
+      pkt->emergency_release_requested != 0u;
+  const bool watchdog_latch_active =
+      heartbeat_only_latch && Emergency_State();
+  /* A STOP request needs no sensor read: it always wins. This preserves the
+   * previous sensor-read conditions for all other inputs. */
+  const bool physical_emergency =
+      !emergency_requested &&
+      (watchdog_latch_active || emergency_release_requested) &&
+      any_physical_emergency();
+  const HeartbeatEmergencyDecision decision = decide_heartbeat_emergency(
+      emergency_requested, emergency_release_requested, physical_emergency,
+      watchdog_latch_active);
+
+  switch (decision.action) {
+    case HeartbeatEmergencyAction::Assert:
+      heartbeat_only_latch = false;  /* host stop is not comms-loss */
+      Emergency_SetState(1);
+      break;
+    case HeartbeatEmergencyAction::Release:
+      Emergency_SetState(0);
+      heartbeat_only_latch = false;
+      break;
+    case HeartbeatEmergencyAction::AutoClearWatchdog:
       Emergency_SetState(0);
       heartbeat_only_latch = false;
       debug_printf("heartbeat resumed: comms-loss emergency auto-cleared\r\n");
-    } else {
-      /* A physical sensor is now asserted — this is no longer a pure comms
-       * latch; require an explicit operator release. */
-      heartbeat_only_latch = false;
+      break;
+    case HeartbeatEmergencyAction::Unchanged:
+      if (decision.clear_heartbeat_only_latch) {
+        /* A physical sensor is now asserted — this is no longer a pure comms
+         * latch; require an explicit operator release. */
+        heartbeat_only_latch = false;
+      }
+      break;
     }
-  }
 
-  if (pkt->emergency_requested) {
-    heartbeat_only_latch = false;  /* host-commanded e-stop is not comms-loss */
-    Emergency_SetState(1);
-  }
-  if (pkt->emergency_release_requested) {
-    /* Only clear emergency if no physical sensor is still asserted.
-     * Firmware is the sole safety authority — never bypass hardware. */
-    if (!any_physical_emergency()) {
-      Emergency_SetState(0);
-      heartbeat_only_latch = false;
-    } else {
-      debug_printf(
-          "emergency release rejected: physical sensor still active\r\n");
-    }
+  if (emergency_release_requested && !emergency_requested &&
+      physical_emergency) {
+    debug_printf("emergency release rejected: physical sensor still active\r\n");
   }
 }
 

--- a/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -380,26 +380,22 @@ static void on_heartbeat(const uint8_t *data, size_t len) {
 
   switch (decision.action) {
     case HeartbeatEmergencyAction::Assert:
-      heartbeat_only_latch = false;  /* host stop is not comms-loss */
       Emergency_SetState(1);
       break;
     case HeartbeatEmergencyAction::Release:
       Emergency_SetState(0);
-      heartbeat_only_latch = false;
       break;
     case HeartbeatEmergencyAction::AutoClearWatchdog:
       Emergency_SetState(0);
-      heartbeat_only_latch = false;
       debug_printf("heartbeat resumed: comms-loss emergency auto-cleared\r\n");
       break;
     case HeartbeatEmergencyAction::Unchanged:
-      if (decision.clear_heartbeat_only_latch) {
-        /* A physical sensor is now asserted — this is no longer a pure comms
-         * latch; require an explicit operator release. */
-        heartbeat_only_latch = false;
-      }
       break;
-    }
+  }
+
+  if (decision.clear_heartbeat_only_latch) {
+    heartbeat_only_latch = false;
+  }
 
   if (emergency_release_requested && !emergency_requested &&
       physical_emergency) {

--- a/ros2/src/mowgli_hardware/CMakeLists.txt
+++ b/ros2/src/mowgli_hardware/CMakeLists.txt
@@ -195,6 +195,17 @@ if(BUILD_TESTING)
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
+
+  # ---- test_heartbeat_emergency_policy ----
+  # The firmware's pure heartbeat safety policy is compiled here directly so
+  # all stop/release combinations are verified without physical hardware.
+  ament_add_gtest(test_heartbeat_emergency_policy
+    test/test_heartbeat_emergency_policy.cpp
+  )
+  target_include_directories(test_heartbeat_emergency_policy
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../firmware/stm32/ros_usbnode/include
+  )
 endif()
 
 # ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_hardware/test/test_heartbeat_emergency_policy.cpp
+++ b/ros2/src/mowgli_hardware/test/test_heartbeat_emergency_policy.cpp
@@ -6,26 +6,30 @@
 
 TEST(HeartbeatEmergencyPolicy, NoFlagsLeaveEmergencyUnchanged)
 {
-  EXPECT_EQ(decide_heartbeat_emergency(false, false, false, false).action,
-            HeartbeatEmergencyAction::Unchanged);
+  const auto decision = decide_heartbeat_emergency(false, false, false, false);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Unchanged);
+  EXPECT_FALSE(decision.clear_heartbeat_only_latch);
 }
 
 TEST(HeartbeatEmergencyPolicy, StopAssertsEmergency)
 {
-  EXPECT_EQ(decide_heartbeat_emergency(true, false, false, false).action,
-            HeartbeatEmergencyAction::Assert);
+  const auto decision = decide_heartbeat_emergency(true, false, false, false);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Assert);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
 }
 
 TEST(HeartbeatEmergencyPolicy, ReleaseOnlyWithoutPhysicalEmergencyReleases)
 {
-  EXPECT_EQ(decide_heartbeat_emergency(false, true, false, false).action,
-            HeartbeatEmergencyAction::Release);
+  const auto decision = decide_heartbeat_emergency(false, true, false, false);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Release);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
 }
 
 TEST(HeartbeatEmergencyPolicy, ReleaseOnlyWithPhysicalEmergencyIsRejected)
 {
-  EXPECT_EQ(decide_heartbeat_emergency(false, true, true, false).action,
-            HeartbeatEmergencyAction::Unchanged);
+  const auto decision = decide_heartbeat_emergency(false, true, true, false);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Unchanged);
+  EXPECT_FALSE(decision.clear_heartbeat_only_latch);
 }
 
 TEST(HeartbeatEmergencyPolicy, StopDominatesReleaseWithoutPhysicalEmergency)
@@ -48,9 +52,79 @@ TEST(HeartbeatEmergencyPolicy, ReleaseWorksAfterPreviousStop)
             HeartbeatEmergencyAction::Release);
 }
 
+TEST(HeartbeatEmergencyPolicy, NormalHeartbeatAutoClearsPureWatchdogLatch)
+{
+  const auto decision = decide_heartbeat_emergency(false, false, false, true);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::AutoClearWatchdog);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}
+
+TEST(HeartbeatEmergencyPolicy, PhysicalEmergencyPreventsWatchdogAutoClear)
+{
+  const auto decision = decide_heartbeat_emergency(false, false, true, true);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Unchanged);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}
+
+TEST(HeartbeatEmergencyPolicy, WatchdogRecoveryPrecedesExplicitRelease)
+{
+  const auto decision = decide_heartbeat_emergency(false, true, false, true);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::AutoClearWatchdog);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}
+
+TEST(HeartbeatEmergencyPolicy, PhysicalEmergencyRejectsReleaseAfterWatchdogLatch)
+{
+  const auto decision = decide_heartbeat_emergency(false, true, true, true);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Unchanged);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}
+
 TEST(HeartbeatEmergencyPolicy, WatchdogAutoClearCannotBypassExplicitStop)
 {
   const auto decision = decide_heartbeat_emergency(true, true, false, true);
   EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Assert);
   EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}
+
+TEST(HeartbeatEmergencyPolicy, CompleteTruthTable)
+{
+  struct Case
+  {
+    bool stop;
+    bool release;
+    bool physical;
+    bool watchdog_latch_active;
+    HeartbeatEmergencyAction action;
+    bool clear_latch;
+  };
+
+  const Case cases[] = {
+      {false, false, false, false, HeartbeatEmergencyAction::Unchanged, false},
+      {false, false, false, true, HeartbeatEmergencyAction::AutoClearWatchdog, true},
+      {false, false, true, false, HeartbeatEmergencyAction::Unchanged, false},
+      {false, false, true, true, HeartbeatEmergencyAction::Unchanged, true},
+      {false, true, false, false, HeartbeatEmergencyAction::Release, true},
+      {false, true, false, true, HeartbeatEmergencyAction::AutoClearWatchdog, true},
+      {false, true, true, false, HeartbeatEmergencyAction::Unchanged, false},
+      {false, true, true, true, HeartbeatEmergencyAction::Unchanged, true},
+      {true, false, false, false, HeartbeatEmergencyAction::Assert, true},
+      {true, false, false, true, HeartbeatEmergencyAction::Assert, true},
+      {true, false, true, false, HeartbeatEmergencyAction::Assert, true},
+      {true, false, true, true, HeartbeatEmergencyAction::Assert, true},
+      {true, true, false, false, HeartbeatEmergencyAction::Assert, true},
+      {true, true, false, true, HeartbeatEmergencyAction::Assert, true},
+      {true, true, true, false, HeartbeatEmergencyAction::Assert, true},
+      {true, true, true, true, HeartbeatEmergencyAction::Assert, true},
+  };
+
+  for (const auto& test_case : cases)
+  {
+    const auto decision = decide_heartbeat_emergency(test_case.stop,
+                                                     test_case.release,
+                                                     test_case.physical,
+                                                     test_case.watchdog_latch_active);
+    EXPECT_EQ(decision.action, test_case.action);
+    EXPECT_EQ(decision.clear_heartbeat_only_latch, test_case.clear_latch);
+  }
 }

--- a/ros2/src/mowgli_hardware/test/test_heartbeat_emergency_policy.cpp
+++ b/ros2/src/mowgli_hardware/test/test_heartbeat_emergency_policy.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "heartbeat_emergency_policy.hpp"
+#include <gtest/gtest.h>
+
+TEST(HeartbeatEmergencyPolicy, NoFlagsLeaveEmergencyUnchanged)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(false, false, false, false).action,
+            HeartbeatEmergencyAction::Unchanged);
+}
+
+TEST(HeartbeatEmergencyPolicy, StopAssertsEmergency)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(true, false, false, false).action,
+            HeartbeatEmergencyAction::Assert);
+}
+
+TEST(HeartbeatEmergencyPolicy, ReleaseOnlyWithoutPhysicalEmergencyReleases)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(false, true, false, false).action,
+            HeartbeatEmergencyAction::Release);
+}
+
+TEST(HeartbeatEmergencyPolicy, ReleaseOnlyWithPhysicalEmergencyIsRejected)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(false, true, true, false).action,
+            HeartbeatEmergencyAction::Unchanged);
+}
+
+TEST(HeartbeatEmergencyPolicy, StopDominatesReleaseWithoutPhysicalEmergency)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(true, true, false, false).action,
+            HeartbeatEmergencyAction::Assert);
+}
+
+TEST(HeartbeatEmergencyPolicy, StopDominatesReleaseWithPhysicalEmergency)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(true, true, true, false).action,
+            HeartbeatEmergencyAction::Assert);
+}
+
+TEST(HeartbeatEmergencyPolicy, ReleaseWorksAfterPreviousStop)
+{
+  EXPECT_EQ(decide_heartbeat_emergency(true, false, false, false).action,
+            HeartbeatEmergencyAction::Assert);
+  EXPECT_EQ(decide_heartbeat_emergency(false, true, false, false).action,
+            HeartbeatEmergencyAction::Release);
+}
+
+TEST(HeartbeatEmergencyPolicy, WatchdogAutoClearCannotBypassExplicitStop)
+{
+  const auto decision = decide_heartbeat_emergency(true, true, false, true);
+  EXPECT_EQ(decision.action, HeartbeatEmergencyAction::Assert);
+  EXPECT_TRUE(decision.clear_heartbeat_only_latch);
+}


### PR DESCRIPTION
## Safety fix

A malformed or buggy heartbeat may carry both `emergency_requested` and `emergency_release_requested`. The prior firmware processed them as independent sequential `if` statements: it asserted STOP, then could immediately process RELEASE and clear the new latch when no physical sensor was active.

This PR makes the heartbeat decision explicit: **STOP ALWAYS DOMINATES RELEASE.** Both fields are wire flags (`non-zero` is true); therefore a malformed non-zero value cannot create another command meaning.

| emergency_requested | emergency_release_requested | result |
| --- | --- | --- |
| 0 | 0 | unchanged, except the existing pure watchdog-latch recovery |
| 1 | 0 | emergency asserted |
| 0 | 1 | release only when no physical emergency is active |
| 1 | 1 | emergency asserted — STOP wins |

### Watchdog and physical-safety behavior

The existing watchdog-only recovery remains intact: a normal heartbeat clears a pure communications-loss latch only when no physical sensor is active. If a physical input appears while that latch is pending, firmware keeps the emergency state asserted and drops its watchdog-only provenance. An explicit STOP is evaluated first, so neither watchdog recovery nor a simultaneous RELEASE can clear it.

`any_physical_emergency()` is unchanged and still covers yellow/white stop buttons, blue/red wheel lift, mechanical tilt, and low-Z accelerometer input. A host heartbeat cannot release any currently active physical emergency.

The host deliberately has independent STOP and one-shot RELEASE state: startup/reconnect watchdog recovery and lift recovery can request RELEASE while an emergency becomes active. This PR makes that combination deterministic in firmware rather than depending on host timing.

### Tests and CI

- `test_heartbeat_emergency_policy`: 13 GTests, including the complete 16-case truth table, STOP+RELEASE with/without physical input, release after a prior STOP, normal watchdog recovery, physical emergency after a watchdog latch, and watchdog-latch + RELEASE precedence.
- The policy helper uses the exact firmware C++11 toolchain and builds for both `Yardforce500` and `Yardforce500B`.
- ROS2 CI now treats exactly `firmware/stm32/ros_usbnode/include/heartbeat_emergency_policy.hpp` as ROS2-relevant, both on `push.paths` and PR change detection. This runs the policy GTest for header-only changes without making unrelated firmware changes build ROS2.
- Verified in GitHub Actions: Firmware builds/board-defaults guard, ROS2 change detection, format, cppcheck, full ROS2 build/test. The full ROS2 log shows `test_heartbeat_emergency_policy` built and all 13 tests passed.
- Local checks: both firmware targets, board-defaults guard, protocol-version guard, clang-format for the new test, and `git diff --check`.

No physical mower test is required for correctness of this isolated deterministic precedence policy. This does not claim to replace hardware verification of the wider emergency system.