### PR TITLE
fix: honor charging limits from advanced robot config

### DIFF
--- a/ros2/src/mowgli_bringup/launch/mowgli.launch.py
+++ b/ros2/src/mowgli_bringup/launch/mowgli.launch.py
@@ -201,6 +201,9 @@ def generate_launch_description() -> LaunchDescription:
             # Allow command-line override of the serial port.
             {"serial_port": serial_port},
             {"use_sim_time": use_sim_time},
+            # Forward configured charge ceilings; firmware enforces its board limits.
+            {"max_charge_voltage": float(robot_params.get("max_charge_voltage", 29.4))},
+            {"max_charge_current": float(robot_params.get("max_charge_current", 1.2))},
             # Pass dock pose from robot config for dock position anchoring
             {"dock_pose_x": float(robot_params.get("dock_pose_x", 0.0))},
             {"dock_pose_y": float(robot_params.get("dock_pose_y", 0.0))},

--- a/ros2/src/mowgli_bringup/test/test_launch_injection.py
+++ b/ros2/src/mowgli_bringup/test/test_launch_injection.py
@@ -258,5 +258,34 @@ def test_navigation_launch_injects_dock_use_charger_detection() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "key,default,configured",
+    [("max_charge_voltage", 29.4, 28.5), ("max_charge_current", 1.2, 1.8)],
+)
+def test_mowgli_launch_passes_charge_limits_to_hardware_bridge(
+    key: str, default: float, configured: float
+) -> None:
+    """Saved charge ceilings must reach the bridge; missing keys keep defaults."""
+    call = _find_node_call(_parse("mowgli.launch.py"), "hardware_bridge_node")
+    assert call is not None
+    parameters = next(kw.value for kw in call.keywords if kw.arg == "parameters")
+    values = [
+        value
+        for entry in parameters.elts
+        if isinstance(entry, ast.Dict)
+        for name, value in zip(entry.keys, entry.values)
+        if isinstance(name, ast.Constant) and name.value == key
+    ]
+    assert len(values) == 1, f"hardware_bridge must receive {key} exactly once"
+    expression = compile(ast.Expression(values[0]), "mowgli.launch.py", "eval")
+    for robot_params, expected in [({}, default), ({key: configured}, configured)]:
+        actual = eval(
+            expression, {"__builtins__": {}, "float": float},
+            {"robot_params": robot_params},
+        )
+        assert isinstance(actual, float)
+        assert actual == pytest.approx(expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Saving `max_charge_voltage` and `max_charge_current` in advanced robot configuration currently leaves the hardware bridge using 29.4 V / 1.2 A. Forward both settings from the merged robot config at startup, so an operator's 28.5 V / 1.8 A configuration reaches the existing firmware safety-limit packet after restarting the stack.

**Safety-critical: charging behavior.** Firmware still enforces its compiled board ceilings. The defaults, firmware, protocol and GUI schema are unchanged.

## Changes

- Add the two missing hardware-bridge launch parameters.
- Extend the existing launch-injection guards to verify custom values and fallback defaults on the correct node.

## Component

- [x] ROS2 Stack (`ros2/`)

## Testing

- [x] Unit tests pass: 51 tests across `test_launch_injection.py` and `test_robot_config_util.py`.
- Both new regression cases fail on unmodified upstream and pass with the fix.
- `git diff --check` passes.
- The same two-parameter forwarding was checked during stationary hardware migration: runtime parameters and bridge transmit logs reported 28.50 V / 1.80 A. No complete charge-cycle validation is claimed.
- Full ROS2 build/colcon testing remains for CI; the local host is Windows without a ROS2 build environment.

## Checklist

- [x] Follows conventional commit format
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes
- [x] Physical behavior flagged as safety-critical above
