### PR TITLE
fix(gnss): restore the universal-gnss gitlink and stop the pre-push hook staging it

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -23,7 +23,13 @@ if ! "$FORMAT_SCRIPT" --check 2>/dev/null; then
   "$FORMAT_SCRIPT"
 
   # Stage and amend the last commit with formatting fixes
-  git add ros2/src/
+  # Stage only what the formatter can touch. `git add ros2/src/` also staged
+  # ros2/src/external/universal-gnss, so any push that triggered a reformat
+  # froze whatever commit the local submodule happened to sit at. That is how
+  # PR #532 (a docs-only change) silently reverted the #531 re-pin and left
+  # dev's GPS image build red: sensors/gps/Dockerfile referenced gnss_runtime
+  # while the gitlink pointed back at a commit predating it.
+  git add -- 'ros2/src/*.cpp' 'ros2/src/*.hpp' 'ros2/src/*.h' ':!ros2/src/external/*'
   git commit -m "chore: auto-format C++ files"
   echo "==> Created formatting commit. Push will continue."
 fi


### PR DESCRIPTION
## dev is red, and this is why

`Sensors — GPS` on `dev`:

| commit | | result |
|---|---|---|
| `64451ef1` | merge of #531 (the re-pin) | **success** |
| `c1818174` | merge of #532 (docs only) | **failure** |

`sensors/gps/Dockerfile` copies and symlinks `gnss_runtime`, a subproject the vendored repo's root `CMakeLists.txt` `add_subdirectory()`s. The gitlink on `dev` points at `4bf5d0a`, which predates that subproject, so the tools configure step fails on a missing directory.

## How the pin got reverted

Not by the PR that changed it. `2b55c0e6`, a commit inside the **docs-only** PR #532 — whose subject is, with some irony, *"docs: realign with the universal-gnss re-pin landed on dev"* — carries `-Subproject commit ab32f67` / `+Subproject commit 4bf5d0a`. That branch predated #531, so its local submodule checkout still sat at the old commit.

The mechanism is the pre-push hook. On a formatting violation it runs:

```sh
git add ros2/src/
git commit -m "chore: auto-format C++ files"
```

`ros2/src/` includes `ros2/src/external/universal-gnss`, so **any push that triggers a reformat stages the submodule gitlink at whatever commit the developer's local checkout happens to be on** — and rewrites the pin inside a commit nobody reads closely, in a PR about something else.

#531 excluded `external/` from the *formatter's* file list. It did not exclude it from this `git add`, which is the half that did the damage. My fix was incomplete.

## Changes

1. **Restore the gitlink to `ab32f67`** — what #531 reviewed, what its green GPS build was built against, and what the Dockerfile on `dev` requires.
2. **Restrict the hook's staging** to the file types the formatter can touch, with `ros2/src/external` excluded outright:

```sh
git add -- 'ros2/src/*.cpp' 'ros2/src/*.hpp' 'ros2/src/*.h' ':!ros2/src/external/*'
```

A vendored submodule can no longer be re-pinned as a side effect of formatting something unrelated.

## Note for reviewers

This class of accident is silent by construction: a gitlink change is one line, shows as `Subproject commit …`, and appears in PRs that have nothing to do with the submodule. It is worth considering a CI guard that fails when the gitlink moves in a PR that does not also touch `.gitmodules` or declare the bump in its title — happy to add it if wanted, but it is out of scope here.

## Test plan

- [ ] CI: `Sensors — GPS` green again on this branch
- [ ] After merge: confirm `dev`'s GPS build is green

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ