### PR TITLE
chore(gnss): re-pin universal-gnss to the fork's main (67 commits, 29-finding driver audit)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,12 +4,12 @@
 	branch = main
 [submodule "ros2/src/external/universal-gnss"]
 	path = ros2/src/external/universal-gnss
-	# Pinned to the mowglinext fork. Two fork fixes are stacked here, both for
-	# issue #395: (1) GLONASS-1230 optional-for-RTK correction health
-	# (Pepeuch/universal-gnss#4) and (2) UM980 MODE ROVER UAV default +
-	# --rover-dynamic-mode override (mowglinext/universal-gnss#1). Points at the
-	# rover-dynamic-mode branch until that fork PR merges into the 1230 branch;
-	# then re-pin the gitlink to the merge commit and restore the branch below.
-	# Revert to https://github.com/pepeuch/universal-gnss.git once upstreamed.
+	# Pinned to the mowglinext fork's main, which tracks Pepeuch/universal-gnss
+	# main. Both fork fixes for issue #395 are now upstream there — the
+	# GLONASS-1230 optional-for-RTK correction health (Pepeuch/universal-gnss#4,
+	# an ancestor of main) and the UM980 MODE ROVER UAV default +
+	# --rover-dynamic-mode override (folded into "fix(unicore): restore rover
+	# mode and correction-age policy") — so the old stacked branch is gone and
+	# this follows main directly.
 	url = https://github.com/mowglinext/universal-gnss.git
-	branch = fix/rover-dynamic-mode-uav
+	branch = main

--- a/ros2/scripts/format.sh
+++ b/ros2/scripts/format.sh
@@ -23,8 +23,16 @@ if [ "$MAJOR" != "$REQUIRED_MAJOR" ]; then
   echo "         Install matching version: pip install clang-format==18.1.8"
 fi
 
+# external/ holds vendored submodules (universal-gnss). They carry their own
+# clang-format policy and are not ours to reformat: doing so left the
+# universal-gnss worktree permanently dirty (155 files on 2026-09-04, purely
+# reflow + include sorting from a local clang-format 22), which then blocks
+# re-pinning the submodule. CI only ever formats lines touched in THIS repo
+# (git-clang-format --diff against the base), so excluding them here matches
+# what CI checks rather than diverging from it.
 FILES=$(find "${ROS2_DIR}/src/" \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
-  -not -path "*/opennav_coverage/*")
+  -not -path "*/opennav_coverage/*" \
+  -not -path "*/external/*")
 
 if [ -z "$FILES" ]; then
   echo "No C++ files found."

--- a/sensors/gps/Dockerfile
+++ b/sensors/gps/Dockerfile
@@ -42,6 +42,7 @@ COPY ros2/src/external/universal-gnss/gnss_protocols /ws/src/gnss_protocols
 COPY ros2/src/external/universal-gnss/gnss_transport /ws/src/gnss_transport
 COPY ros2/src/external/universal-gnss/gnss_driver /ws/src/gnss_driver
 COPY ros2/src/external/universal-gnss/gnss_ntrip /ws/src/gnss_ntrip
+COPY ros2/src/external/universal-gnss/gnss_runtime /ws/src/gnss_runtime
 COPY ros2/src/external/universal-gnss/gnss_tools /ws/src/gnss_tools
 COPY ros2/src/external/universal-gnss/CMakeLists.txt /ws/gnss_tools_root/CMakeLists.txt
 
@@ -55,6 +56,7 @@ RUN . /opt/ros/kilted/setup.sh \
  && ln -s /ws/src/gnss_driver /ws/gnss_tools_root/gnss_driver \
  && ln -s /ws/src/gnss_transport /ws/gnss_tools_root/gnss_transport \
  && ln -s /ws/src/gnss_ntrip /ws/gnss_tools_root/gnss_ntrip \
+ && ln -s /ws/src/gnss_runtime /ws/gnss_tools_root/gnss_runtime \
  && ln -s /ws/src/gnss_tools /ws/gnss_tools_root/gnss_tools \
  && cmake -S /ws/gnss_tools_root -B /ws/gnss_tools_build \
       -DBUILD_TESTING=OFF \


### PR DESCRIPTION
## Why now

Our gitlink pointed at `4bf5d0a` on `fix/rover-dynamic-mode-uav` — **a branch that no longer exists on the fork**. The mowglinext fork's `main` is now synced with `Pepeuch/universal-gnss` main (`ab32f67`, 2026-09-03).

## Nothing is lost by following main

All three commits we carried locally have upstream equivalents, verified before discarding them:

| our local commit | upstream |
|---|---|
| GLONASS-1230 optional-for-RTK correction health (`3495ffb9`) | ancestor of `main` |
| UM980 `MODE ROVER UAV` default + `--rover-dynamic-mode` | folded into `5281472` *fix(unicore): restore rover mode and correction-age policy* |
| `4bf5d0a` never leave a truncated frame on the wire | `bceb76b` *preserve partial RTCM writes across callbacks* |

(The three are also archived as patches outside the repo in case a reviewer wants to diff them.)

## What the 67 commits bring, in paths we actually run

A full audit of the driver (UGA-001…029, each with a regression test):

- **NMEA framer dereferenced a `string_view` into a destroyed temporary** — ASan aborts on ordinary valid sentences.
- **Stale positions republished with a fresh timestamp**, and fed back to NTRIP as the GGA source.
- **NTRIP could sit in `Streaming` with no RTCM flowing** and never reconnect.
- **Partial RTCM writes left a broken frame prefix** on the receiver link and dropped the rest.
- **Structurally malformed RTCM satisfied correction health**; monotonic and ROS clock domains were mixed in freshness checks.
- `build(ros2): replace deprecated ament_target_dependencies` — Kilted deprecation fix.

## Compatibility

Interface changes from our pin are **additive only**: one new `GnssStatus` field (`position_observation_sequence`) and a new `GetReceiverSnapshot` service. No field removed, so `mowgli_gnss_bridge` is unaffected. `universal_gnss_ros2` is in the colcon workspace, so the ROS2 CI job compiles all of this.

## Compatibility audit (nothing to change in our code or the GUI)

Checked field by field against our pin, not by reading commit messages:

| surface | result |
|---|---|
| CLI flags `start_gps.sh` passes | all 15 still exist upstream (only `--ros-args` differs, and that is a ROS built-in) |
| `universal_gnss_ros2/GnssStatus` fields | **none removed**; one added: `position_observation_sequence` |
| `receiver_node` ROS parameters | **none removed**; five added, all defaulted |
| `mowgli_gnss_bridge` | unaffected — every field it maps still exists |
| GUI | unaffected — `ros.generated.ts` and `GnssLiveDiagnosticsCard.tsx` need no change |

Correction to an earlier draft of this description: it claimed the update *adds* `mean_cn0_db_hz` / `max_cn0_db_hz`. **That was wrong** — both fields already existed at our old pin, are already mapped by `mowgli_gnss_bridge`, and are already rendered by `GnssLiveDiagnosticsCard`. The signal-strength data was available all along on 2026-09-02; reading it off the serial port by hand was unnecessary.

One new capability worth wiring later, but deliberately **not** in this PR: `position_observation_sequence` distinguishes a real position observation from a cached status republication (the UGA-002 fix). That is exactly the signal that would let the mower detect a frozen GPS rather than trusting a stale-but-fresh-looking fix. Follow-up, not a blocker.

The new node-side `auto_config_profile` / `auto_config_dry_run_enabled` parameters do **not** conflict with the auto-config `start_gps.sh` already performs: the node path is a dry run that only plans and reports diagnostics, and `auto_config_dry_run_enabled` defaults to `false`.

## Two changes beyond the gitlink

1. **`sensors/gps/Dockerfile`** — upstream's root `CMakeLists.txt` now `add_subdirectory()`s a new `gnss_runtime` subproject, so the sidecar image must copy and symlink it alongside the others or the tools configure step fails with a missing-directory error.
2. **`ros2/scripts/format.sh`** — it globbed all of `ros2/src/` and excluded only `opennav_coverage`, so **every pre-push reformatted the vendored submodule** with whatever clang-format the developer has installed. That is the origin of the 155 permanently-modified files in the universal-gnss worktree, and it actively blocked this re-pin: the hook re-dirtied the submodule on each push attempt. Verified before discarding that all 155 were formatting-only (line rejoining, include and `using`-declaration sorting) by comparing every file's content with all whitespace stripped. CI never formats submodule content (`git-clang-format --diff` against the merge base only sees lines changed in this repo), so excluding `external/` matches CI rather than diverging from it.

## Test plan

- [ ] CI: ROS2 build + tests, GPS sidecar image (amd64/arm64)
- [ ] Field: `mowgli-pull && mowgli-up`, confirm RTK Fixed returns and `/gps/status` still populates `rtk_mode` / `horizontal_accuracy_m`, and that NTRIP reconnects after a deliberate drop

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
