### PR TITLE
feat(gnss): observation-freshness provenance so a frozen receiver stops looking healthy (split 1/3 of #534)

### DIFF
--- a/firmware/stm32/ros_usbnode/src/ros/ros_lib/mower_msgs/GnssStatus.h
+++ b/firmware/stm32/ros_usbnode/src/ros/ros_lib/mower_msgs/GnssStatus.h
@@ -106,6 +106,8 @@ namespace mower_msgs
       _msm_summary_cell_count_type msm_summary_cell_count;
       typedef float _msm_summary_age_s_type;
       _msm_summary_age_s_type msm_summary_age_s;
+      typedef uint64_t _position_observation_sequence_type;
+      _position_observation_sequence_type position_observation_sequence;
       enum { FIX_TYPE_NO_FIX = 0 };
       enum { FIX_TYPE_GPS_FIX = 1 };
       enum { FIX_TYPE_RTK_FLOAT = 2 };
@@ -200,7 +202,8 @@ namespace mower_msgs
       msm_summary_satellite_count(0),
       msm_summary_signal_count(0),
       msm_summary_cell_count(0),
-      msm_summary_age_s(0)
+      msm_summary_age_s(0),
+      position_observation_sequence(0)
     {
     }
 
@@ -542,6 +545,20 @@ namespace mower_msgs
       *(outbuffer + offset + 2) = (u_msm_summary_age_s.base >> (8 * 2)) & 0xFF;
       *(outbuffer + offset + 3) = (u_msm_summary_age_s.base >> (8 * 3)) & 0xFF;
       offset += sizeof(this->msm_summary_age_s);
+      union {
+        uint64_t real;
+        uint64_t base;
+      } u_position_observation_sequence;
+      u_position_observation_sequence.real = this->position_observation_sequence;
+      *(outbuffer + offset + 0) = (u_position_observation_sequence.base >> (8 * 0)) & 0xFF;
+      *(outbuffer + offset + 1) = (u_position_observation_sequence.base >> (8 * 1)) & 0xFF;
+      *(outbuffer + offset + 2) = (u_position_observation_sequence.base >> (8 * 2)) & 0xFF;
+      *(outbuffer + offset + 3) = (u_position_observation_sequence.base >> (8 * 3)) & 0xFF;
+      *(outbuffer + offset + 4) = (u_position_observation_sequence.base >> (8 * 4)) & 0xFF;
+      *(outbuffer + offset + 5) = (u_position_observation_sequence.base >> (8 * 5)) & 0xFF;
+      *(outbuffer + offset + 6) = (u_position_observation_sequence.base >> (8 * 6)) & 0xFF;
+      *(outbuffer + offset + 7) = (u_position_observation_sequence.base >> (8 * 7)) & 0xFF;
+      offset += sizeof(this->position_observation_sequence);
       return offset;
     }
 
@@ -938,11 +955,26 @@ namespace mower_msgs
       u_msm_summary_age_s.base |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
       this->msm_summary_age_s = u_msm_summary_age_s.real;
       offset += sizeof(this->msm_summary_age_s);
+      union {
+        uint64_t real;
+        uint64_t base;
+      } u_position_observation_sequence;
+      u_position_observation_sequence.base = 0;
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 0))) << (8 * 0);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 1))) << (8 * 1);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 2))) << (8 * 2);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 3))) << (8 * 3);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 4))) << (8 * 4);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 5))) << (8 * 5);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 6))) << (8 * 6);
+      u_position_observation_sequence.base |= ((uint64_t) (*(inbuffer + offset + 7))) << (8 * 7);
+      this->position_observation_sequence = u_position_observation_sequence.real;
+      offset += sizeof(this->position_observation_sequence);
      return offset;
     }
 
     virtual const char * getType() override { return "mower_msgs/GnssStatus"; };
-    virtual const char * getMD5() override { return "71b4eb0e6897be3f7e44ad3f15ca54e5"; };
+    virtual const char * getMD5() override { return "2abb8ee551e47aac5db970d0e1a1740b"; };
 
   };
 

--- a/gui/pkg/msgs/mowgli/types_generated.go
+++ b/gui/pkg/msgs/mowgli/types_generated.go
@@ -118,6 +118,7 @@ type GnssStatus struct {
 	MsmSummarySignalCount     uint16                         `json:"msm_summary_signal_count"`
 	MsmSummaryCellCount       uint16                         `json:"msm_summary_cell_count"`
 	MsmSummaryAgeS            float32                        `json:"msm_summary_age_s"`
+	PositionObservationSequence uint64                         `json:"position_observation_sequence"`
 }
 
 // HighLevelStatus matches mowgli_interfaces/msg/HighLevelStatus.

--- a/gui/web/src/types/ros.generated.ts
+++ b/gui/web/src/types/ros.generated.ts
@@ -313,6 +313,7 @@ export type GnssStatus = {
   msm_summary_signal_count?: number;
   msm_summary_cell_count?: number;
   msm_summary_age_s?: number;
+  position_observation_sequence?: number;
 };
 
 export const enum HighLevelStatusConstants {

--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -247,6 +247,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_gnss_timestamp fusion_graph_core)
 
+  ament_add_gtest(test_gnss_observation_freshness
+    test/test_gnss_observation_freshness.cpp
+  )
+  target_link_libraries(test_gnss_observation_freshness fusion_graph_core)
+
   # Performance benchmarks. Long-running (~30 s on ARM); only meaningful
   # in Release builds. Output is grep-friendly for tracking regressions.
   ament_add_gtest(test_perf

--- a/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
@@ -41,6 +41,7 @@
 #include "fusion_graph/scan_matcher.hpp"
 #include <Eigen/Core>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <mowgli_interfaces/gnss_observation_freshness.hpp>
 #include <mowgli_interfaces/msg/high_level_status.hpp>
 #include <mowgli_interfaces/msg/status.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -98,6 +99,9 @@ private:
 
   // Try to seed X_0. Returns true once initialization succeeded.
   bool TrySeedInitialPose();
+  // RTK freshness is based on receiver-receipt provenance in ROS time.
+  // Negative age (future stamp / clock rewind) is always not fresh.
+  bool RtkFixedReceiptIsFresh(double maximum_age_s) const;
 
   // Publish TF map->odom and /odometry/filtered_map.
   void PublishOutputs(const TickOutput& out);
@@ -596,8 +600,9 @@ private:
   // GraphStats.gps_rejects_wrongfix).
   //
   // wheel_dist_since_last_gps_m_ accumulates |wheel translation|
-  // between consecutive OnGnss calls; reset to 0 in OnGnss after
-  // the check.
+  // between consecutive genuine observations; cached republications return
+  // before this state is touched.
+  mowgli_interfaces::gnss_observation_freshness::ObservationTracker gnss_observation_tracker_;
   std::optional<gtsam::Vector2> last_gps_map_xy_;
   double wheel_dist_since_last_gps_m_ = 0.0;
   // GPS jump (m) above which the sample is rejected as a wrong-fix (motion-

--- a/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_a.cpp
@@ -109,6 +109,50 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
 {
   if (msg->status.status < sensor_msgs::msg::NavSatStatus::STATUS_FIX)
     return;
+
+  // The pinned Universal GNSS adapter stamps NavSatFix with the local receiver
+  // acceptance/receipt time and preserves that same stamp for timer-driven
+  // republications. It is therefore the strongest identity available on
+  // /gps/fix itself: compare provenance, never coordinates or callback time.
+  //
+  // sequence=0 deliberately selects the tracker's receipt-only compatibility
+  // mode. The stronger position_observation_sequence now crosses /gps/status
+  // for consumers that subscribe to the typed contract, but associating two
+  // independently delivered topics here would reintroduce the asynchronous
+  // pairing defect deferred to MGNSS-002.
+  const rclcpp::Time ros_now = this->now();
+  const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
+  const auto steady_now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                 std::chrono::steady_clock::now().time_since_epoch())
+                                 .count();
+  const auto observation_update = gnss_observation_tracker_.Observe(0,
+                                                                    receipt_stamp.nanoseconds(),
+                                                                    ros_now.nanoseconds(),
+                                                                    steady_now_ns);
+  using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
+  if (observation_update == ObservationUpdate::kRosTimeDiscontinuity)
+  {
+    last_rtk_fixed_stamp_.reset();
+    rtk_fixed_streak_ = 0;
+    last_gps_sigma_ = -1.0;
+    last_gps_map_xy_.reset();
+    ResetRtkWrongFixAccumulators(wheel_dist_since_last_gps_m_, abs_dtheta_since_last_gps_rad_);
+    RCLCPP_WARN(get_logger(), "fusion_graph: ROS time moved backward; GNSS evidence epoch reset");
+    return;
+  }
+  if (observation_update != ObservationUpdate::kNewObservation &&
+      observation_update != ObservationUpdate::kSourceRestart)
+  {
+    if (observation_update == ObservationUpdate::kInvalidProvenance)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "fusion_graph: GNSS receipt stamp is zero/future; sample dropped");
+    }
+    return;
+  }
+
   // First valid fix gates the dock-arrival pose seed below. Without
   // this, a robot that boots already docked could anchor on the dock
   // before GPS is ready and walk the graph over once GPS arrives.
@@ -239,10 +283,6 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
     last_gps_sigma_ = -1.0;
     return;
   }
-  // Latch the most-recent valid GPS σ for the keyframe-capture quality gate
-  // (only capture when the fix is mm-accurate). <0 means no usable σ.
-  last_gps_sigma_ = sigma;
-
   // Robust noise model on GPS — applied unconditionally now (was
   // RTK-Float only). Field measurement 2026-05-17 (gps_stability.py,
   // 10 min stationary on RTK-Fixed 100 %) showed even Fixed solutions
@@ -254,17 +294,35 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
   // session, or a slow drift that builds up to >5 cm without a
   // detectable wheel discrepancy).
   const bool rtk_fixed = msg->status.status == sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX;
-  // Track the freshness of RTK-Fixed for the scan-match yield gate. Updated
-  // even while docked (GPS factors are suppressed below, but the freshness is
-  // still the honest signal of whether absolute position is available).
-  if (rtk_fixed)
+
+  // Resolve the receipt provenance against the live graph window BEFORE any
+  // current-RTK latch is committed below. This is the same lookup the factor
+  // path performs further down (measurement_stamp is this same stamp); it is
+  // hoisted here because the docking and on-dock branches return early, and an
+  // observation too old to still have a live graph node must not refresh their
+  // freshness latches either. Stateless per sample — it cannot latch GPS out.
+  if (graph_->IsInitialized() && !graph_->FindNodeAtOrBefore(receipt_stamp.seconds()))
   {
-    last_rtk_fixed_stamp_ = this->now();
+    RCLCPP_WARN_THROTTLE(
+        get_logger(),
+        *get_clock(),
+        5000,
+        "fusion_graph: no live graph node at/before GNSS receipt time; sample dropped");
+    return;
   }
-  // Debounce counter for keyframe capture: only capture after RTK-Fixed has
-  // held for several consecutive epochs (a single carrSoln Fixed flicker can
-  // otherwise freeze a slightly-off anchor that poisons every later match).
-  rtk_fixed_streak_ = rtk_fixed ? (rtk_fixed_streak_ + 1) : 0;
+
+  const auto commit_current_gnss_evidence = [this, rtk_fixed, receipt_stamp, sigma]()
+  {
+    // Receipt time, not callback time, is the freshness basis. Downstream gates
+    // additionally reject negative age via IsReceiptFresh.
+    if (rtk_fixed)
+    {
+      last_rtk_fixed_stamp_ = receipt_stamp;
+    }
+    // Debounce only genuinely new, accepted receiver observations.
+    rtk_fixed_streak_ = rtk_fixed ? (rtk_fixed_streak_ + 1) : 0;
+    last_gps_sigma_ = sigma;
+  };
   // During the dock approach, hold position through the RTK fixed↔float
   // per-epoch flicker: drop non-Fixed epochs entirely so the dock controller's
   // target doesn't jump between cm-accurate Fixed and dm-noisy Float (the
@@ -275,6 +333,7 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
   if (gate_float_gps_during_docking_ && !rtk_fixed && DockingApproachActive() &&
       graph_->IsInitialized())
   {
+    commit_current_gnss_evidence();
     return;
   }
   // Suppress GPS factors while the robot is on the dock.
@@ -298,6 +357,7 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
   // to bootstrap if the graph somehow becomes uninitialised.
   if (last_is_charging_valid_ && last_is_charging_)
   {
+    commit_current_gnss_evidence();
     // On the dock the dock_pose is authoritative ground truth — the dock does
     // not move. The previous approach injected a WEAK live-GPS factor here for
     // well-posedness, but a ~7 Hz stream of σ≈0.5 m factors at the live RTK
@@ -416,6 +476,7 @@ void FusionGraphNode::OnGnss(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg)
                          "fusion_graph: GNSS epoch node left the live graph; sample dropped");
     return;
   }
+  commit_current_gnss_evidence();
   // Latch whether the most recent seed came from RTK-Fixed so the next
   // graph initialization can use a tight prior matching that quality.
   // Stale once seeded but TrySeedInitialPose only fires once per

--- a/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_b.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_b.cpp
@@ -24,6 +24,18 @@
 namespace fusion_graph
 {
 
+bool FusionGraphNode::RtkFixedReceiptIsFresh(const double maximum_age_s) const
+{
+  if (!last_rtk_fixed_stamp_ || !std::isfinite(maximum_age_s) || maximum_age_s < 0.0)
+  {
+    return false;
+  }
+  const auto maximum_age_ns = static_cast<std::int64_t>(maximum_age_s * 1.0e9);
+  const rclcpp::Time ros_now = this->now();
+  return mowgli_interfaces::gnss_observation_freshness::IsReceiptFresh(
+      last_rtk_fixed_stamp_->nanoseconds(), ros_now.nanoseconds(), maximum_age_ns);
+}
+
 void FusionGraphNode::OnDockingCmd(geometry_msgs::msg::TwistStamped::ConstSharedPtr msg)
 {
   // Stamp only NON-ZERO docking commands — the graceful controller emits ~0
@@ -60,8 +72,7 @@ void FusionGraphNode::OnCogHeading(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   // balloons → lever-arm amplifies jitter into position jumps → robot drives
   // out of bounds). Apply it only when RTK-Fixed AND translating forward; else
   // the gyro carries yaw. Before init the seed always needs it.
-  const bool rtk_fresh = last_rtk_fixed_stamp_ &&
-                         (this->now() - *last_rtk_fixed_stamp_).seconds() < cog_rtk_max_age_s_;
+  const bool rtk_fresh = RtkFixedReceiptIsFresh(cog_rtk_max_age_s_);
   if (!CogShouldApply(
           graph_->IsInitialized(), rtk_fresh, wheel_vx_, cog_require_rtk_, cog_min_speed_mps_))
   {
@@ -88,10 +99,7 @@ void FusionGraphNode::OnCogHeading(sensor_msgs::msg::Imu::ConstSharedPtr msg)
     // (RTK-Fixed fresh). With cog_to_imu's straight-baseline gate the COGs
     // that arrive are already clean; requiring RTK-Fixed avoids snapping the
     // yaw onto a Float-era COG.
-    const bool rtk_fresh =
-        !cog_flip_require_rtk_ ||
-        (last_rtk_fixed_stamp_ &&
-         (this->now() - *last_rtk_fixed_stamp_).seconds() < scan_yield_timeout_s_);
+    const bool rtk_fresh = !cog_flip_require_rtk_ || RtkFixedReceiptIsFresh(scan_yield_timeout_s_);
     auto snap = graph_->LatestSnapshot();
     if (!rtk_fresh || !snap)
     {

--- a/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
@@ -18,6 +18,7 @@
 
 #include "fusion_graph/fusion_graph_node.hpp"
 #include "fusion_graph/fusion_graph_node_util.hpp"
+#include "fusion_graph/rtk_wrongfix_gate.hpp"
 
 namespace fusion_graph
 {
@@ -243,6 +244,12 @@ void FusionGraphNode::SetupCommunications(double node_period_s)
         seed_xy_.reset();
         seed_yaw_.reset();
         seed_xy_rtk_fixed_ = false;
+        gnss_observation_tracker_.Reset();
+        last_rtk_fixed_stamp_.reset();
+        rtk_fixed_streak_ = 0;
+        last_gps_sigma_ = -1.0;
+        last_gps_map_xy_.reset();
+        ResetRtkWrongFixAccumulators(wheel_dist_since_last_gps_m_, abs_dtheta_since_last_gps_rad_);
         // Re-zero the dead-reckoning frame. Without this the odom→base
         // transform keeps whatever offset it had accumulated (observed
         // 74 m), so map→odom = graph_pose ∘ dr⁻¹ still has the huge

--- a/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
@@ -146,8 +146,7 @@ void FusionGraphNode::OnTimer()
       // scan-matching carries dead-reckoning through the no-fix window.
       double sm_sigma_xy = res.sigma_xy;
       double sm_sigma_theta = res.sigma_theta;
-      if (scan_yield_to_rtk_ && last_rtk_fixed_stamp_ &&
-          (this->now() - *last_rtk_fixed_stamp_).seconds() < scan_yield_timeout_s_)
+      if (scan_yield_to_rtk_ && RtkFixedReceiptIsFresh(scan_yield_timeout_s_))
       {
         sm_sigma_xy = std::max(sm_sigma_xy, scan_yield_sigma_xy_);
         sm_sigma_theta = std::max(sm_sigma_theta, scan_yield_sigma_theta_);
@@ -184,8 +183,7 @@ void FusionGraphNode::OnTimer()
   // direction locked by test_factors.cpp::ScanToKeyframeComposition.
   if (use_keyframe_map_ && scan_matcher_ && curr_valid)
   {
-    const bool rtk_recent = last_rtk_fixed_stamp_ &&
-                            (this->now() - *last_rtk_fixed_stamp_).seconds() < kf_engage_age_s_;
+    const bool rtk_recent = RtkFixedReceiptIsFresh(kf_engage_age_s_);
     if (!rtk_recent)
     {
       if (auto cur = graph_->LatestSnapshot())
@@ -317,8 +315,7 @@ void FusionGraphNode::OnTimer()
     // above (Float) never both fire.
     if (use_keyframe_map_ && curr_valid && curr_scan.size() >= 10)
     {
-      const bool rtk_fresh =
-          last_rtk_fixed_stamp_ && (this->now() - *last_rtk_fixed_stamp_).seconds() < 1.0;
+      const bool rtk_fresh = RtkFixedReceiptIsFresh(1.0);
       const bool moved = !last_kf_capture_xy_ ||
                          std::hypot(out->pose.x() - last_kf_capture_xy_->x(),
                                     out->pose.y() - last_kf_capture_xy_->y()) >= kf_spacing_m_;
@@ -341,10 +338,8 @@ void FusionGraphNode::OnTimer()
     // ~no information — an unbounded leak over a long stationary dwell that
     // OOM-killed the node 2026-06-09. Re-enables once the fix is stale past
     // scan_yield_timeout_s so LC still carries the no-fix (tree-cover) windows.
-    const bool rtk_fixed_fresh =
-        last_rtk_fixed_stamp_ &&
-        (this->now() - *last_rtk_fixed_stamp_).seconds() < scan_yield_timeout_s_;
-    //
+    const bool rtk_fixed_fresh = RtkFixedReceiptIsFresh(scan_yield_timeout_s_);
+
     // Rate/travel gate (issue #513): with LC enabled exactly when GPS is Float
     // or absent, the unbounded search accepted 13.7 LC/s on featureless grass
     // (3816 in 286 s of mowing), each a 5 cm factor snapping to the adjacent
@@ -354,16 +349,20 @@ void FusionGraphNode::OnTimer()
     // loop_closure_gate.hpp for why that polarity is right here.
     const bool lc_search_enabled = loop_closure_enabled_ && scan_matcher_ && curr_valid &&
                                    !(lc_skip_when_rtk_fixed_ && rtk_fixed_fresh);
+
     const double time_since_lc_s = last_lc_accept_stamp_
                                        ? (this->now() - *last_lc_accept_stamp_).seconds()
                                        : std::numeric_limits<double>::infinity();
+
     const bool lc_gate_open =
         lc_search_enabled && LoopClosureRateAllows(wheel_dist_since_last_lc_m_,
                                                    time_since_lc_s,
                                                    lc_min_travel_m_,
                                                    lc_min_interval_s_);
+
     if (lc_search_enabled && !lc_gate_open)
       ++lc_rate_gated_;
+
     if (lc_gate_open)
     {
       auto candidates = graph_->FindLoopClosureCandidates(out->node_index,
@@ -412,8 +411,7 @@ void FusionGraphNode::OnTimer()
         // no-fix (tree-cover) windows.
         double lc_sigma_xy = lc_sigma_xy_;
         double lc_sigma_theta = lc_sigma_theta_;
-        if (scan_yield_to_rtk_ && last_rtk_fixed_stamp_ &&
-            (this->now() - *last_rtk_fixed_stamp_).seconds() < scan_yield_timeout_s_)
+        if (scan_yield_to_rtk_ && RtkFixedReceiptIsFresh(scan_yield_timeout_s_))
         {
           lc_sigma_xy = std::max(lc_sigma_xy, scan_yield_sigma_xy_);
           lc_sigma_theta = std::max(lc_sigma_theta, scan_yield_sigma_theta_);

--- a/ros2/src/fusion_graph/test/test_gnss_observation_freshness.cpp
+++ b/ros2/src/fusion_graph/test/test_gnss_observation_freshness.cpp
@@ -1,0 +1,127 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <cstdint>
+
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
+#include <gtest/gtest.h>
+
+namespace gnss = mowgli_interfaces::gnss_observation_freshness;
+
+namespace
+{
+
+constexpr std::int64_t kSecond = 1000000000LL;
+
+bool IsAcceptedEvidence(const gnss::ObservationUpdate update)
+{
+  return update == gnss::ObservationUpdate::kNewObservation ||
+         update == gnss::ObservationUpdate::kSourceRestart;
+}
+
+TEST(GnssObservationFreshness, SequencePreservesCachedAndIdenticalObservationSemantics)
+{
+  gnss::ObservationTracker tracker;
+
+  EXPECT_EQ(tracker.Observe(10, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(10, 100 * kSecond, 101 * kSecond, 2 * kSecond),
+            gnss::ObservationUpdate::kCachedPublication);
+
+  // Numerically identical observations can share every payload value. A new
+  // upstream sequence remains distinct even if ROS time is paused.
+  EXPECT_EQ(tracker.Observe(11, 100 * kSecond, 101 * kSecond, 3 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.last_sequence(), 11U);
+}
+
+TEST(GnssObservationFreshness, ReceiptOnlyGatePreventsDuplicateFactorsAndLatchRefresh)
+{
+  gnss::ObservationTracker tracker;
+  int factor_submissions = 0;
+  int rtk_streak = 0;
+  std::int64_t last_rtk_receipt_ns = 0;
+
+  const auto feed_fixed = [&](const std::int64_t receipt_ns,
+                              const std::int64_t ros_now_ns,
+                              const std::int64_t delivery_ns)
+  {
+    const auto update = tracker.Observe(0, receipt_ns, ros_now_ns, delivery_ns);
+    if (IsAcceptedEvidence(update))
+    {
+      ++factor_submissions;
+      ++rtk_streak;
+      last_rtk_receipt_ns = receipt_ns;
+    }
+    return update;
+  };
+
+  EXPECT_EQ(feed_fixed(10 * kSecond, 10 * kSecond, 1 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(feed_fixed(10 * kSecond, 11 * kSecond, 2 * kSecond),
+            gnss::ObservationUpdate::kCachedPublication);
+  EXPECT_EQ(feed_fixed(10 * kSecond, 12 * kSecond, 3 * kSecond),
+            gnss::ObservationUpdate::kCachedPublication);
+  EXPECT_EQ(factor_submissions, 1);
+  EXPECT_EQ(rtk_streak, 1);
+  EXPECT_EQ(last_rtk_receipt_ns, 10 * kSecond);
+
+  // Same coordinates are deliberately absent from the identity decision. A
+  // new receiver-receipt stamp is accepted normally.
+  EXPECT_EQ(feed_fixed(13 * kSecond, 13 * kSecond, 4 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(factor_submissions, 2);
+  EXPECT_EQ(rtk_streak, 2);
+  EXPECT_EQ(last_rtk_receipt_ns, 13 * kSecond);
+
+  // A delayed duplicate cannot refresh latches or submit another factor.
+  EXPECT_EQ(feed_fixed(10 * kSecond, 14 * kSecond, 5 * kSecond),
+            gnss::ObservationUpdate::kOutOfOrder);
+  EXPECT_EQ(factor_submissions, 2);
+  EXPECT_EQ(rtk_streak, 2);
+  EXPECT_EQ(last_rtk_receipt_ns, 13 * kSecond);
+}
+
+TEST(GnssObservationFreshness, DeliveryLivenessCannotRefreshObservationFreshness)
+{
+  gnss::ObservationTracker tracker;
+  ASSERT_TRUE(IsAcceptedEvidence(tracker.Observe(25, 10 * kSecond, 10 * kSecond, 1 * kSecond)));
+
+  EXPECT_EQ(tracker.Observe(25, 10 * kSecond, 20 * kSecond, 5 * kSecond),
+            gnss::ObservationUpdate::kCachedPublication);
+  EXPECT_FALSE(tracker.ObservationIsFresh(20 * kSecond, 2 * kSecond));
+  EXPECT_TRUE(tracker.DeliveryIsLive(6 * kSecond, 2 * kSecond));
+  EXPECT_FALSE(tracker.DeliveryIsLive(8 * kSecond, 2 * kSecond));
+}
+
+TEST(GnssObservationFreshness, ClockRewindAndFutureProvenanceFailClosed)
+{
+  gnss::ObservationTracker tracker;
+  ASSERT_TRUE(IsAcceptedEvidence(tracker.Observe(0, 100 * kSecond, 100 * kSecond, 1 * kSecond)));
+
+  EXPECT_EQ(tracker.Observe(0, 5 * kSecond, 5 * kSecond, 2 * kSecond),
+            gnss::ObservationUpdate::kRosTimeDiscontinuity);
+  EXPECT_FALSE(tracker.ObservationIsFresh(5 * kSecond, 2 * kSecond));
+
+  // Cached data from the old clock epoch is now future provenance.
+  EXPECT_EQ(tracker.Observe(0, 100 * kSecond, 5 * kSecond, 3 * kSecond),
+            gnss::ObservationUpdate::kInvalidProvenance);
+  EXPECT_FALSE(tracker.ObservationIsFresh(5 * kSecond, 2 * kSecond));
+
+  EXPECT_EQ(tracker.Observe(0, 6 * kSecond, 6 * kSecond, 4 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_FALSE(tracker.ObservationIsFresh(5 * kSecond, 2 * kSecond));
+  EXPECT_TRUE(tracker.ObservationIsFresh(6 * kSecond, 2 * kSecond));
+}
+
+TEST(GnssObservationFreshness, LaterReceiptWithResetSequenceStartsNewSourceEpoch)
+{
+  gnss::ObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(50, 50 * kSecond, 50 * kSecond, 1 * kSecond),
+            gnss::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(1, 51 * kSecond, 51 * kSecond, 2 * kSecond),
+            gnss::ObservationUpdate::kSourceRestart);
+  EXPECT_EQ(tracker.last_sequence(), 1U);
+}
+
+}  // namespace

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -478,6 +478,7 @@ if(BUILD_TESTING)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
+  ament_target_dependencies(test_localization_health mowgli_interfaces)
 
   # ---- test_battery_critical_resume ----
   # Regression for "robot stuck after a critical-battery charge": the

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/localization_health.hpp
@@ -175,6 +175,13 @@ public:
     return latched_;
   }
 
+  void ForceLatched()
+  {
+    latched_ = true;
+    bad_since_s_ = -1.0;
+    good_since_s_ = -1.0;
+  }
+
   /// Seconds the pending (not yet flipped) condition has been held, or 0.
   double pending_for_s(double now_s) const
   {
@@ -195,8 +202,10 @@ struct LocalizationObservation
   /// True once ANY /gps/status has been received. While false the monitor
   /// stays inert — see LocalizationHealthMonitor::Update.
   bool gnss_seen = false;
-  /// Clock reading when the most recent /gps/status arrived [s].
-  double gnss_stamp_s = 0.0;
+  /// True only while the last genuinely new receiver observation satisfies
+  /// the shared receipt-provenance and monotonic-age policy. Cached ROS
+  /// republication never changes this value.
+  bool gnss_fresh = false;
   RtkMode rtk_mode = RtkMode::kUnknown;
   /// Receiver-reported horizontal accuracy [m]; negative when unavailable
   /// (capability bit clear, or NaN in the message).
@@ -227,7 +236,7 @@ public:
       return false;
     }
 
-    const bool stale = (now_s - obs.gnss_stamp_s) > cfg_.gnss_stale_s;
+    const bool stale = !obs.gnss_fresh;
     const bool has_acc = obs.gnss_accuracy_m >= 0.0 && std::isfinite(obs.gnss_accuracy_m);
     // Prefer the metric signal. rtk_mode only decides when the receiver does
     // not report an accuracy at all — otherwise a receiver that leaves
@@ -257,8 +266,21 @@ public:
     }
 
     const bool was_gnss = gnss_latch_.latched();
-    const bool gnss_degraded = gnss_latch_.Update(
-        now_s, gnss_bad, gnss_good, cfg_.gnss_pause_persist_s, cfg_.gnss_resume_persist_s);
+    bool gnss_degraded = false;
+    if (stale)
+    {
+      // Observation freshness is an authorization boundary, not receiver
+      // quality flicker. Once the existing provenance timeout has elapsed,
+      // fail closed immediately; retain the configured resume persistence for
+      // a later genuine observation.
+      gnss_latch_.ForceLatched();
+      gnss_degraded = true;
+    }
+    else
+    {
+      gnss_degraded = gnss_latch_.Update(
+          now_s, gnss_bad, gnss_good, cfg_.gnss_pause_persist_s, cfg_.gnss_resume_persist_s);
+    }
 
     // Divergence backstop. Disabled at 0, and skipped when σ is unavailable
     // so a missing covariance never latches on its own.
@@ -297,6 +319,10 @@ public:
   LocalizationFault fault() const
   {
     return fault_;
+  }
+  double gnss_stale_s() const
+  {
+    return cfg_.gnss_stale_s;
   }
 
 private:

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -37,6 +37,7 @@
 #include "mowgli_behavior/localization_health.hpp"
 #include "mowgli_behavior/recording_nodes.hpp"
 #include "mowgli_behavior/status_snapshot.hpp"
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include "mowgli_interfaces/gnss_status_utils.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
 #include "mowgli_interfaces/msg/emergency.hpp"
@@ -431,17 +432,37 @@ private:
         {
           std::lock_guard<std::mutex> lock(context_->context_mutex);
           has_authoritative_gnss_status_ = true;
+          loc_obs_.gnss_seen = true;
+
+          const rclcpp::Time ros_now = now();
+          const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
+          const auto observation_update =
+              gnss_observation_freshness_.Observe(msg->position_observation_sequence,
+                                                  receipt_stamp.nanoseconds(),
+                                                  ros_now.nanoseconds(),
+                                                  steadyNowNs());
+          using mowgli_interfaces::gnss_observation_freshness::IsAcceptedObservation;
+          using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
+          if (!IsAcceptedObservation(observation_update))
+          {
+            if (observation_update == ObservationUpdate::kInvalidProvenance)
+            {
+              RCLCPP_WARN_THROTTLE(get_logger(),
+                                   *get_clock(),
+                                   5000,
+                                   "behavior: GNSS receipt stamp is zero/future; authority denied");
+            }
+            updateLocalizationHealthLocked();
+            return;
+          }
 
           // LocalizationGuard feed: the receiver's own view of solution
           // quality. horizontal_accuracy_m is only trusted when the message's
           // value_flags say it carries a live value; otherwise rtk_mode
           // decides (see LocalizationHealthMonitor::Update).
-          loc_obs_.gnss_seen = true;
-          loc_obs_.gnss_stamp_s = get_clock()->now().seconds();
           loc_obs_.rtk_mode = static_cast<mowgli_behavior::RtkMode>(msg->rtk_mode);
           const auto acc = mowgli_interfaces::gnss_status_utils::HorizontalAccuracyMeters(*msg);
           loc_obs_.gnss_accuracy_m = acc ? static_cast<double>(*acc) : -1.0;
-          updateLocalizationHealthLocked();
 
           context_->gps_fix_type = mowgli_interfaces::gnss_status_utils::BehaviorTreeFixType(*msg);
           context_->gps_quality = mowgli_interfaces::gnss_status_utils::NormalizedQuality(*msg);
@@ -451,7 +472,7 @@ private:
           // /gps/status contract rather than /gps/absolute_pose covariance.
           constexpr double kGpsFixDebounceSec = 2.0;
           const bool raw_fixed = mowgli_interfaces::gnss_status_utils::BehaviorTreeRtkFixed(*msg);
-          const rclcpp::Time gps_now = this->now();
+          const rclcpp::Time gps_now = ros_now;
           if (!gps_fix_debounce_init_)
           {
             gps_fix_debounce_init_ = true;
@@ -471,6 +492,7 @@ private:
               context_->gps_is_fixed = gps_fix_candidate_;
             }
           }
+          updateLocalizationHealthLocked();
         });
 
     // collision_monitor state — used by IsObstacleStuck to detect when
@@ -657,7 +679,29 @@ private:
   // loc_obs_, so the monitor sees a consistent snapshot.
   void updateLocalizationHealthLocked()
   {
-    const double now_s = get_clock()->now().seconds();
+    const rclcpp::Time ros_now = now();
+    const auto maximum_age_ns = static_cast<std::int64_t>(loc_monitor_.gnss_stale_s() * 1.0e9);
+    loc_obs_.gnss_fresh = gnss_observation_freshness_.ObservationIsFresh(ros_now.nanoseconds(),
+                                                                         steadyNowNs(),
+                                                                         maximum_age_ns);
+    if (gnss_observation_freshness_.ConsumeEpochReset())
+    {
+      // Force a fresh semantic epoch: old debounce state must not survive a
+      // ROS/steady rewind and become authoritative when the clock catches up.
+      gps_fix_debounce_init_ = false;
+    }
+    if (loc_obs_.gnss_seen && !loc_obs_.gnss_fresh)
+    {
+      // Fixed-only behavior must fail closed at the physical-observation
+      // deadline even though LocalizationHealth keeps its existing latch
+      // persistence before pausing the whole mowing tree.
+      context_->gps_fix_type = 0;
+      context_->gps_quality = 0.0f;
+      context_->gps_is_fixed = false;
+      gps_fix_debounce_init_ = false;
+    }
+
+    const double now_s = ros_now.seconds();
     const bool was_degraded = context_->localization_degraded;
     const bool degraded = loc_monitor_.Update(now_s, loc_obs_);
     if (degraded == was_degraded)
@@ -997,6 +1041,11 @@ private:
 
   void tickTree()
   {
+    {
+      std::lock_guard<std::mutex> lock(context_->context_mutex);
+      updateLocalizationHealthLocked();
+    }
+
     // Apply a pending "Start fresh" clear BEFORE ticking, on the tick thread —
     // every coverage-map mutation stays on this thread (see the service
     // registration comment). Between ticks no BT node holds a reference into
@@ -1054,6 +1103,13 @@ private:
   rclcpp::Time gps_fix_candidate_since_;
   bool has_authoritative_gnss_status_{false};
 
+  static std::int64_t steadyNowNs()
+  {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+  }
+
   // Subscribers
   rclcpp::Subscription<mowgli_interfaces::msg::Status>::SharedPtr status_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::Emergency>::SharedPtr emergency_sub_;
@@ -1068,6 +1124,8 @@ private:
   // context_->context_mutex and then call updateLocalizationHealthLocked().
   LocalizationHealthMonitor loc_monitor_{};
   LocalizationObservation loc_obs_{};
+  mowgli_interfaces::gnss_observation_freshness::PhysicalObservationTracker
+      gnss_observation_freshness_;
   rclcpp::Subscription<mowgli_interfaces::msg::AbsolutePose>::SharedPtr gps_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::GnssStatus>::SharedPtr gnss_status_sub_;
   rclcpp::Subscription<nav2_msgs::msg::CollisionMonitorState>::SharedPtr collision_monitor_sub_;

--- a/ros2/src/mowgli_behavior/test/test_localization_health.cpp
+++ b/ros2/src/mowgli_behavior/test/test_localization_health.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "mowgli_behavior/localization_health.hpp"
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include <gtest/gtest.h>
 
 namespace
@@ -36,13 +37,24 @@ using mowgli_behavior::LocalizationHealthMonitor;
 using mowgli_behavior::LocalizationObservation;
 using mowgli_behavior::PersistentLatch;
 using mowgli_behavior::RtkMode;
+namespace freshness = mowgli_interfaces::gnss_observation_freshness;
+
+constexpr std::int64_t kSecond = 1000000000LL;
+
+LocalizationHealthCfg ImmediateHealthCfg()
+{
+  LocalizationHealthCfg cfg;
+  cfg.gnss_pause_persist_s = 0.0;
+  cfg.gnss_resume_persist_s = 0.0;
+  return cfg;
+}
 
 // A healthy RTK-Fixed epoch, as the live robot reports it.
-LocalizationObservation HealthyFix(double now_s, double sigma_xy = 0.05)
+LocalizationObservation HealthyFix(double sigma_xy = 0.05)
 {
   LocalizationObservation obs;
   obs.gnss_seen = true;
-  obs.gnss_stamp_s = now_s;
+  obs.gnss_fresh = true;
   obs.rtk_mode = RtkMode::kFixed;
   obs.gnss_accuracy_m = 0.014;
   obs.fused_sigma_xy_m = sigma_xy;
@@ -57,7 +69,7 @@ bool RunFor(LocalizationHealthMonitor* mon, double start_s, double duration_s, M
   bool ever = false;
   for (double t = start_s; t <= start_s + duration_s; t += 0.2)
   {
-    if (mon->Update(t, make(t)))
+    if (mon->Update(t, make()))
       ever = true;
   }
   return ever;
@@ -82,9 +94,9 @@ TEST(LocalizationHealthTest, PivotCovarianceSpikeDoesNotDegrade)
     if (RunFor(&mon,
                t,
                15.0,
-               [sigma](double now)
+               [sigma]()
                {
-                 return HealthyFix(now, sigma);
+                 return HealthyFix(sigma);
                }))
       ever_degraded = true;
     t += 15.2;
@@ -105,20 +117,20 @@ TEST(LocalizationHealthTest, PlainGpsFallbackStillDegrades)
   ASSERT_FALSE(RunFor(&mon,
                       0.0,
                       10.0,
-                      [](double now)
+                      []()
                       {
-                        return HealthyFix(now);
+                        return HealthyFix();
                       }));
 
   // 2026-08-02: RTK -> plain GPS, sigma ~1.5 m, for >60 s.
   const bool degraded = RunFor(&mon,
                                20.0,
                                60.0,
-                               [](double now)
+                               []()
                                {
                                  LocalizationObservation obs;
                                  obs.gnss_seen = true;
-                                 obs.gnss_stamp_s = now;
+                                 obs.gnss_fresh = true;
                                  obs.rtk_mode = RtkMode::kNone;
                                  obs.gnss_accuracy_m = 1.5;
                                  obs.fused_sigma_xy_m = 1.5;
@@ -137,11 +149,11 @@ TEST(LocalizationHealthTest, RecoveryReleasesTheLatch)
   ASSERT_TRUE(RunFor(&mon,
                      0.0,
                      30.0,
-                     [](double now)
+                     []()
                      {
                        LocalizationObservation obs;
                        obs.gnss_seen = true;
-                       obs.gnss_stamp_s = now;
+                       obs.gnss_fresh = true;
                        obs.rtk_mode = RtkMode::kNone;
                        obs.gnss_accuracy_m = 1.5;
                        return obs;
@@ -151,9 +163,9 @@ TEST(LocalizationHealthTest, RecoveryReleasesTheLatch)
   RunFor(&mon,
          40.0,
          10.0,
-         [](double now)
+         []()
          {
-           return HealthyFix(now);
+           return HealthyFix();
          });
   EXPECT_FALSE(mon.degraded());
   EXPECT_EQ(mon.fault(), LocalizationFault::kNone);
@@ -169,11 +181,11 @@ TEST(LocalizationHealthTest, BriefAccuracyExcursionDoesNotFlipTheLatch)
   const bool degraded = RunFor(&mon,
                                0.0,
                                2.0,
-                               [](double now)
+                               []()
                                {
                                  LocalizationObservation obs;
                                  obs.gnss_seen = true;
-                                 obs.gnss_stamp_s = now;
+                                 obs.gnss_fresh = true;
                                  obs.rtk_mode = RtkMode::kFloat;
                                  obs.gnss_accuracy_m = 0.9;
                                  return obs;
@@ -189,11 +201,11 @@ TEST(LocalizationHealthTest, DeadBandHoldsTheLatchUntilAccuracyClearsResume)
   ASSERT_TRUE(RunFor(&mon,
                      0.0,
                      30.0,
-                     [](double now)
+                     []()
                      {
                        LocalizationObservation obs;
                        obs.gnss_seen = true;
-                       obs.gnss_stamp_s = now;
+                       obs.gnss_fresh = true;
                        obs.rtk_mode = RtkMode::kFloat;
                        obs.gnss_accuracy_m = 1.2;
                        return obs;
@@ -203,11 +215,11 @@ TEST(LocalizationHealthTest, DeadBandHoldsTheLatchUntilAccuracyClearsResume)
   RunFor(&mon,
          40.0,
          30.0,
-         [](double now)
+         []()
          {
            LocalizationObservation obs;
            obs.gnss_seen = true;
-           obs.gnss_stamp_s = now;
+           obs.gnss_fresh = true;
            obs.rtk_mode = RtkMode::kFloat;
            obs.gnss_accuracy_m = 0.20;
            return obs;
@@ -223,19 +235,84 @@ TEST(LocalizationHealthTest, StaleGnssFeedDegrades)
   ASSERT_FALSE(RunFor(&mon,
                       0.0,
                       10.0,
-                      [](double now)
+                      []()
                       {
-                        return HealthyFix(now);
+                        return HealthyFix();
                       }));
 
   // /gps/status stops at t=10; clock keeps running.
-  LocalizationObservation frozen = HealthyFix(10.0);
+  LocalizationObservation frozen = HealthyFix();
   bool degraded = false;
   for (double t = 10.0; t <= 30.0; t += 0.2)
+  {
+    frozen.gnss_fresh = t <= 15.0;
     degraded = mon.Update(t, frozen);
+  }
 
   EXPECT_TRUE(degraded);
   EXPECT_EQ(mon.fault(), LocalizationFault::kGnssStale);
+}
+
+TEST(LocalizationHealthFreshnessTest, GenuineFixedObservationAuthorizesHealth)
+{
+  freshness::PhysicalObservationTracker tracker;
+  LocalizationHealthMonitor mon{ImmediateHealthCfg()};
+  auto obs = HealthyFix();
+
+  ASSERT_EQ(tracker.Observe(1, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  obs.gnss_fresh = tracker.ObservationIsFresh(100 * kSecond, 1 * kSecond, 5 * kSecond);
+
+  EXPECT_FALSE(mon.Update(100.0, obs));
+  EXPECT_EQ(mon.fault(), LocalizationFault::kNone);
+}
+
+TEST(LocalizationHealthFreshnessTest, CachedFixedCallbacksCannotExtendDeadline)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+
+  for (std::int64_t second = 101; second <= 106; ++second)
+  {
+    EXPECT_EQ(tracker.Observe(1, 100 * kSecond, second * kSecond, (second - 99) * kSecond),
+              freshness::ObservationUpdate::kCachedPublication);
+  }
+
+  EXPECT_FALSE(tracker.ObservationIsFresh(106 * kSecond, 7 * kSecond, 5 * kSecond));
+  EXPECT_TRUE(tracker.DeliveryIsLive(7 * kSecond, 1 * kSecond));
+}
+
+TEST(LocalizationHealthFreshnessTest, CachedFixedBecomesGnssStaleAfterTimeout)
+{
+  freshness::PhysicalObservationTracker tracker;
+  LocalizationHealthMonitor mon{LocalizationHealthCfg{}};
+  auto obs = HealthyFix();
+  ASSERT_EQ(tracker.Observe(4, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(4, 100 * kSecond, 106 * kSecond, 7 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+
+  obs.gnss_fresh = tracker.ObservationIsFresh(106 * kSecond, 7 * kSecond, 5 * kSecond);
+  EXPECT_TRUE(mon.Update(106.0, obs));
+  EXPECT_EQ(mon.fault(), LocalizationFault::kGnssStale);
+}
+
+TEST(LocalizationHealthFreshnessTest, GenuineFixedAfterTimeoutRestoresHealth)
+{
+  freshness::PhysicalObservationTracker tracker;
+  LocalizationHealthMonitor mon{ImmediateHealthCfg()};
+  auto obs = HealthyFix();
+  ASSERT_EQ(tracker.Observe(8, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  obs.gnss_fresh = tracker.ObservationIsFresh(106 * kSecond, 7 * kSecond, 5 * kSecond);
+  ASSERT_TRUE(mon.Update(106.0, obs));
+
+  ASSERT_EQ(tracker.Observe(9, 106 * kSecond, 106 * kSecond, 7 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  obs.gnss_fresh = tracker.ObservationIsFresh(106 * kSecond, 7 * kSecond, 5 * kSecond);
+  EXPECT_FALSE(mon.Update(106.0, obs));
+  EXPECT_EQ(mon.fault(), LocalizationFault::kNone);
 }
 
 TEST(LocalizationHealthTest, MonitorIsInertBeforeAnyGnssStatus)
@@ -263,11 +340,11 @@ TEST(LocalizationHealthTest, MissingAccuracyFallsBackToRtkMode)
   ASSERT_FALSE(RunFor(&mon,
                       0.0,
                       20.0,
-                      [](double now)
+                      []()
                       {
                         LocalizationObservation obs;
                         obs.gnss_seen = true;
-                        obs.gnss_stamp_s = now;
+                        obs.gnss_fresh = true;
                         obs.rtk_mode = RtkMode::kFloat;
                         obs.gnss_accuracy_m = -1.0;
                         return obs;
@@ -277,11 +354,11 @@ TEST(LocalizationHealthTest, MissingAccuracyFallsBackToRtkMode)
   const bool degraded = RunFor(&mon,
                                30.0,
                                20.0,
-                               [](double now)
+                               []()
                                {
                                  LocalizationObservation obs;
                                  obs.gnss_seen = true;
-                                 obs.gnss_stamp_s = now;
+                                 obs.gnss_fresh = true;
                                  obs.rtk_mode = RtkMode::kNone;
                                  obs.gnss_accuracy_m = -1.0;
                                  return obs;
@@ -298,11 +375,11 @@ TEST(LocalizationHealthTest, GoodAccuracyOutranksUnknownRtkMode)
   const bool degraded = RunFor(&mon,
                                0.0,
                                60.0,
-                               [](double now)
+                               []()
                                {
                                  LocalizationObservation obs;
                                  obs.gnss_seen = true;
-                                 obs.gnss_stamp_s = now;
+                                 obs.gnss_fresh = true;
                                  obs.rtk_mode = RtkMode::kUnknown;
                                  obs.gnss_accuracy_m = 0.014;
                                  return obs;
@@ -321,9 +398,9 @@ TEST(LocalizationHealthTest, SigmaBackstopCatchesLocalizerDivergence)
   const bool degraded = RunFor(&mon,
                                0.0,
                                30.0,
-                               [](double now)
+                               []()
                                {
-                                 return HealthyFix(now, 8.0);
+                                 return HealthyFix(8.0);
                                });
 
   EXPECT_TRUE(degraded);
@@ -339,9 +416,9 @@ TEST(LocalizationHealthTest, SigmaBackstopSitsAboveThePivotInflationCeiling)
   const bool degraded = RunFor(&mon,
                                0.0,
                                120.0,
-                               [](double now)
+                               []()
                                {
-                                 return HealthyFix(now, 2.35);
+                                 return HealthyFix(2.35);
                                });
 
   EXPECT_FALSE(degraded);
@@ -356,9 +433,9 @@ TEST(LocalizationHealthTest, SigmaBackstopDisabledAtZero)
   const bool degraded = RunFor(&mon,
                                0.0,
                                120.0,
-                               [](double now)
+                               []()
                                {
-                                 return HealthyFix(now, 40.0);
+                                 return HealthyFix(40.0);
                                });
   EXPECT_FALSE(degraded);
 }
@@ -370,9 +447,9 @@ TEST(LocalizationHealthTest, MissingSigmaNeverLatchesTheBackstop)
   const bool degraded = RunFor(&mon,
                                0.0,
                                120.0,
-                               [](double now)
+                               []()
                                {
-                                 return HealthyFix(now, -1.0);
+                                 return HealthyFix(-1.0);
                                });
   EXPECT_FALSE(degraded);
 }

--- a/ros2/src/mowgli_hardware/CMakeLists.txt
+++ b/ros2/src/mowgli_hardware/CMakeLists.txt
@@ -161,6 +161,7 @@ if(BUILD_TESTING)
     PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   )
+  ament_target_dependencies(test_dig_detector mowgli_interfaces)
 
   # ---- test_imu_liveness ----
   # Header-only pure logic (imu_liveness.hpp): no link against

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/gnss_hardware_status.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/gnss_hardware_status.hpp
@@ -1,0 +1,21 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <cstdint>
+
+namespace mowgli_hardware
+{
+
+// The STM32's existing no-current-GNSS indication is quality zero: firmware
+// turns PANEL_LED_LOCK off below 90. Preserve every fresh quality mapping and
+// only substitute that established safe value when physical provenance ages
+// out.
+inline std::uint8_t GnssQualityForFirmware(const bool observation_fresh,
+                                           const std::uint8_t quality_percent)
+{
+  return observation_fresh ? quality_percent : 0U;
+}
+
+}  // namespace mowgli_hardware

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -63,6 +63,7 @@
 #include "mowgli_hardware/blade_gate.hpp"
 #include "mowgli_hardware/clock_fit.hpp"
 #include "mowgli_hardware/dig_detector.hpp"
+#include "mowgli_hardware/gnss_hardware_status.hpp"
 #include "mowgli_hardware/imu_liveness.hpp"
 #include "mowgli_hardware/ll_datatypes.hpp"
 #include "mowgli_hardware/odometry_publisher.hpp"
@@ -119,6 +120,7 @@ static const char* high_level_mode_name(const uint8_t mode)
   }
 }
 
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include "mowgli_interfaces/gnss_status_utils.hpp"
 #include "mowgli_interfaces/msg/dig_event.hpp"
 #include "mowgli_interfaces/msg/emergency.hpp"
@@ -755,6 +757,27 @@ private:
         rclcpp::QoS(10),
         [this](mowgli_interfaces::msg::GnssStatus::ConstSharedPtr msg)
         {
+          const rclcpp::Time ros_now = now();
+          const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
+          const auto observation_update =
+              gnss_observation_freshness_.Observe(msg->position_observation_sequence,
+                                                  receipt_stamp.nanoseconds(),
+                                                  ros_now.nanoseconds(),
+                                                  steadyNowNs());
+          using mowgli_interfaces::gnss_observation_freshness::IsAcceptedObservation;
+          using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
+          if (!IsAcceptedObservation(observation_update))
+          {
+            if (observation_update == ObservationUpdate::kInvalidProvenance)
+            {
+              RCLCPP_WARN_THROTTLE(get_logger(),
+                                   *get_clock(),
+                                   5000,
+                                   "hardware: GNSS receipt stamp is zero/future; trust denied");
+            }
+            return;
+          }
+
           gps_quality_ = mowgli_interfaces::gnss_status_utils::HardwareQualityPercent(*msg);
 
           // Trust signal for the dig detector. The receiver's own accuracy
@@ -762,8 +785,6 @@ private:
           const auto acc = mowgli_interfaces::gnss_status_utils::HorizontalAccuracyMeters(*msg);
           dig_gnss_acc_m_ = acc ? static_cast<double>(*acc) : -1.0;
           dig_gnss_rtk_fixed_ = mowgli_interfaces::gnss_status_utils::BehaviorTreeRtkFixed(*msg);
-          dig_gnss_time_ = now();
-          have_dig_gnss_ = true;
         });
 
     // Mirror the behavior tree's high-level state to the firmware so it
@@ -2165,12 +2186,45 @@ private:
                     sizeof(LlHeartbeat) - sizeof(uint16_t));  // CRC appended by encode_packet.
   }
 
+  static std::int64_t steadyNowNs()
+  {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+  }
+
+  bool gnssObservationFresh()
+  {
+    const auto maximum_age_ns = static_cast<std::int64_t>(dig_gnss_timeout_s_ * 1.0e9);
+    const bool fresh = gnss_observation_freshness_.ObservationIsFresh(now().nanoseconds(),
+                                                                      steadyNowNs(),
+                                                                      maximum_age_ns);
+    if (!gnss_freshness_initialized_)
+    {
+      gnss_freshness_initialized_ = true;
+      last_gnss_observation_fresh_ = fresh;
+    }
+    else if (fresh != last_gnss_observation_fresh_)
+    {
+      last_gnss_observation_fresh_ = fresh;
+      if (fresh)
+      {
+        RCLCPP_INFO(get_logger(), "GNSS physical observation recovered; dig trust/lock restored");
+      }
+      else
+      {
+        RCLCPP_WARN(get_logger(), "GNSS physical observation stale; dig trust/lock cleared");
+      }
+    }
+    return fresh;
+  }
+
   void send_high_level_state()
   {
     LlHighLevelState pkt{};
     pkt.type = PACKET_ID_LL_HIGH_LEVEL_STATE;
     pkt.current_mode = current_mode_;
-    pkt.gps_quality = gps_quality_;
+    pkt.gps_quality = GnssQualityForFirmware(gnssObservationFresh(), gps_quality_);
 
     if (last_sent_mode_ != current_mode_ || last_sent_mode_state_name_ != current_mode_state_name_)
     {
@@ -2180,7 +2234,7 @@ private:
                   current_mode_,
                   high_level_mode_name(current_mode_),
                   current_mode_state_name_.c_str(),
-                  gps_quality_);
+                  pkt.gps_quality);
       last_sent_mode_ = current_mode_;
       last_sent_mode_state_name_ = current_mode_state_name_;
     }
@@ -2866,8 +2920,7 @@ private:
     const double yaw_rate =
         gyro_fresh ? last_gyro_yaw_rate_ : std::numeric_limits<double>::infinity();
 
-    const bool gnss_fresh =
-        have_dig_gnss_ && (tick_now - dig_gnss_time_).seconds() < dig_gnss_timeout_s_;
+    const bool gnss_fresh = gnssObservationFresh();
     const double trust_sigma =
         DigTrustSigma(gnss_fresh, dig_gnss_rtk_fixed_, dig_gnss_acc_m_ >= 0.0, dig_gnss_acc_m_);
 
@@ -3063,11 +3116,16 @@ private:
   /// Receiver-reported position quality, for the dig detector's trust gate.
   /// The factor graph's own marginal is NOT usable for this — see
   /// dig_detector.hpp.
-  bool have_dig_gnss_{false};
   bool dig_gnss_rtk_fixed_{false};
   double dig_gnss_acc_m_{-1.0};
-  rclcpp::Time dig_gnss_time_{0, 0, RCL_ROS_TIME};
+  /// Existing hardware GNSS trust timeout. It now governs both the dig trust
+  /// gate and the quality forwarded to the lock LED; only a genuinely new
+  /// receiver observation refreshes it.
   double dig_gnss_timeout_s_{2.0};
+  mowgli_interfaces::gnss_observation_freshness::PhysicalObservationTracker
+      gnss_observation_freshness_;
+  bool gnss_freshness_initialized_{false};
+  bool last_gnss_observation_fresh_{false};
 
   /// Calibrated gyro yaw rate, for the dig detector's turn exclusion. Gyro,
   /// never wheels — see dig_detector.hpp.

--- a/ros2/src/mowgli_hardware/test/test_dig_detector.cpp
+++ b/ros2/src/mowgli_hardware/test/test_dig_detector.cpp
@@ -7,12 +7,17 @@
 #include <limits>
 
 #include "mowgli_hardware/dig_detector.hpp"
+#include "mowgli_hardware/gnss_hardware_status.hpp"
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include <gtest/gtest.h>
 
 namespace mh = mowgli_hardware;
+namespace freshness = mowgli_interfaces::gnss_observation_freshness;
 
 namespace
 {
+constexpr std::int64_t kSecond = 1000000000LL;
+
 // The map side is fed as a POSITION (DigDecide measures net displacement from
 // its own per-window anchor), so the helpers integrate a straight-line track.
 
@@ -495,4 +500,87 @@ TEST(DigTrustSigma, GraphMarginalWouldBlockWhereReceiverAccuracyDoesNot)
   mh::DigDetectorState st_gnss;
   EXPECT_EQ(RunDigging(cfg, st_gnss, 9.0, 0.014, 0.1, 0.01), mh::DigAction::kDig)
       << "receiver accuracy at the same instant";
+}
+
+TEST(DigGnssFreshness, GenuineRtkObservationPermitsExistingTrustPolicy)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  const bool fresh = tracker.ObservationIsFresh(10 * kSecond, 1 * kSecond, 2 * kSecond);
+  EXPECT_NEAR(mh::DigTrustSigma(fresh, true, true, 0.014), 0.014, 1e-12);
+}
+
+TEST(DigGnssFreshness, CachedRtkObservationCannotExtendTrust)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(2, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(2, 10 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  EXPECT_EQ(mh::DigTrustSigma(fresh, true, true, 0.014), std::numeric_limits<double>::infinity());
+}
+
+TEST(DigGnssFreshness, StaleCachedFixedCannotCreateDigAnchor)
+{
+  freshness::PhysicalObservationTracker tracker;
+  mh::DigDetectorCfg cfg;
+  mh::DigDetectorState state;
+  ASSERT_EQ(tracker.Observe(3, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(3, 10 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  const double sigma = mh::DigTrustSigma(fresh, true, true, 0.014);
+
+  EXPECT_EQ(mh::DigDecide(cfg, state, 0.3, 0.03, 1.0, 2.0, sigma, 0.0, 0.1).action,
+            mh::DigAction::kNone);
+  EXPECT_FALSE(state.have_anchor);
+}
+
+TEST(DigGnssFreshness, NewGenuineObservationRestoresTrust)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(4, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_FALSE(tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond));
+  ASSERT_EQ(tracker.Observe(5, 13 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  EXPECT_NEAR(mh::DigTrustSigma(fresh, true, true, 0.014), 0.014, 1e-12);
+}
+
+TEST(GnssLockFreshness, FreshFixedKeepsExistingQualityIndication)
+{
+  EXPECT_EQ(mh::GnssQualityForFirmware(true, 100U), 100U);
+  EXPECT_EQ(mh::GnssQualityForFirmware(true, 70U), 70U);
+}
+
+TEST(GnssLockFreshness, CachedFixedCannotKeepIndicationFresh)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(6, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(6, 10 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  EXPECT_EQ(mh::GnssQualityForFirmware(fresh, 100U), 0U);
+}
+
+TEST(GnssLockFreshness, TimeoutUsesExistingNoCurrentDataValue)
+{
+  EXPECT_EQ(mh::GnssQualityForFirmware(false, 100U), 0U);
+}
+
+TEST(GnssLockFreshness, NewGenuineObservationRestoresQuality)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(7, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_FALSE(tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond));
+  ASSERT_EQ(tracker.Observe(8, 13 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  EXPECT_EQ(mh::GnssQualityForFirmware(fresh, 100U), 100U);
 }

--- a/ros2/src/mowgli_interfaces/include/mowgli_interfaces/gnss_observation_freshness.hpp
+++ b/ros2/src/mowgli_interfaces/include/mowgli_interfaces/gnss_observation_freshness.hpp
@@ -1,0 +1,326 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Shared GNSS observation-identity and freshness policy.
+//
+// Receipt provenance is expressed in the ROS clock domain. Delivery liveness
+// is expressed independently in a monotonic clock domain. Callers must never
+// substitute callback time for receipt time or mix the two clock domains.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace mowgli_interfaces::gnss_observation_freshness
+{
+
+enum class ObservationUpdate
+{
+  kNewObservation,
+  kSourceRestart,
+  kCachedPublication,
+  kOutOfOrder,
+  kInvalidProvenance,
+  kRosTimeDiscontinuity,
+  kMonotonicTimeDiscontinuity,
+};
+
+inline bool IsAcceptedObservation(const ObservationUpdate update)
+{
+  return update == ObservationUpdate::kNewObservation ||
+         update == ObservationUpdate::kSourceRestart;
+}
+
+inline bool IsReceiptFresh(const std::int64_t receipt_time_ns,
+                           const std::int64_t ros_now_ns,
+                           const std::int64_t maximum_age_ns)
+{
+  if (receipt_time_ns <= 0 || maximum_age_ns < 0 || ros_now_ns < receipt_time_ns)
+  {
+    return false;
+  }
+  return ros_now_ns - receipt_time_ns <= maximum_age_ns;
+}
+
+class ObservationTracker
+{
+public:
+  // Record one delivered status/fix.
+  //
+  // sequence=0 selects the backward-compatible receipt-stamp identity used by
+  // NavSatFix and legacy status producers. A non-zero sequence is stronger:
+  // it distinguishes genuine numerically identical observations even if their
+  // receipt timestamps happen to be equal.
+  ObservationUpdate Observe(const std::uint64_t sequence,
+                            const std::int64_t receipt_time_ns,
+                            const std::int64_t ros_now_ns,
+                            const std::int64_t monotonic_delivery_time_ns)
+  {
+    last_delivery_time_ns_ = monotonic_delivery_time_ns;
+
+    if (last_ros_now_ns_ && ros_now_ns < *last_ros_now_ns_)
+    {
+      ResetObservationEpoch();
+      last_ros_now_ns_ = ros_now_ns;
+      return ObservationUpdate::kRosTimeDiscontinuity;
+    }
+    last_ros_now_ns_ = ros_now_ns;
+
+    // Receipt stamps are mandatory for the audited Universal GNSS path. A
+    // future stamp is invalid evidence, not a fresh observation.
+    if (receipt_time_ns <= 0 || receipt_time_ns > ros_now_ns)
+    {
+      return ObservationUpdate::kInvalidProvenance;
+    }
+
+    if (!last_receipt_time_ns_)
+    {
+      Accept(sequence, receipt_time_ns);
+      return ObservationUpdate::kNewObservation;
+    }
+
+    if (sequence != 0 && last_sequence_ != 0)
+    {
+      if (sequence == last_sequence_)
+      {
+        return receipt_time_ns == *last_receipt_time_ns_ ? ObservationUpdate::kCachedPublication
+                                                         : ObservationUpdate::kInvalidProvenance;
+      }
+
+      if (sequence > last_sequence_)
+      {
+        if (receipt_time_ns < *last_receipt_time_ns_)
+        {
+          return ObservationUpdate::kOutOfOrder;
+        }
+        Accept(sequence, receipt_time_ns);
+        return ObservationUpdate::kNewObservation;
+      }
+
+      // A lower sequence paired with a later receipt stamp is a receiver
+      // restart/reconnect epoch, not a delayed packet from the old epoch.
+      if (receipt_time_ns > *last_receipt_time_ns_)
+      {
+        Accept(sequence, receipt_time_ns);
+        return ObservationUpdate::kSourceRestart;
+      }
+      return ObservationUpdate::kOutOfOrder;
+    }
+
+    // Legacy/receipt-only identity. This is also the transition path when one
+    // side has not yet supplied a non-zero sequence.
+    if (receipt_time_ns == *last_receipt_time_ns_)
+    {
+      if (sequence != 0 && last_sequence_ == 0)
+      {
+        Accept(sequence, receipt_time_ns);
+        return ObservationUpdate::kNewObservation;
+      }
+      return ObservationUpdate::kCachedPublication;
+    }
+    if (receipt_time_ns < *last_receipt_time_ns_)
+    {
+      return ObservationUpdate::kOutOfOrder;
+    }
+
+    Accept(sequence, receipt_time_ns);
+    return ObservationUpdate::kNewObservation;
+  }
+
+  bool ObservationIsFresh(const std::int64_t ros_now_ns, const std::int64_t maximum_age_ns) const
+  {
+    return last_receipt_time_ns_ &&
+           IsReceiptFresh(*last_receipt_time_ns_, ros_now_ns, maximum_age_ns);
+  }
+
+  bool DeliveryIsLive(const std::int64_t monotonic_now_ns,
+                      const std::int64_t maximum_silence_ns) const
+  {
+    if (!last_delivery_time_ns_ || maximum_silence_ns < 0 ||
+        monotonic_now_ns < *last_delivery_time_ns_)
+    {
+      return false;
+    }
+    return monotonic_now_ns - *last_delivery_time_ns_ <= maximum_silence_ns;
+  }
+
+  std::optional<std::int64_t> last_receipt_time_ns() const
+  {
+    return last_receipt_time_ns_;
+  }
+
+  std::uint64_t last_sequence() const
+  {
+    return last_sequence_;
+  }
+
+  void Reset()
+  {
+    ResetObservationEpoch();
+    last_ros_now_ns_.reset();
+    last_delivery_time_ns_.reset();
+  }
+
+private:
+  void Accept(const std::uint64_t sequence, const std::int64_t receipt_time_ns)
+  {
+    last_sequence_ = sequence;
+    last_receipt_time_ns_ = receipt_time_ns;
+  }
+
+  void ResetObservationEpoch()
+  {
+    last_sequence_ = 0;
+    last_receipt_time_ns_.reset();
+  }
+
+  std::uint64_t last_sequence_ = 0;
+  std::optional<std::int64_t> last_receipt_time_ns_;
+  std::optional<std::int64_t> last_ros_now_ns_;
+  std::optional<std::int64_t> last_delivery_time_ns_;
+};
+
+// Consumer-facing physical-observation freshness.
+//
+// ObservationTracker above intentionally keeps callback delivery liveness and
+// receiver-receipt provenance as separate facts. Downstream authorization
+// needs one additional rule: elapsed liveness advances only when the identity
+// tracker accepts a genuinely new observation, never when DDS delivers a
+// cached publication. This wrapper supplies that rule without mixing clocks:
+//
+// - receipt age is checked entirely in the ROS clock domain;
+// - elapsed observation liveness is checked entirely in the monotonic domain;
+// - both checks must pass before physical evidence is fresh.
+//
+// Invalid/future provenance invalidates authority immediately. An out-of-order
+// sequence-bearing sample is treated as a delayed duplicate and cannot refresh
+// the current deadline. In receipt-only compatibility mode, a receipt rewind
+// cannot be distinguished from a producer epoch reset, so it fails closed
+// until a later advancing receipt is accepted.
+class PhysicalObservationTracker
+{
+public:
+  ObservationUpdate Observe(const std::uint64_t sequence,
+                            const std::int64_t receipt_time_ns,
+                            const std::int64_t ros_now_ns,
+                            const std::int64_t monotonic_delivery_time_ns)
+  {
+    if (const auto discontinuity = CheckClockContinuity(ros_now_ns, monotonic_delivery_time_ns))
+    {
+      return *discontinuity;
+    }
+
+    const ObservationUpdate update =
+        identity_.Observe(sequence, receipt_time_ns, ros_now_ns, monotonic_delivery_time_ns);
+    if (IsAcceptedObservation(update))
+    {
+      last_observation_monotonic_time_ns_ = monotonic_delivery_time_ns;
+      evidence_valid_ = true;
+    }
+    else if (update == ObservationUpdate::kInvalidProvenance ||
+             (update == ObservationUpdate::kOutOfOrder && sequence == 0))
+    {
+      evidence_valid_ = false;
+    }
+    else if (update == ObservationUpdate::kRosTimeDiscontinuity)
+    {
+      ResetEvidence();
+    }
+    return update;
+  }
+
+  bool ObservationIsFresh(const std::int64_t ros_now_ns,
+                          const std::int64_t monotonic_now_ns,
+                          const std::int64_t maximum_age_ns)
+  {
+    if (CheckClockContinuity(ros_now_ns, monotonic_now_ns) || !evidence_valid_ ||
+        !last_observation_monotonic_time_ns_ || maximum_age_ns < 0 ||
+        monotonic_now_ns < *last_observation_monotonic_time_ns_)
+    {
+      return false;
+    }
+
+    return identity_.ObservationIsFresh(ros_now_ns, maximum_age_ns) &&
+           monotonic_now_ns - *last_observation_monotonic_time_ns_ <= maximum_age_ns;
+  }
+
+  bool DeliveryIsLive(const std::int64_t monotonic_now_ns,
+                      const std::int64_t maximum_silence_ns) const
+  {
+    return identity_.DeliveryIsLive(monotonic_now_ns, maximum_silence_ns);
+  }
+
+  std::optional<std::int64_t> last_receipt_time_ns() const
+  {
+    return identity_.last_receipt_time_ns();
+  }
+
+  std::uint64_t last_sequence() const
+  {
+    return identity_.last_sequence();
+  }
+
+  // Consume the transition marker set when either clock moves backward. This
+  // lets a semantic consumer reset its own debounce/latch epoch without
+  // duplicating clock-discontinuity detection.
+  bool ConsumeEpochReset()
+  {
+    const bool pending = epoch_reset_pending_;
+    epoch_reset_pending_ = false;
+    return pending;
+  }
+
+  void Reset()
+  {
+    identity_.Reset();
+    last_observation_monotonic_time_ns_.reset();
+    last_ros_now_ns_.reset();
+    last_monotonic_now_ns_.reset();
+    evidence_valid_ = false;
+    epoch_reset_pending_ = false;
+  }
+
+private:
+  std::optional<ObservationUpdate> CheckClockContinuity(const std::int64_t ros_now_ns,
+                                                        const std::int64_t monotonic_now_ns)
+  {
+    if (last_ros_now_ns_ && ros_now_ns < *last_ros_now_ns_)
+    {
+      ResetEvidence();
+      epoch_reset_pending_ = true;
+      last_ros_now_ns_ = ros_now_ns;
+      last_monotonic_now_ns_ = monotonic_now_ns;
+      return ObservationUpdate::kRosTimeDiscontinuity;
+    }
+    if (monotonic_now_ns < 0 ||
+        (last_monotonic_now_ns_ && monotonic_now_ns < *last_monotonic_now_ns_))
+    {
+      ResetEvidence();
+      epoch_reset_pending_ = true;
+      last_ros_now_ns_ = ros_now_ns;
+      last_monotonic_now_ns_ = monotonic_now_ns;
+      return ObservationUpdate::kMonotonicTimeDiscontinuity;
+    }
+
+    last_ros_now_ns_ = ros_now_ns;
+    last_monotonic_now_ns_ = monotonic_now_ns;
+    return std::nullopt;
+  }
+
+  void ResetEvidence()
+  {
+    identity_.Reset();
+    last_observation_monotonic_time_ns_.reset();
+    evidence_valid_ = false;
+  }
+
+  ObservationTracker identity_;
+  std::optional<std::int64_t> last_observation_monotonic_time_ns_;
+  std::optional<std::int64_t> last_ros_now_ns_;
+  std::optional<std::int64_t> last_monotonic_now_ns_;
+  bool evidence_valid_ = false;
+  bool epoch_reset_pending_ = false;
+};
+
+}  // namespace mowgli_interfaces::gnss_observation_freshness

--- a/ros2/src/mowgli_interfaces/msg/GnssStatus.msg
+++ b/ros2/src/mowgli_interfaces/msg/GnssStatus.msg
@@ -118,3 +118,14 @@ uint16 msm_summary_satellite_count
 uint16 msm_summary_signal_count
 uint16 msm_summary_cell_count
 float32 msm_summary_age_s
+
+# Identity of the receiver position observation represented by this sample.
+# Copied verbatim from Universal GNSS when the pinned adapter supplies it:
+# - advances only for a genuinely accepted position observation
+# - remains unchanged for timer-driven cached republication
+# - 0 means "not supplied", which selects the receipt-stamp compatibility
+#   mode in mowgli_interfaces/gnss_observation_freshness.hpp
+#
+# Kept at the end of the message to preserve existing field ordering as far as
+# ROS interface evolution permits.
+uint64 position_observation_sequence

--- a/ros2/src/mowgli_localization/include/mowgli_localization/navsat_to_absolute_pose_node.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/navsat_to_absolute_pose_node.hpp
@@ -26,6 +26,13 @@
  * authoritative RTK/fix state, then publishes /gps/absolute_pose plus the
  * robot_localization-friendly /gps/pose_cov twin.
  *
+ * /gps/pose_cov additionally requires a GENUINELY NEW receiver observation.
+ * The adapter republishes its last accepted fix on a timer with the receipt
+ * stamp unchanged, so callbacks keep arriving after the receiver freezes.
+ * /gps/absolute_pose still mirrors every delivery (it carries its own stamp
+ * and flags), but the pose_cov twin is consumed as an absolute anchor — see
+ * the freshness gate in on_navsat_fix.
+ *
  * Subscribed topics:
  *   /gps/fix     sensor_msgs/msg/NavSatFix
  *   /gps/status  mowgli_interfaces/msg/GnssStatus
@@ -38,10 +45,12 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <memory>
 
 #include "geometry_msgs/msg/pose_with_covariance.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
 #include "mowgli_interfaces/msg/gnss_status.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -106,6 +115,16 @@ private:
   /// source even when /gps/fix covariance is missing or rejected.
   mowgli_interfaces::msg::GnssStatus last_status_;
   bool has_status_{false};
+
+  /// Receiver-receipt identity of the /gps/fix stream. The Universal GNSS
+  /// adapter preserves the receipt stamp across its timer-driven cached
+  /// republications, so the stamp — never callback arrival time — is what
+  /// distinguishes a genuine new observation from a frozen receiver.
+  ///
+  /// sequence=0 selects the tracker's receipt-only compatibility mode:
+  /// NavSatFix has no sequence field, and pairing it against the separately
+  /// delivered /gps/status sequence is deliberately left to a follow-up.
+  mowgli_interfaces::gnss_observation_freshness::ObservationTracker fix_observation_tracker_;
 
   /// TF listener to resolve base_footprint↔gps_link (static from URDF,
   /// gives the lever arm) and map↔base_footprint (dynamic from ekf_map,

--- a/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
+++ b/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
@@ -37,7 +37,9 @@
 #include "mowgli_localization/navsat_to_absolute_pose_node.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 
@@ -56,6 +58,15 @@ static constexpr double DEG_TO_RAD = M_PI / 180.0;
 
 /// Metres per degree of latitude (approximate, at the equator).
 static constexpr double METERS_PER_DEG = EARTH_RADIUS_M * DEG_TO_RAD;
+
+/// Monotonic delivery clock. Kept strictly separate from the ROS clock used
+/// for receipt provenance — the freshness policy never mixes the two domains.
+static std::int64_t steady_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
 
 // ---------------------------------------------------------------------------
 // Constructor
@@ -194,6 +205,29 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   // Store latest fix for set_datum service.
   last_fix_ = *msg;
   has_fix_ = true;
+
+  // Receiver-observation identity, evaluated before anything is published.
+  // A frozen receiver still produces callbacks: the adapter republishes the
+  // last accepted fix on its own timer with the receipt stamp unchanged, so
+  // arrival time says "live" while the physical observation behind it is
+  // minutes old. Compare provenance, never callback time and never
+  // coordinates (a stationary robot legitimately repeats coordinates).
+  const rclcpp::Time ros_now = now();
+  const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
+  const auto observation_update = fix_observation_tracker_.Observe(0,
+                                                                   receipt_stamp.nanoseconds(),
+                                                                   ros_now.nanoseconds(),
+                                                                   steady_now_ns());
+  using mowgli_interfaces::gnss_observation_freshness::IsAcceptedObservation;
+  using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
+  const bool observation_is_new = IsAcceptedObservation(observation_update);
+  if (!observation_is_new && observation_update == ObservationUpdate::kInvalidProvenance)
+  {
+    RCLCPP_WARN_THROTTLE(get_logger(),
+                         *get_clock(),
+                         5000,
+                         "GNSS receipt stamp is zero/future; /gps/pose_cov withheld");
+  }
 
   using AbsPose = mowgli_interfaces::msg::AbsolutePose;
   using NavSat = sensor_msgs::msg::NavSatFix;
@@ -335,6 +369,21 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   out.pose.pose.position.x = base_x;
   out.pose.pose.position.y = base_y;
   pose_pub_->publish(out);
+
+  // Freshness gate on the localization-fusion twin only. /gps/absolute_pose
+  // above stays a faithful mirror of what the driver delivered (it carries
+  // its own stamp and flags, and the GUI reasons about both), but
+  // /gps/pose_cov is consumed as an ABSOLUTE ANCHOR — map_server averages it
+  // into the dock pose. Re-emitting a frozen observation there manufactures
+  // fresh-looking evidence out of one old measurement: the averaging window
+  // fills with copies of a single sample, so its spread collapses and the
+  // result looks more confident the longer the receiver has been dead.
+  // Arrival-time staleness checks downstream cannot see this, because the
+  // republication makes arrival time current.
+  if (!observation_is_new)
+  {
+    return;
+  }
 
   // RTK-aware gate: skip standalone (no RTK) fixes — those have σ ~ 1-3 m
   // and jump erratically under multipath. RTK Float (σ ~ 20 cm) is fused

--- a/sensors/gps/mowgli_gnss_bridge/src/universal_gnss_topic_bridge.cpp
+++ b/sensors/gps/mowgli_gnss_bridge/src/universal_gnss_topic_bridge.cpp
@@ -317,6 +317,11 @@ void UniversalGnssTopicBridge::onStatus(const UniversalGnssStatus & msg)
   PublicGnssStatus public_msg;
   public_msg.header.stamp = msg.stamp;
   public_msg.header.frame_id = frame_id_;
+  // Receiver observation identity, copied verbatim. It advances only for a
+  // genuinely accepted position observation and stays put for the timer-driven
+  // cached republication, which is what lets consumers tell a frozen receiver
+  // from a live one. See mowgli_interfaces/gnss_observation_freshness.hpp.
+  public_msg.position_observation_sequence = msg.position_observation_sequence;
   public_msg.backend = backend_;
   public_msg.receiver_vendor = receiver_vendor_;
 

--- a/sensors/gps/mowgli_gnss_bridge/test/test_universal_gnss_topic_bridge.cpp
+++ b/sensors/gps/mowgli_gnss_bridge/test/test_universal_gnss_topic_bridge.cpp
@@ -114,6 +114,9 @@ TEST_F(BridgeTest, StatusIsMappedToPublicContract)
   EXPECT_EQ(received.receiver_vendor, "u-blox");
   EXPECT_EQ(received.header.frame_id, "gps_link");
   EXPECT_FLOAT_EQ(received.horizontal_accuracy_m, 0.014F);
+  // Unset upstream stays 0, which selects the receipt-stamp compatibility mode
+  // in mowgli_interfaces/gnss_observation_freshness.hpp.
+  EXPECT_EQ(received.position_observation_sequence, 0U);
 
   exec.remove_node(helper);
   exec.remove_node(bridge);
@@ -151,6 +154,58 @@ TEST_F(BridgeTest, RtcmFrameIsForwardedByteExact)
 
   ASSERT_TRUE(got);
   EXPECT_EQ(received.message, frame.data);
+
+  exec.remove_node(helper);
+  exec.remove_node(bridge);
+}
+
+// The observation sequence is the strongest identity a consumer can use to tell
+// a genuinely new receiver observation from the timer-driven republication of a
+// cached one. The bridge must forward it verbatim and must never latch it: a
+// stale value here would make a frozen receiver look live to every consumer of
+// the typed contract.
+TEST_F(BridgeTest, PositionObservationSequenceIsForwardedVerbatim)
+{
+  auto bridge = makeBridge();
+  auto helper = std::make_shared<rclcpp::Node>("bridge_test_helper_sequence");
+
+  const rclcpp::QoS qos = rclcpp::QoS(10).reliable().durability_volatile();
+  auto status_pub =
+    helper->create_publisher<UniversalGnssStatus>("/test/universal/status", qos);
+
+  PublicGnssStatus received;
+  bool got = false;
+  auto status_sub = helper->create_subscription<PublicGnssStatus>(
+    "/test/gps/status", qos,
+    [&](const PublicGnssStatus & msg) {
+      received = msg;
+      got = true;
+    });
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(bridge);
+  exec.add_node(helper);
+
+  UniversalGnssStatus in;
+  in.fix_type = UniversalGnssStatus::FIX_TYPE_RTK_FIXED;
+  in.fix_valid = true;
+  in.position_observation_sequence = 4242U;
+
+  spinUntil(exec, [&]() {
+    status_pub->publish(in);
+    return got;
+  });
+  ASSERT_TRUE(got);
+  EXPECT_EQ(received.position_observation_sequence, 4242U);
+
+  // A numerically identical observation with a new upstream sequence must come
+  // through as the NEW sequence — the payload is deliberately not the identity.
+  in.position_observation_sequence = 4243U;
+  const bool advanced = spinUntil(exec, [&]() {
+    status_pub->publish(in);
+    return received.position_observation_sequence == 4243U;
+  });
+  EXPECT_TRUE(advanced) << "bridge latched the observation sequence instead of forwarding it";
 
   exec.remove_node(helper);
   exec.remove_node(bridge);

--- a/sensors/gps/universal_gnss_topic_bridge.py
+++ b/sensors/gps/universal_gnss_topic_bridge.py
@@ -234,6 +234,12 @@ class UniversalGnssTopicBridge(Node):
         public_msg = PublicGnssStatus()
         public_msg.header.stamp = msg.stamp
         public_msg.header.frame_id = self._frame_id
+        # Receiver observation identity, copied verbatim. It advances only for a
+        # genuinely accepted position observation and stays put for the
+        # timer-driven cached republication, which is what lets consumers tell a
+        # frozen receiver from a live one. Mirrors the C++ bridge exactly; see
+        # mowgli_interfaces/gnss_observation_freshness.hpp.
+        public_msg.position_observation_sequence = msg.position_observation_sequence
         public_msg.backend = self._backend
         public_msg.receiver_vendor = self._receiver_vendor
 


### PR DESCRIPTION
## What this does

A GNSS receiver that stops producing observations does not stop producing ROS
traffic. `universal_gnss`'s `receiver_node::PublishNow()` runs on a
`publish_rate_hz` wall timer and republishes `session_->current_state()` every
tick — `/gps/fix` and `/gps/status` keep arriving at full rate, with the
**receipt stamp frozen** at the last real observation. Every consumer on this
robot measured freshness by *when the callback ran*, so a dead receiver kept
looking perfectly healthy.

This PR introduces one shared policy header and wires the four consumers that
were fooled by it. It separates two facts that were previously conflated:

- **receipt provenance** — when the receiver actually produced this
  observation, in the ROS clock domain;
- **delivery liveness** — when DDS last handed us a message, in a monotonic
  domain that a ROS-clock jump cannot corrupt.

`mowgli_interfaces/gnss_observation_freshness.hpp` classifies each delivery as
new / source restart / cached republication / out-of-order / invalid
provenance / ROS- or monotonic-clock discontinuity, and answers
"is the physical observation fresh?" separately from "is the topic alive?".
It fails closed on a zero or future stamp and on a clock rewind.

`ObservationTracker` is backward compatible: `sequence == 0` selects
receipt-stamp identity, which is what every producer supplies today.

## The four consumers this protects

1. **Dig detector** (`hardware_bridge_node`) — `gnss_fresh` was
   `have_dig_gnss_ && (tick_now - dig_gnss_time_) < dig_gnss_timeout_s_`, i.e.
   message arrival. It stayed true forever behind a frozen receiver, so
   `DigTrustSigma` kept handing the detector a cm-level trust sigma derived
   from a measurement that had stopped updating — the detector then compared
   wheel travel against a map anchor that could not move. It now means
   observation novelty. The same signal gates the quality forwarded to the
   firmware lock LED (`GnssQualityForFirmware`), which substitutes the
   established "no current GNSS" value 0 rather than inventing a new one.
   Invariant 16 is untouched: the reference is still the GNSS-anchored fused
   pose, the trust signal is still the receiver's own accuracy under confirmed
   RTK-Fixed, and the turn exclusion still reads the gyro.
2. **`fusion_graph`** — a cached republication used to submit another GPS
   factor, advance `rtk_fixed_streak_`, and refresh `last_rtk_fixed_stamp_`
   with `this->now()`. One real observation could therefore hold the
   scan-match yield gate, the keyframe-capture gate and the loop-closure gate
   in their "RTK is fine" branch indefinitely. RTK freshness is now measured
   from the **receipt stamp** (`RtkFixedReceiptIsFresh`, which also rejects
   negative age), and the latches only advance for an accepted observation.
   The gate is stateless per sample — it cannot run away and lock GPS out the
   way the reverted `GnssMobileGate` did.
3. **`navsat_to_absolute_pose_node`** — stops emitting `/gps/pose_cov` from a
   frozen observation. `/gps/pose_cov` is consumed by `map_server_node` as the
   absolute anchor for `~/set_docking_point`; re-emitting one old measurement
   fills the averaging window with copies of itself, so its spread collapses
   and the dock pose looks *more* confident the longer the receiver has been
   dead. `area_manager`'s existing staleness check cannot see this, because
   the republication makes arrival time current. `/gps/absolute_pose` still
   mirrors every delivery — it carries its own stamp and flags, and the GUI
   reasons about both.
4. **`LocalizationHealthMonitor`** (behavior tree) — `gnss_stamp_s` was set to
   `get_clock()->now()` in the `/gps/status` callback, so `stale` was
   structurally unreachable while the adapter republished. It is now a
   `gnss_fresh` boolean computed from the shared policy, re-evaluated on every
   BT tick rather than only on a status callback (otherwise the check that
   detects a frozen feed only runs when the frozen feed arrives). Crossing the
   existing `gnss_stale_s` deadline fails closed immediately instead of
   waiting out the pause-persistence debounce, and forces `gps_is_fixed` false.

## The bridge passthrough

`GnssStatus.msg` gains `uint64 position_observation_sequence`, and both bridges
forward it verbatim from the Universal GNSS status:
`sensors/gps/mowgli_gnss_bridge` (the C++ node that actually runs in
production) and `sensors/gps/universal_gnss_topic_bridge.py` (the reference
implementation), kept behaviour-identical as `sensors/CLAUDE.md` requires.

The sequence is the *stronger* identity: it separates two genuinely distinct
observations that happen to share a receipt stamp. Where it is 0 — a legacy or
non-Universal producer — the tracker falls back to receipt-stamp identity and
every consumer still works, so this is additive, not a new requirement.

`CorrectionDiagnosticTracker` and every `correction_*` field stay out; those
are split 2/3.

## Regenerated surfaces

`GnssStatus.msg` gains one field, `uint64 position_observation_sequence`, and
all three generated surfaces are regenerated with `LC_ALL=C` and committed:

- `gui/pkg/msgs/mowgli/types_generated.go`
- `gui/web/src/types/ros.generated.ts`
- `firmware/stm32/ros_usbnode/src/ros/ros_lib/mower_msgs/GnssStatus.h`

Re-running all three a second time produces no further diff. (#534 regenerated
the two GUI surfaces but not the firmware one; `msg-codegen-drift.yml` never
ran on it because fork-PR workflows were not approved.)

## Deliberately NOT in this PR

Agreed with @Pepeuch to land #534 as a series. Left for the follow-ups:

- `CorrectionDiagnosticTracker` and the whole `correction_*` /
  `CORRECTION_*` / `CAP_CORRECTION_*` message surface — correction
  diagnostics, split 2.
- `navsat_status_association`, `cog_observation_timing`,
  `localization_monitor_policy` — the asynchronous fix↔status pairing story,
  split 3. This PR's navsat gate therefore uses the tracker's receipt-only
  compatibility mode rather than pairing `/gps/fix` against the `/gps/status`
  sequence.
- The GUI-side work, the `.agent/` policy pack, `MOWGLINEXT_GNSS_AUDIT.md`,
  the backlog dashboards and `scripts/update_backlog_status.py`.

Rebased onto current `dev` (which now pins universal-gnss `ab32f673` again
after #538 restored the gitlink that #532 had silently reverted). That pin
carries `position_observation_sequence`, so the bridge passthrough below is
included; it also carries `gnss_runtime`, which is what turns the inherited
`build / Build gps` failure green.

## Testing

Built and tested in `ros:kilted-ros-base`:

- `mowgli_hardware` — `test_dig_detector` gains 8 freshness/lock cases.
- `mowgli_behavior` — `test_localization_health` gains 4 freshness cases; the
  existing suite is migrated from `gnss_stamp_s` to `gnss_fresh`.
- `fusion_graph` — new `test_gnss_observation_freshness` (5 cases) pins the
  shared policy: cached republication, delayed duplicate, delivery liveness
  not implying observation freshness, clock rewind + future provenance, and
  the sequence-reset source-restart epoch.

- `mowgli_gnss_bridge` — `test_universal_gnss_topic_bridge` gains
  `PositionObservationSequenceIsForwardedVerbatim` (forwarded verbatim, and it
  *advances* rather than latching), plus an assertion in the existing mapping
  test that an unset upstream sequence stays 0. **This package has no CI job**
  (`sensors/CLAUDE.md`: the image builds `-DBUILD_TESTING=OFF` and `ros2-ci.yml`
  only builds `ros2/src`), so it was built and run by hand in the scratch
  overlay that file prescribes.

`fusion_graph` needs GTSAM and is not buildable in the plain base image; it is
left to CI. `clang-format` 18.1.8 clean for `ros2/src`; the bridge sources are
outside the formatter's scope and already follow ament style, so the added
lines match the surrounding file rather than reformatting it.

## Attribution

The core header and the consumer wiring are @Pepeuch's work, ported from #534
and rebased onto current `dev`. The navsat gate is adapted rather than copied
verbatim, because #534's version routes through `NavSatStatusAssociation`
(split 3).

Refs #533

Co-authored-by: Pepeuch <Pepeuch@users.noreply.github.com>

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
