### PR TITLE
docs(agents): fold the GNSS audit's usable policy into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ These files are the maintained map of the tree — read the relevant one before 
 ## ROS2 formatting
 
 - Any change under `ros2/` that touches C++ source or headers (`.cpp`, `.hpp`, `.h`) must be `clang-format` clean before finishing.
+- **`ros2/` is the whole scope — do not apply this to C++ elsewhere.** `sensors/gps/mowgli_gnss_bridge` is C++ that `ros2/scripts/format.sh` has never walked (its `find` starts at `ros2/src/`), so it follows ament's uncrustify profile instead and its `CMakeLists.txt` keeps that linter enabled. Running clang-format there restyles ~180 lines and then fails CI. See [`sensors/CLAUDE.md`](sensors/CLAUDE.md).
 - Use **clang-format 18** and the repository style file. CI installs `clang-format-18`, `ros2/scripts/format.sh` expects major 18 (it only *warns* on a mismatch) and `ros2/.pre-commit-config.yaml` pins `v18.1.8` — any other major reformats lines CI never asked about, and the opt-in `.githooks/pre-push` hook will amend them into a `chore: auto-format C++ files` commit.
 
 ```bash
@@ -39,3 +40,45 @@ clang-format -n -style=file:ros2/.clang-format <touched-files>
 - Never run `pio`, `platformio`, `colcon`, `cmake`, `make`, `ninja`, `go`, `yarn`, `npm`, formatters, or generated-file workflows as `root`.
 - Always use the normal project user so the repository does not accumulate root-owned files.
 - If a previous run created root-owned artifacts, fix ownership or remove those artifacts before continuing.
+
+## Evidence and hardware claims
+
+This robot has spinning blades and most of its hard bugs were only ever settled
+by a field observation. Two rules follow from that.
+
+**Never generalise hardware evidence past its exact baseline.** A measurement is
+valid for the repo commit, the firmware image, the submodule gitlink, the robot
+unit, and the receiver/driver revision it was taken on — and nothing else. Say
+which of those the number came from. This is not pedantry here: a GNSS receiver
+reporting 14 mm accuracy while sitting 2.5 m off after a cold power cycle, and a
+graph marginal reporting metre-level sigma while the receiver reported
+centimetres, are both real MowgliNext incidents where a number was trusted
+outside the conditions that produced it.
+
+**When the remaining question is physical, stop and say so** instead of doing
+more repository searching. Record it in one of two explicit states:
+
+- `HARDWARE_REQUIRED` — the remaining acceptance evidence intrinsically needs
+  the robot or the field, and has not been acquired.
+- `HARDWARE_PENDING` — the exact setup and procedure are identified and every
+  software-side prerequisite is done; only the run is outstanding.
+
+Either way write down the exact baseline, the procedure, the observable
+pass/fail criterion, and the safety prerequisites. "Field test owed" on its own
+is not a handover — the next person cannot run it.
+
+## Diagnosing freshness and provenance
+
+**Never paper over an ownership or provenance defect with a timeout.** If the
+real defect is that a consumer cannot tell a genuinely new observation from a
+cached republication, or cannot tell which producer a value came from, then a
+deadline only changes how long the wrong answer survives. Fix the identity
+first, then apply a deadline to it.
+
+This is the finding behind the GNSS observation-identity work
+(`mowgli_interfaces/gnss_observation_freshness.hpp`): several consumers treated
+callback arrival as physical acquisition, so a frozen receiver kept looking
+healthy. Receipt provenance and delivery liveness are two different questions in
+two different clock domains — the ROS clock for "when was this observed", a
+monotonic clock for "is the stream alive". Do not substitute one for the other,
+and do not mix the domains.


### PR DESCRIPTION
Part of the #534 split. That PR ships ~2100 lines of `.agent/policies/*`, an expanded `AGENTS.md`, a `README.md` addition and a 1217-line `MOWGLINEXT_GNSS_AUDIT.md`. Per the maintainer's direction those are **not** merged as a parallel doc tree — they are mined for what is actually ours, and the rest is dropped.

Most of that content either duplicates what this repo already documents (clang-format, non-root builds, the codemap index in `AGENTS.md` and `docs/claude/`) or is generic agent process that does not need to live in the tree. Three ideas were genuinely MowgliNext-specific and written down nowhere, so they land here.

**1. Hardware evidence is valid only for its exact baseline.** Repo commit, firmware image, submodule gitlink, robot unit, receiver revision. We have two real incidents of a number being trusted outside the conditions that produced it — a receiver reporting 14 mm accuracy while sitting 2.5 m off for ~45 min after a cold power cycle (#520), and fusion_graph's marginal reporting p50 0.574 m while the receiver reported 0.014 m (invariant 16). Cheap to state, and both cost real debugging time.

**2. `HARDWARE_REQUIRED` / `HARDWARE_PENDING` as explicit stop states.** This project ends a lot of work with "field test owed". That is not a handover: without the baseline, the procedure, the observable pass/fail criterion and the safety prerequisites, the next person cannot actually run it. Naming two states makes the difference between "we still need the robot" and "everything is ready, only the run is outstanding".

**3. Never paper over an ownership or provenance defect with a timeout.** If a consumer cannot tell a new observation from a cached republication, a deadline only changes how long the wrong answer survives. This is the actual finding behind `gnss_observation_freshness.hpp` — several consumers treated callback arrival as physical acquisition, so a frozen receiver kept looking healthy — and it generalises in a codebase this full of freshness logic. Includes the two-clock-domain rule the header itself states.

**Also a scope correction.** The formatting section opens with "any change under `ros2/`", which reads as "all C++ in the repo". It is not: `sensors/gps/mowgli_gnss_bridge` is C++ that `ros2/scripts/format.sh` has never walked (its `find` starts at `ros2/src/`), so it follows ament's uncrustify profile and breaks if clang-formatted. I made exactly this mistake today before checking the script, so the pointer is earned.

Docs only — no code, no CI behaviour change.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ