### PR TITLE
feat(localization): apply GNSS observation identity to the localization consumers

### DIFF
--- a/ros2/src/mowgli_bringup/launch/navigation.launch.py
+++ b/ros2/src/mowgli_bringup/launch/navigation.launch.py
@@ -529,6 +529,11 @@ def generate_launch_description() -> LaunchDescription:
     declination_deg = 1.5
     min_horizontal_uT = 5.0
     mag_yaw_variance = 0.0027
+    # Physical receiver observation cadence, not the ROS publication cadence.
+    # The same gnss_profile_rate_hz value configures the receiver profile in
+    # start_gps.sh; pass it to cog_to_imu so its receipt-gap policy has one
+    # source of truth.
+    physical_gnss_observation_rate_hz = 5.0
     runtime_robot_config = "/ros2_ws/config/mowgli_robot.yaml"
     # Merged params: in-package template defaults with the installed sparse
     # config layered on top. Every rt_rp.get(key, <fallback>) below therefore
@@ -577,6 +582,12 @@ def generate_launch_description() -> LaunchDescription:
         declination_deg = float(rt_rp.get("declination_deg", declination_deg))
         min_horizontal_uT = float(rt_rp.get("min_horizontal_uT", min_horizontal_uT))
         mag_yaw_variance = float(rt_rp.get("mag_yaw_variance", mag_yaw_variance))
+        physical_gnss_observation_rate_hz = float(
+            rt_rp.get(
+                "gnss_profile_rate_hz",
+                physical_gnss_observation_rate_hz,
+            )
+        )
         tool_width = float(rt_rp.get("tool_width", tool_width))
         headland_width = float(rt_rp.get("headland_width", headland_width))
         num_headland_passes = int(rt_rp.get(
@@ -1146,6 +1157,7 @@ def generate_launch_description() -> LaunchDescription:
              "enable_mag_cal": enable_mag_cal,
              "mag_calibration_path": mag_cal_path,
              "stationary_seed_rate_hz": cog_stationary_rate,
+             "physical_gnss_observation_rate_hz": physical_gnss_observation_rate_hz,
              # Stationary-yaw aging penalty. The republish_latched path
              # adds (rate · age)² to the variance to model the chance
              # that the latched yaw has gone stale (manual rotation,

--- a/ros2/src/mowgli_bringup/test/test_launch_injection.py
+++ b/ros2/src/mowgli_bringup/test/test_launch_injection.py
@@ -108,8 +108,55 @@ def _node_parameter_keys(call: ast.Call) -> List[str]:
     return keys
 
 
+def _node_parameter_values(call: ast.Call, key: str) -> List[ast.expr]:
+    """Values assigned to one string key in a Node's parameter dicts."""
+    values: List[ast.expr] = []
+    for kw in call.keywords:
+        if kw.arg != "parameters" or not isinstance(kw.value, ast.List):
+            continue
+        for elt in kw.value.elts:
+            if not isinstance(elt, ast.Dict):
+                continue
+            for dict_key, dict_value in zip(elt.keys, elt.values):
+                if (
+                    isinstance(dict_key, ast.Constant)
+                    and dict_key.value == key
+                ):
+                    values.append(dict_value)
+    return values
+
+
 # ---------------------------------------------------------------------------
-# (a) num_headland_passes must reach coverage_server UNCLAMPED (issue #429).
+# (a) physical GNSS cadence must reach cog_to_imu (MGNSS-011).
+# ---------------------------------------------------------------------------
+
+
+def test_navigation_launch_wires_physical_gnss_rate_to_cog() -> None:
+    tree = _parse("navigation.launch.py")
+    assert _reads_robot_param(
+        tree,
+        "physical_gnss_observation_rate_hz",
+        "gnss_profile_rate_hz",
+    ), (
+        "navigation.launch.py must read the configured receiver-profile rate; "
+        "COG timing must not invent or infer a ROS publication rate."
+    )
+
+    call = _find_node_call(tree, "cog_to_imu")
+    assert call is not None, "navigation.launch.py no longer launches cog_to_imu"
+    values = _node_parameter_values(call, "physical_gnss_observation_rate_hz")
+    assert len(values) == 1
+    assert (
+        isinstance(values[0], ast.Name)
+        and values[0].id == "physical_gnss_observation_rate_hz"
+    ), (
+        "cog_to_imu must receive the bare physical GNSS rate loaded from "
+        "gnss_profile_rate_hz, not a publication-rate expression."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) num_headland_passes must reach coverage_server UNCLAMPED (issue #429).
 # ---------------------------------------------------------------------------
 
 
@@ -162,7 +209,7 @@ def test_navigation_launch_does_not_clamp_num_headland_passes() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (b) mowing_enabled must reach hardware_bridge_node (issue #195).
+# (c) mowing_enabled must reach hardware_bridge_node (issue #195).
 # ---------------------------------------------------------------------------
 
 
@@ -213,7 +260,7 @@ def test_mowing_enabled_is_not_wired_to_some_other_node() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (c) dock_max_retries / dock_use_charger_detection must reach docking_server
+# (d) dock_max_retries / dock_use_charger_detection must reach docking_server
 #     (issue #195). test_nav2_params.py only checks the keys exist in the static
 #     YAML — which was already true BEFORE they were wired up, so that test
 #     cannot fail if the injection is deleted. These can.

--- a/ros2/src/mowgli_bringup/test/test_navsat_status_universal.launch.py
+++ b/ros2/src/mowgli_bringup/test/test_navsat_status_universal.launch.py
@@ -11,6 +11,7 @@ import launch_testing
 import launch_testing.actions
 import pytest
 import rclpy
+from geometry_msgs.msg import PoseWithCovarianceStamped
 from mowgli_interfaces.msg import AbsolutePose
 from rclpy.executors import SingleThreadedExecutor
 from sensor_msgs.msg import NavSatFix, NavSatStatus
@@ -101,14 +102,22 @@ class TestNavSatUniversalStatus(unittest.TestCase):
 
     def test_fix_still_updates_absolute_pose_without_local_status_publish(self) -> None:
         absolute_pose = []
+        pose_cov = []
         pose_sub = self.node.create_subscription(
             AbsolutePose,
             "/gps/absolute_pose",
             lambda msg: absolute_pose.append(msg),
             10,
         )
+        pose_cov_sub = self.node.create_subscription(
+            PoseWithCovarianceStamped,
+            "/gps/pose_cov",
+            lambda msg: pose_cov.append(msg),
+            10,
+        )
         fix_pub = self.node.create_publisher(NavSatFix, "/gps/fix", 10)
         self.addCleanup(self.node.destroy_subscription, pose_sub)
+        self.addCleanup(self.node.destroy_subscription, pose_cov_sub)
         self.addCleanup(self.node.destroy_publisher, fix_pub)
 
         self._spin_until(
@@ -117,7 +126,9 @@ class TestNavSatUniversalStatus(unittest.TestCase):
             message="navsat node did not subscribe to /gps/fix",
         )
 
-        fix_pub.publish(_make_fix())
+        fix = _make_fix()
+        fix.header.stamp = self.node.get_clock().now().to_msg()
+        fix_pub.publish(fix)
 
         self._spin_until(
             lambda: len(absolute_pose) > 0,
@@ -125,6 +136,8 @@ class TestNavSatUniversalStatus(unittest.TestCase):
             message="navsat node stopped publishing /gps/absolute_pose in universal mode",
         )
         self._spin_for(1.0)
+        self.assertEqual(len(absolute_pose), 1)
+        self.assertEqual(len(pose_cov), 0)
         self.assertEqual(self.node.count_publishers("/gps/status"), 0)
 
 

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -64,6 +64,17 @@ ament_target_dependencies(wheel_odometry_node
 # Executable: navsat_to_absolute_pose_node
 # ---------------------------------------------------------------------------
 
+add_library(navsat_status_association
+  src/navsat_status_association.cpp
+)
+
+target_include_directories(navsat_status_association PUBLIC ${INCLUDE_DIR})
+
+ament_target_dependencies(navsat_status_association
+  sensor_msgs
+  mowgli_interfaces
+)
+
 add_executable(navsat_to_absolute_pose_node
   src/navsat_to_absolute_pose_node.cpp
 )
@@ -79,6 +90,8 @@ ament_target_dependencies(navsat_to_absolute_pose_node
   tf2_ros
   mowgli_interfaces
 )
+
+target_link_libraries(navsat_to_absolute_pose_node navsat_status_association)
 
 # ---------------------------------------------------------------------------
 # Executable: localization_monitor_node
@@ -229,6 +242,7 @@ install(
 
 install(
   TARGETS
+    navsat_status_association
     wheel_odometry_node
     navsat_to_absolute_pose_node
     localization_monitor_node
@@ -319,6 +333,18 @@ if(BUILD_TESTING)
     mowgli_interfaces
     sensor_msgs
   )
+
+  ament_add_gtest(test_navsat_status_association
+    test/test_navsat_status_association.cpp
+  )
+  target_include_directories(test_navsat_status_association PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  ament_target_dependencies(test_navsat_status_association
+    mowgli_interfaces
+    sensor_msgs
+  )
+  target_link_libraries(test_navsat_status_association navsat_status_association)
 
   # ---- test_dock_cog_gate ----
   # Pure C++ test of the one-click dock-calibration COG-coherence gate

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -113,6 +113,7 @@ ament_target_dependencies(cog_to_imu
   nav_msgs
   geometry_msgs
   sensor_msgs
+  mowgli_interfaces
 )
 
 target_link_libraries(cog_to_imu yaml-cpp)
@@ -285,6 +286,16 @@ if(BUILD_TESTING)
 
   target_include_directories(test_cog_yaw_math PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
+  ament_add_gtest(test_cog_observation_timing
+    test/test_cog_observation_timing.cpp
+  )
+  target_include_directories(test_cog_observation_timing PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  ament_target_dependencies(test_cog_observation_timing
+    mowgli_interfaces
   )
 
   # ---- test_costmap_scan_filter ----

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -312,6 +312,16 @@ if(BUILD_TESTING)
     mowgli_interfaces
   )
 
+  ament_add_gtest(test_localization_monitor_freshness
+    test/test_localization_monitor_freshness.cpp
+  )
+  target_include_directories(test_localization_monitor_freshness PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  ament_target_dependencies(test_localization_monitor_freshness
+    mowgli_interfaces
+  )
+
   # ---- test_costmap_scan_filter ----
   # Re-implements the static helper so we don't drag rclcpp/main symbols
   # into the test binary; the helper is small enough to keep in sync by

--- a/ros2/src/mowgli_localization/include/mowgli_localization/cog_observation_timing.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/cog_observation_timing.hpp
@@ -1,0 +1,307 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Receipt-provenance timing policy for cog_to_imu.
+//
+// Physical observation intervals are derived exclusively from receiver receipt
+// stamps. Callback cadence, ROS publication rate, and wall-clock delivery gaps
+// are deliberately absent from this API.
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
+
+namespace mowgli_localization
+{
+
+inline double DeriveMaximumCogObservationIntervalSeconds(const double physical_observation_rate_hz,
+                                                         const double period_tolerance_factor)
+{
+  if (!std::isfinite(physical_observation_rate_hz) || physical_observation_rate_hz <= 0.0)
+  {
+    throw std::invalid_argument("physical GNSS observation rate must be finite and positive");
+  }
+  if (!std::isfinite(period_tolerance_factor) || period_tolerance_factor < 1.0)
+  {
+    throw std::invalid_argument("COG observation-period tolerance factor must be >= 1");
+  }
+  return period_tolerance_factor / physical_observation_rate_hz;
+}
+
+inline std::int64_t CogSecondsToNanoseconds(const double seconds)
+{
+  constexpr double kNanosecondsPerSecond = 1.0e9;
+  const double nanoseconds = seconds * kNanosecondsPerSecond;
+  if (!std::isfinite(seconds) || seconds < 0.0 ||
+      nanoseconds > static_cast<double>(std::numeric_limits<std::int64_t>::max()))
+  {
+    throw std::invalid_argument("COG timing duration is invalid or out of range");
+  }
+  return static_cast<std::int64_t>(std::llround(nanoseconds));
+}
+
+enum class CogObservationTimingDecision
+{
+  kSeed,
+  kAdvance,
+  kDuplicate,
+  kTooSoon,
+  kGapReseed,
+  kInvalidProvenance,
+  kReceiptRewind,
+  kRosTimeDiscontinuity,
+};
+
+struct CogObservationTimingResult
+{
+  CogObservationTimingDecision decision{CogObservationTimingDecision::kInvalidProvenance};
+
+  bool accepts_current_observation() const
+  {
+    return decision == CogObservationTimingDecision::kSeed ||
+           decision == CogObservationTimingDecision::kAdvance ||
+           decision == CogObservationTimingDecision::kGapReseed;
+  }
+
+  bool reseeds_baseline() const
+  {
+    return decision == CogObservationTimingDecision::kSeed ||
+           decision == CogObservationTimingDecision::kGapReseed;
+  }
+};
+
+// Bounded receipt-only timing tracker for NavSatFix.
+//
+// A small receipt history distinguishes a delayed duplicate from a genuinely
+// unseen stamp rewind: the former is ignored without touching the active
+// baseline, while the latter resets the receipt epoch and drops the triggering
+// sample. An excessive forward gap accepts the current observation only as the
+// seed of a clean baseline.
+class CogObservationTiming
+{
+public:
+  CogObservationTiming(const double minimum_interval_s,
+                       const double maximum_interval_s,
+                       const double maximum_provenance_age_s,
+                       const std::size_t receipt_history_capacity = 64)
+      : minimum_interval_ns_(CogSecondsToNanoseconds(minimum_interval_s)),
+        maximum_interval_ns_(CogSecondsToNanoseconds(maximum_interval_s)),
+        maximum_provenance_age_ns_(CogSecondsToNanoseconds(maximum_provenance_age_s)),
+        receipt_history_capacity_(receipt_history_capacity)
+  {
+    if (maximum_interval_ns_ <= minimum_interval_ns_)
+    {
+      throw std::invalid_argument("COG maximum observation interval must exceed minimum interval");
+    }
+    if (receipt_history_capacity_ == 0)
+    {
+      throw std::invalid_argument("COG receipt history capacity must be positive");
+    }
+  }
+
+  CogObservationTimingResult Observe(const std::int64_t receipt_time_ns,
+                                     const std::int64_t ros_now_ns)
+  {
+    if (last_ros_now_ns_ && ros_now_ns < *last_ros_now_ns_)
+    {
+      ResetReceiptEpoch();
+      last_ros_now_ns_ = ros_now_ns;
+      return {CogObservationTimingDecision::kRosTimeDiscontinuity};
+    }
+    last_ros_now_ns_ = ros_now_ns;
+
+    // A cached or delayed duplicate is never a new physical sample, even if it
+    // arrives after the provenance-age window. It must not disturb a newer
+    // valid baseline.
+    if (ReceiptWasAccepted(receipt_time_ns))
+    {
+      return {CogObservationTimingDecision::kDuplicate};
+    }
+
+    if (!mowgli_interfaces::gnss_observation_freshness::IsReceiptFresh(receipt_time_ns,
+                                                                       ros_now_ns,
+                                                                       maximum_provenance_age_ns_))
+    {
+      ResetReceiptEpoch();
+      return {CogObservationTimingDecision::kInvalidProvenance};
+    }
+
+    if (!last_receipt_time_ns_)
+    {
+      Accept(receipt_time_ns);
+      return {CogObservationTimingDecision::kSeed};
+    }
+
+    if (receipt_time_ns < *last_receipt_time_ns_)
+    {
+      ResetReceiptEpoch();
+      return {CogObservationTimingDecision::kReceiptRewind};
+    }
+
+    const std::int64_t interval_ns = receipt_time_ns - *last_receipt_time_ns_;
+    if (interval_ns < minimum_interval_ns_)
+    {
+      return {CogObservationTimingDecision::kTooSoon};
+    }
+
+    Accept(receipt_time_ns);
+    if (interval_ns > maximum_interval_ns_)
+    {
+      return {CogObservationTimingDecision::kGapReseed};
+    }
+    return {CogObservationTimingDecision::kAdvance};
+  }
+
+  void Reset()
+  {
+    ResetReceiptEpoch();
+    last_ros_now_ns_.reset();
+  }
+
+  std::optional<std::int64_t> last_receipt_time_ns() const
+  {
+    return last_receipt_time_ns_;
+  }
+
+private:
+  bool ReceiptWasAccepted(const std::int64_t receipt_time_ns) const
+  {
+    return std::find(recent_receipts_.begin(), recent_receipts_.end(), receipt_time_ns) !=
+           recent_receipts_.end();
+  }
+
+  void Accept(const std::int64_t receipt_time_ns)
+  {
+    last_receipt_time_ns_ = receipt_time_ns;
+    recent_receipts_.push_back(receipt_time_ns);
+    while (recent_receipts_.size() > receipt_history_capacity_)
+    {
+      recent_receipts_.pop_front();
+    }
+  }
+
+  void ResetReceiptEpoch()
+  {
+    last_receipt_time_ns_.reset();
+    recent_receipts_.clear();
+  }
+
+  std::int64_t minimum_interval_ns_;
+  std::int64_t maximum_interval_ns_;
+  std::int64_t maximum_provenance_age_ns_;
+  std::size_t receipt_history_capacity_;
+  std::optional<std::int64_t> last_receipt_time_ns_;
+  std::optional<std::int64_t> last_ros_now_ns_;
+  std::deque<std::int64_t> recent_receipts_;
+};
+
+enum class StationaryLatchState
+{
+  kNoLatch,
+  kFresh,
+  kExpired,
+  kInvalidProvenance,
+  kClockDiscontinuity,
+};
+
+struct StationaryLatchResult
+{
+  StationaryLatchState state{StationaryLatchState::kNoLatch};
+  double age_s{0.0};
+
+  bool fresh() const
+  {
+    return state == StationaryLatchState::kFresh;
+  }
+};
+
+// The latch has two explicit clocks:
+// - ROS receipt provenance rejects future/negative age and ROS rewinds;
+// - monotonic elapsed time makes pause/liveness expiry independent of ROS time.
+// Both ages must remain bounded; drift inflation uses the larger elapsed age.
+class StationaryLatchClock
+{
+public:
+  explicit StationaryLatchClock(const double maximum_age_s)
+      : maximum_age_ns_(CogSecondsToNanoseconds(maximum_age_s))
+  {
+  }
+
+  bool Latch(const std::int64_t receipt_time_ns,
+             const std::int64_t ros_now_ns,
+             const std::int64_t monotonic_now_ns)
+  {
+    if (monotonic_now_ns < 0 || !mowgli_interfaces::gnss_observation_freshness::IsReceiptFresh(
+                                    receipt_time_ns, ros_now_ns, maximum_age_ns_))
+    {
+      Reset();
+      return false;
+    }
+    receipt_time_ns_ = receipt_time_ns;
+    latch_monotonic_time_ns_ = monotonic_now_ns;
+    last_ros_now_ns_ = ros_now_ns;
+    last_monotonic_now_ns_ = monotonic_now_ns;
+    return true;
+  }
+
+  StationaryLatchResult Check(const std::int64_t ros_now_ns, const std::int64_t monotonic_now_ns)
+  {
+    if (!receipt_time_ns_ || !latch_monotonic_time_ns_)
+    {
+      return {StationaryLatchState::kNoLatch, 0.0};
+    }
+    if ((last_ros_now_ns_ && ros_now_ns < *last_ros_now_ns_) ||
+        (last_monotonic_now_ns_ && monotonic_now_ns < *last_monotonic_now_ns_))
+    {
+      Reset();
+      return {StationaryLatchState::kClockDiscontinuity, 0.0};
+    }
+    last_ros_now_ns_ = ros_now_ns;
+    last_monotonic_now_ns_ = monotonic_now_ns;
+
+    if (ros_now_ns < *receipt_time_ns_)
+    {
+      Reset();
+      return {StationaryLatchState::kInvalidProvenance, 0.0};
+    }
+
+    const std::int64_t ros_age_ns = ros_now_ns - *receipt_time_ns_;
+    const std::int64_t monotonic_age_ns = monotonic_now_ns - *latch_monotonic_time_ns_;
+    if (ros_age_ns > maximum_age_ns_ || monotonic_age_ns > maximum_age_ns_)
+    {
+      Reset();
+      return {StationaryLatchState::kExpired, 0.0};
+    }
+
+    constexpr double kNanosecondsPerSecond = 1.0e9;
+    const double age_s =
+        static_cast<double>(std::max(ros_age_ns, monotonic_age_ns)) / kNanosecondsPerSecond;
+    return {StationaryLatchState::kFresh, age_s};
+  }
+
+  void Reset()
+  {
+    receipt_time_ns_.reset();
+    latch_monotonic_time_ns_.reset();
+    last_ros_now_ns_.reset();
+    last_monotonic_now_ns_.reset();
+  }
+
+private:
+  std::int64_t maximum_age_ns_;
+  std::optional<std::int64_t> receipt_time_ns_;
+  std::optional<std::int64_t> latch_monotonic_time_ns_;
+  std::optional<std::int64_t> last_ros_now_ns_;
+  std::optional<std::int64_t> last_monotonic_now_ns_;
+};
+
+}  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_node.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_node.hpp
@@ -49,7 +49,9 @@
 #include <memory>
 #include <string>
 
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
+#include "mowgli_localization/localization_monitor_policy.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/int32.hpp"
@@ -57,15 +59,6 @@
 
 namespace mowgli_localization
 {
-
-/// Integer IDs for each localization mode (published on /localization/mode_id).
-enum class LocalizationMode : int32_t
-{
-  DEAD_RECKONING = 0,
-  GPS_ONLY = 1,
-  RTK_FLOAT = 2,
-  RTK_FIXED = 3,
-};
 
 class LocalizationMonitorNode : public rclcpp::Node
 {
@@ -100,7 +93,7 @@ private:
   /**
    * @brief Evaluate the current localization mode from source freshness / quality.
    */
-  LocalizationMode evaluate_mode() const;
+  LocalizationMode evaluate_mode(bool gps_observation_fresh) const;
 
   /**
    * @brief Convert a LocalizationMode enum to its string representation.
@@ -129,7 +122,10 @@ private:
   // Source state
   // ---------------------------------------------------------------------------
   rclcpp::Time last_wheel_odom_stamp_{0, 0, RCL_ROS_TIME};
-  rclcpp::Time last_gps_stamp_{0, 0, RCL_ROS_TIME};
+  mowgli_interfaces::gnss_observation_freshness::PhysicalObservationTracker
+      gps_observation_freshness_;
+  bool gps_freshness_initialized_{false};
+  bool last_gps_observation_fresh_{false};
 
   /// True when the last GPS message carried an RTK-fixed or RTK-float flag.
   bool gps_rtk_active_{false};
@@ -154,6 +150,8 @@ private:
   rclcpp::Subscription<mowgli_interfaces::msg::AbsolutePose>::SharedPtr abs_pose_sub_;
 
   rclcpp::TimerBase::SharedPtr publish_timer_;
+
+  static std::int64_t steady_now_ns();
 };
 
 }  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_policy.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/localization_monitor_policy.hpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <cstdint>
+
+namespace mowgli_localization
+{
+
+enum class LocalizationMode : std::int32_t
+{
+  DEAD_RECKONING = 0,
+  GPS_ONLY = 1,
+  RTK_FLOAT = 2,
+  RTK_FIXED = 3,
+};
+
+inline LocalizationMode EvaluateLocalizationMode(const bool observation_fresh,
+                                                 const bool rtk_active,
+                                                 const bool rtk_fixed)
+{
+  if (!observation_fresh)
+  {
+    return LocalizationMode::DEAD_RECKONING;
+  }
+  if (rtk_fixed)
+  {
+    return LocalizationMode::RTK_FIXED;
+  }
+  if (rtk_active)
+  {
+    return LocalizationMode::RTK_FLOAT;
+  }
+  return LocalizationMode::GPS_ONLY;
+}
+
+}  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/include/mowgli_localization/navsat_status_association.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/navsat_status_association.hpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include "mowgli_interfaces/msg/gnss_status.hpp"
+#include "sensor_msgs/msg/nav_sat_fix.hpp"
+
+namespace mowgli_localization
+{
+
+// Result of adding one delivery to the bounded association state. Complete
+// pairs are deliberately withheld until the monotonic association window
+// closes, so a conflicting sequence on the same receipt stamp can fail closed
+// before any projection is published.
+enum class AssociationEvent
+{
+  kNone,
+  kWaiting,
+  kDuplicateFix,
+  kCachedStatus,
+  kClosedReceipt,
+  kInvalidProvenance,
+  kInvalidIdentity,
+  kAmbiguousReceipt,
+  kReceiptRewind,
+  kSourceRestart,
+  kClockDiscontinuity,
+  kCapacityEviction,
+};
+
+struct AssociatedNavSatObservation
+{
+  sensor_msgs::msg::NavSatFix fix;
+  mowgli_interfaces::msg::GnssStatus status;
+};
+
+struct AssociationBatch
+{
+  AssociationEvent event{AssociationEvent::kNone};
+  std::int64_t event_receipt_time_ns{0};
+  std::vector<AssociatedNavSatObservation> ready;
+  std::vector<sensor_msgs::msg::NavSatFix> fix_only_fallbacks;
+  std::size_t expired_incomplete{0};
+  std::size_t expired_ambiguous{0};
+  std::size_t expired_invalid_provenance{0};
+  std::size_t capacity_evictions{0};
+};
+
+// Exact, bounded rendez-vous for independently delivered /gps/fix and
+// /gps/status observations.
+//
+// Identity and ordering invariants:
+// - receipt provenance (header.stamp) is the only cross-topic pairing key;
+// - coordinates are never compared;
+// - a non-zero status sequence identifies genuine versus cached status;
+// - one receipt carrying different status sequences is ambiguous and dropped;
+// - completed, expired, evicted, and rejected receipts cannot be resurrected;
+// - queue deadlines use monotonic time; receipt validity uses ROS time;
+// - a ROS/monotonic clock rewind clears the association epoch and drops the
+//   triggering delivery.
+class NavSatStatusAssociation
+{
+public:
+  NavSatStatusAssociation(std::size_t maximum_pending_receipts,
+                          std::int64_t association_window_ns,
+                          std::int64_t maximum_provenance_age_ns);
+
+  AssociationBatch AddFix(const sensor_msgs::msg::NavSatFix& fix,
+                          std::int64_t receipt_time_ns,
+                          std::int64_t ros_now_ns,
+                          std::int64_t monotonic_now_ns);
+
+  AssociationBatch AddStatus(const mowgli_interfaces::msg::GnssStatus& status,
+                             std::int64_t receipt_time_ns,
+                             std::int64_t ros_now_ns,
+                             std::int64_t monotonic_now_ns);
+
+  // Close every association whose monotonic window has elapsed. Complete,
+  // unambiguous pairs are returned exactly once. A fix-only entry is returned
+  // separately for the safe AbsolutePose-only fallback; it never gains typed
+  // RTK authority. Status-only and ambiguous entries are dropped.
+  AssociationBatch Poll(std::int64_t ros_now_ns, std::int64_t monotonic_now_ns);
+
+  void Reset();
+
+  std::size_t pending_size() const
+  {
+    return pending_.size();
+  }
+
+private:
+  struct PendingObservation
+  {
+    std::int64_t first_delivery_time_ns{0};
+    std::optional<sensor_msgs::msg::NavSatFix> fix;
+    std::optional<mowgli_interfaces::msg::GnssStatus> status;
+    bool ambiguous{false};
+  };
+
+  using PendingMap = std::map<std::int64_t, PendingObservation>;
+
+  bool Prepare(std::int64_t ros_now_ns, std::int64_t monotonic_now_ns, AssociationBatch& batch);
+  void CollectDue(std::int64_t ros_now_ns, std::int64_t monotonic_now_ns, AssociationBatch& batch);
+  PendingMap::iterator CreatePending(std::int64_t receipt_time_ns,
+                                     std::int64_t monotonic_now_ns,
+                                     AssociationBatch& batch);
+  void CloseAndErase(PendingMap::iterator entry);
+  void CloseReceipt(std::int64_t receipt_time_ns);
+  void ResetAssociationEpoch();
+  bool ReceiptIsClosed(std::int64_t receipt_time_ns) const;
+  bool ReceiptCanStart(std::int64_t receipt_time_ns, AssociationBatch& batch) const;
+  bool ProvenanceIsValid(std::int64_t receipt_time_ns, std::int64_t ros_now_ns) const;
+
+  std::size_t maximum_pending_receipts_;
+  std::int64_t association_window_ns_;
+  std::int64_t maximum_provenance_age_ns_;
+
+  PendingMap pending_;
+  std::optional<std::int64_t> greatest_receipt_seen_ns_;
+  std::optional<std::int64_t> greatest_closed_receipt_ns_;
+  std::optional<std::uint64_t> latest_status_sequence_;
+  std::optional<std::int64_t> latest_status_receipt_ns_;
+  std::optional<std::int64_t> last_ros_now_ns_;
+  std::optional<std::int64_t> last_monotonic_now_ns_;
+};
+
+}  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/include/mowgli_localization/navsat_to_absolute_pose_node.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/navsat_to_absolute_pose_node.hpp
@@ -26,13 +26,6 @@
  * authoritative RTK/fix state, then publishes /gps/absolute_pose plus the
  * robot_localization-friendly /gps/pose_cov twin.
  *
- * /gps/pose_cov additionally requires a GENUINELY NEW receiver observation.
- * The adapter republishes its last accepted fix on a timer with the receipt
- * stamp unchanged, so callbacks keep arriving after the receiver freezes.
- * /gps/absolute_pose still mirrors every delivery (it carries its own stamp
- * and flags), but the pose_cov twin is consumed as an absolute anchor — see
- * the freshness gate in on_navsat_fix.
- *
  * Subscribed topics:
  *   /gps/fix     sensor_msgs/msg/NavSatFix
  *   /gps/status  mowgli_interfaces/msg/GnssStatus
@@ -45,14 +38,16 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "geometry_msgs/msg/pose_with_covariance.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "mowgli_interfaces/gnss_observation_freshness.hpp"
 #include "mowgli_interfaces/msg/absolute_pose.hpp"
 #include "mowgli_interfaces/msg/gnss_status.hpp"
+#include "mowgli_localization/navsat_status_association.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "std_srvs/srv/trigger.hpp"
@@ -75,6 +70,12 @@ private:
   void create_services();
 
   void on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstSharedPtr msg);
+  void on_gnss_status(mowgli_interfaces::msg::GnssStatus::ConstSharedPtr msg);
+  void on_association_timer();
+  void handle_association_batch(AssociationBatch batch);
+  void project_observation(
+      sensor_msgs::msg::NavSatFix::ConstSharedPtr msg,
+      const std::optional<mowgli_interfaces::msg::GnssStatus>& authoritative_status);
   void on_set_datum(const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                     std::shared_ptr<std_srvs::srv::Trigger::Response> response);
 
@@ -90,6 +91,9 @@ private:
   double datum_lat_{0.0};
   double datum_lon_{0.0};
   double cos_datum_lat_{1.0};  ///< Precomputed cos(datum_lat) for projection
+  double status_pairing_window_s_{0.25};
+  double status_pairing_max_provenance_age_s_{2.0};
+  std::size_t status_pairing_capacity_{32};
 
   // Latest GPS fix for the set_datum service.
   sensor_msgs::msg::NavSatFix last_fix_;
@@ -109,22 +113,13 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_cov_pub_;
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr fix_sub_;
   rclcpp::Subscription<mowgli_interfaces::msg::GnssStatus>::SharedPtr status_sub_;
+  rclcpp::TimerBase::SharedPtr association_timer_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr set_datum_srv_;
 
-  /// Latest typed GNSS status. /gps/status is the authoritative RTK/fix-state
-  /// source even when /gps/fix covariance is missing or rejected.
-  mowgli_interfaces::msg::GnssStatus last_status_;
-  bool has_status_{false};
-
-  /// Receiver-receipt identity of the /gps/fix stream. The Universal GNSS
-  /// adapter preserves the receipt stamp across its timer-driven cached
-  /// republications, so the stamp — never callback arrival time — is what
-  /// distinguishes a genuine new observation from a frozen receiver.
-  ///
-  /// sequence=0 selects the tracker's receipt-only compatibility mode:
-  /// NavSatFix has no sequence field, and pairing it against the separately
-  /// delivered /gps/status sequence is deliberately left to a follow-up.
-  mowgli_interfaces::gnss_observation_freshness::ObservationTracker fix_observation_tracker_;
+  /// Bounded exact receipt-provenance association. There is deliberately no
+  /// authoritative "latest status" fallback: an unmatched fix may produce only
+  /// the NavSatFix-derived AbsolutePose path, never a typed RTK projection.
+  std::unique_ptr<NavSatStatusAssociation> status_association_;
 
   /// TF listener to resolve base_footprint↔gps_link (static from URDF,
   /// gives the lever arm) and map↔base_footprint (dynamic from ekf_map,

--- a/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
+++ b/ros2/src/mowgli_localization/src/cog_to_imu_node.cpp
@@ -17,17 +17,21 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <ctime>
 #include <deque>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>
 
 #include "geometry_msgs/msg/quaternion.hpp"
+#include "mowgli_localization/cog_observation_timing.hpp"
 #include "mowgli_localization/cog_yaw_math.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/qos.hpp"
@@ -45,6 +49,20 @@ namespace
 {
 constexpr double kDegToRad = M_PI / 180.0;
 constexpr double kMetersPerDeg = 111319.49079327357;
+constexpr double kNanosecondsPerSecond = 1.0e9;
+
+std::int64_t stamp_to_nanoseconds(const builtin_interfaces::msg::Time& stamp)
+{
+  return static_cast<std::int64_t>(stamp.sec) * static_cast<std::int64_t>(kNanosecondsPerSecond) +
+         static_cast<std::int64_t>(stamp.nanosec);
+}
+
+std::int64_t steady_now_nanoseconds()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
 
 rclcpp::QoS sensor_qos()
 {
@@ -142,7 +160,33 @@ public:
     rotation_quiet_min_samples_ = declare_parameter<int>("rotation_quiet_min_samples", 2);
     max_pos_accuracy_ = declare_parameter<double>("max_pos_accuracy_m", 0.05);
     min_dt_ = declare_parameter<double>("min_sample_dt_s", 0.05);
-    max_dt_ = declare_parameter<double>("max_sample_dt_s", 0.50);
+    physical_gnss_observation_rate_hz_ =
+        declare_parameter<double>("physical_gnss_observation_rate_hz", 5.0);
+    // A 1.5-period deadline admits up to half a receiver period of receipt
+    // jitter at every configured rate, while a genuinely missed full cycle
+    // (2 periods) still resets instead of spanning an unbounded baseline.
+    sample_period_tolerance_factor_ =
+        declare_parameter<double>("sample_period_tolerance_factor", 1.5);
+    const double expected_observation_period_s =
+        DeriveMaximumCogObservationIntervalSeconds(physical_gnss_observation_rate_hz_, 1.0);
+    const double derived_max_dt_s =
+        DeriveMaximumCogObservationIntervalSeconds(physical_gnss_observation_rate_hz_,
+                                                   sample_period_tolerance_factor_);
+    // Existing max_sample_dt_s remains an explicit operator override. Its
+    // default is now derived from PHYSICAL receiver cadence, never callback or
+    // ROS publication cadence.
+    max_dt_ = declare_parameter<double>("max_sample_dt_s", derived_max_dt_s);
+    maximum_fix_provenance_age_s_ = declare_parameter<double>("maximum_fix_provenance_age_s", 2.0);
+    if (!std::isfinite(min_dt_) || min_dt_ < 0.0 || !std::isfinite(max_dt_) ||
+        max_dt_ < expected_observation_period_s || !std::isfinite(maximum_fix_provenance_age_s_) ||
+        maximum_fix_provenance_age_s_ <= 0.0)
+    {
+      throw std::invalid_argument(
+          "COG timing requires finite non-negative min_dt, max_dt >= the physical "
+          "observation period, and positive provenance age");
+    }
+    observation_timing_ =
+        std::make_unique<CogObservationTiming>(min_dt_, max_dt_, maximum_fix_provenance_age_s_);
     max_yaw_var_ = declare_parameter<double>("max_yaw_variance", 3.0);
     min_yaw_var_ = declare_parameter<double>("min_yaw_variance", 7.6e-5);
 
@@ -159,6 +203,11 @@ public:
     stationary_seed_rate_hz_ = declare_parameter<double>("stationary_seed_rate_hz", 2.0);
     stationary_drift_rate_ = declare_parameter<double>("stationary_yaw_drift_rate", 0.005);
     stationary_max_age_s_ = declare_parameter<double>("stationary_max_age_s", 600.0);
+    if (!std::isfinite(stationary_max_age_s_) || stationary_max_age_s_ <= 0.0)
+    {
+      throw std::invalid_argument("stationary_max_age_s must be finite and positive");
+    }
+    stationary_latch_clock_ = std::make_unique<StationaryLatchClock>(stationary_max_age_s_);
 
     // Datum for flat-earth ENU projection.
     datum_lat_ = declare_parameter<double>("datum_lat", 0.0);
@@ -297,6 +346,15 @@ public:
                 lever_arm_x_,
                 lever_arm_y_,
                 omega_noise_rps_);
+    RCLCPP_INFO(get_logger(),
+                "COG receipt timing: physical GNSS rate %.3f Hz, expected period %.3f s, "
+                "effective max gap %.3f s (automatic-default period factor %.2f), "
+                "min gap %.3f s",
+                physical_gnss_observation_rate_hz_,
+                expected_observation_period_s,
+                max_dt_,
+                sample_period_tolerance_factor_,
+                min_dt_);
   }
 
 private:
@@ -340,6 +398,38 @@ private:
       return;
     }
 
+    const std::int64_t receipt_time_ns = stamp_to_nanoseconds(msg.header.stamp);
+    const rclcpp::Time ros_now = now();
+    const CogObservationTimingResult timing =
+        observation_timing_->Observe(receipt_time_ns, ros_now.nanoseconds());
+    if (!timing.accepts_current_observation())
+    {
+      if (timing.decision == CogObservationTimingDecision::kDuplicate ||
+          timing.decision == CogObservationTimingDecision::kTooSoon)
+      {
+        return;
+      }
+
+      reset_cog_temporal_state();
+      RCLCPP_WARN_THROTTLE(
+          get_logger(),
+          *get_clock(),
+          5000,
+          "COG rejected invalid/rewound receipt timing (decision=%d, receipt=%lld ns)",
+          static_cast<int>(timing.decision),
+          static_cast<long long>(receipt_time_ns));
+      return;
+    }
+    if (timing.decision == CogObservationTimingDecision::kGapReseed)
+    {
+      reset_cog_temporal_state();
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "COG physical observation gap exceeded %.3f s; baseline reseeded",
+                           max_dt_);
+    }
+
     if (!datum_seeded_)
     {
       datum_lat_ = msg.latitude;
@@ -354,29 +444,8 @@ private:
 
     const double x = (msg.longitude - datum_lon_) * cos_datum_lat_ * kMetersPerDeg;
     const double y = (msg.latitude - datum_lat_) * kMetersPerDeg;
-    const double t = static_cast<double>(msg.header.stamp.sec) +
-                     static_cast<double>(msg.header.stamp.nanosec) * 1e-9;
+    const double t = static_cast<double>(receipt_time_ns) / kNanosecondsPerSecond;
     pos_acc = std::max(pos_acc, 0.002);
-
-    // Sample-to-sample dt sanity. A long gap means we lost lock or paused;
-    // the anchor's age would inflate σ_pos and the wheel direction may
-    // have flipped silently — drop the anchor and restart accumulation.
-    if (have_last_sample_)
-    {
-      const double dt_sample = t - last_sample_t_;
-      if (dt_sample > max_dt_)
-      {
-        have_anchor_ = false;
-        have_last_sample_ = false;
-      }
-      else if (dt_sample < min_dt_)
-      {
-        // Duplicate / out-of-order; ignore but don't disturb anchor.
-        return;
-      }
-    }
-    last_sample_t_ = t;
-    have_last_sample_ = true;
 
     // Rotation gate. During in-place pivots (PRE_ROTATE, headland turns)
     // the GPS antenna swings on a lever-arm arc around base_link. Each
@@ -553,8 +622,17 @@ private:
     // fix epoch.
     publish_imu(rclcpp::Time(msg.header.stamp), yaw, yaw_var);
 
-    const double mono_now = static_cast<double>(get_clock()->now().nanoseconds()) * 1e-9;
-    latched_yaw_ = LatchedYaw{mono_now, yaw, yaw_var};
+    const rclcpp::Time latch_ros_now = now();
+    if (stationary_latch_clock_->Latch(receipt_time_ns,
+                                       latch_ros_now.nanoseconds(),
+                                       steady_now_nanoseconds()))
+    {
+      latched_yaw_ = LatchedYaw{yaw, yaw_var};
+    }
+    else
+    {
+      latched_yaw_.reset();
+    }
     // Fresh latch — start counting rotation away from this heading from zero.
     abs_dtheta_since_latch_ = 0.0;
 
@@ -574,6 +652,18 @@ private:
   {
     if (!latched_yaw_)
     {
+      return;
+    }
+    const rclcpp::Time ros_now = now();
+    const StationaryLatchResult latch_time =
+        stationary_latch_clock_->Check(ros_now.nanoseconds(), steady_now_nanoseconds());
+    if (!latch_time.fresh())
+    {
+      latched_yaw_.reset();
+      if (latch_time.state == StationaryLatchState::kClockDiscontinuity)
+      {
+        RCLCPP_WARN(get_logger(), "COG stationary latch reset after clock discontinuity");
+      }
       return;
     }
     if (std::abs(wheel_vx_) >= min_abs_wheel_)
@@ -616,21 +706,26 @@ private:
     if (abs_dtheta_since_latch_.load() > latch_max_rotation_rad_)
     {
       latched_yaw_.reset();
+      stationary_latch_clock_->Reset();
       ++latch_invalidated_rotation_;
       return;
     }
-    const double mono_now = static_cast<double>(get_clock()->now().nanoseconds()) * 1e-9;
-    const double age = std::max(0.0, mono_now - latched_yaw_->stamp);
-    if (age > stationary_max_age_s_)
-    {
-      latched_yaw_.reset();
-      return;
-    }
+    const double age = latch_time.age_s;
     const double drift_var = (stationary_drift_rate_ * age) * (stationary_drift_rate_ * age);
     const double yaw_var =
         std::max(min_yaw_var_, std::min(latched_yaw_->base_var + drift_var, max_yaw_var_));
-    publish_imu(now(), latched_yaw_->yaw, yaw_var);
+    publish_imu(ros_now, latched_yaw_->yaw, yaw_var);
     ++stationary_seeds_published_;
+  }
+
+  void reset_cog_temporal_state()
+  {
+    have_anchor_ = false;
+    anchor_wheel_sign_ = 0;
+    abs_dtheta_since_anchor_ = 0.0;
+    latched_yaw_.reset();
+    stationary_latch_clock_->Reset();
+    abs_dtheta_since_latch_ = 0.0;
   }
 
   void publish_imu(const rclcpp::Time& stamp, double yaw, double yaw_var)
@@ -926,6 +1021,9 @@ private:
   double latch_rotation_deadband_rps_{0.05};
   double max_pos_accuracy_{};
   double min_dt_{}, max_dt_{};
+  double physical_gnss_observation_rate_hz_{5.0};
+  double sample_period_tolerance_factor_{1.5};
+  double maximum_fix_provenance_age_s_{2.0};
   double max_yaw_var_{}, min_yaw_var_{};
   double stationary_seed_rate_hz_{};
   double stationary_drift_rate_{};
@@ -952,20 +1050,20 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::MagneticField>::SharedPtr mag_sub_;
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr stats_timer_, stationary_timer_, mag_refit_timer_;
+  std::unique_ptr<CogObservationTiming> observation_timing_;
+  std::unique_ptr<StationaryLatchClock> stationary_latch_clock_;
 
   // Baseline accumulator. The COG yaw is computed from the displacement
   // between an anchor sample and the current sample once the accumulated
   // displacement crosses min_baseline_displacement_m. The anchor advances
   // to the current sample after each successful publish; it is reset
   // whenever the wheel direction changes, the robot is stationary, or
-  // the gap to the previous fix exceeds max_dt_.
+  // CogObservationTiming reports a physical receipt gap exceeding max_dt_.
   bool have_anchor_{false};
   double anchor_t_{}, anchor_x_{}, anchor_y_{}, anchor_pa_{};
   // Wheel sign at the anchor sample: +1 forward, -1 reverse, 0 unknown.
   // A change in sign during the baseline invalidates the anchor.
   int anchor_wheel_sign_{0};
-  double last_sample_t_{};
-  bool have_last_sample_{false};
   // wheel_vx_ / wheel_omega_ are mutated from the /wheel_odom callback
   // (50 Hz), gyro_z_ from the /imu/data callback (100 Hz). Both are
   // read by on_fix() (GPS callback, ~5 Hz) and by
@@ -1006,7 +1104,6 @@ private:
 
   struct LatchedYaw
   {
-    double stamp;
     double yaw;
     double base_var;
   };

--- a/ros2/src/mowgli_localization/src/localization_monitor_node.cpp
+++ b/ros2/src/mowgli_localization/src/localization_monitor_node.cpp
@@ -133,7 +133,25 @@ void LocalizationMonitorNode::on_absolute_pose(
 {
   using Flags = mowgli_interfaces::msg::AbsolutePose;
 
-  last_gps_stamp_ = msg->header.stamp;
+  const rclcpp::Time ros_now = now();
+  const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
+  const auto update = gps_observation_freshness_.Observe(0,
+                                                         receipt_stamp.nanoseconds(),
+                                                         ros_now.nanoseconds(),
+                                                         steady_now_ns());
+  using mowgli_interfaces::gnss_observation_freshness::IsAcceptedObservation;
+  using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
+  if (!IsAcceptedObservation(update))
+  {
+    if (update == ObservationUpdate::kInvalidProvenance)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "localization monitor: GPS receipt stamp is zero/future; sample denied");
+    }
+    return;
+  }
 
   gps_rtk_fixed_ = (msg->flags & Flags::FLAG_GPS_RTK_FIXED) != 0u;
   gps_rtk_active_ = gps_rtk_fixed_ || ((msg->flags & Flags::FLAG_GPS_RTK_FLOAT) != 0u) ||
@@ -146,7 +164,45 @@ void LocalizationMonitorNode::on_absolute_pose(
 
 void LocalizationMonitorNode::on_publish_timer()
 {
-  const LocalizationMode instant = evaluate_mode();
+  const rclcpp::Time now = this->now();
+  const auto maximum_age_ns = static_cast<std::int64_t>(gps_timeout_ * 1.0e9);
+  const auto steady_now = steady_now_ns();
+  const bool gps_observation_fresh =
+      gps_observation_freshness_.ObservationIsFresh(now.nanoseconds(), steady_now, maximum_age_ns);
+  if (gps_observation_freshness_.ConsumeEpochReset())
+  {
+    // A clock epoch break is not mode flicker. Publish the safe mode now and
+    // require new provenance before ordinary mode debounce can start again.
+    stable_mode_ = LocalizationMode::DEAD_RECKONING;
+    pending_mode_ = stable_mode_;
+    pending_since_ = now;
+  }
+  const bool gps_delivery_live =
+      gps_observation_freshness_.DeliveryIsLive(steady_now, maximum_age_ns);
+  if (!gps_freshness_initialized_)
+  {
+    gps_freshness_initialized_ = true;
+    last_gps_observation_fresh_ = gps_observation_fresh;
+  }
+  else if (gps_observation_fresh != last_gps_observation_fresh_)
+  {
+    last_gps_observation_fresh_ = gps_observation_fresh;
+    if (gps_observation_fresh)
+    {
+      RCLCPP_INFO(get_logger(), "GNSS physical observation freshness recovered");
+    }
+    else if (gps_delivery_live)
+    {
+      RCLCPP_WARN(get_logger(),
+                  "GNSS physical observations stale while cached message delivery remains active");
+    }
+    else
+    {
+      RCLCPP_WARN(get_logger(), "GNSS physical observations and message delivery are stale");
+    }
+  }
+
+  const LocalizationMode instant = evaluate_mode(gps_observation_fresh);
 
   // Hysteresis (mode_debounce_sec_): only commit a changed mode once the new
   // value has persisted continuously for the debounce window. This filters the
@@ -154,7 +210,6 @@ void LocalizationMonitorNode::on_publish_timer()
   // toggle every epoch during motion while position σ stays sub-cm) so the
   // published localization mode — and anything gating on it — does not flap.
   // mode_debounce_sec_ <= 0 disables the hysteresis (commit immediately).
-  const rclcpp::Time now = this->now();
   if (instant == stable_mode_)
   {
     // Back to the committed mode — cancel any pending change.
@@ -189,28 +244,9 @@ void LocalizationMonitorNode::on_publish_timer()
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-LocalizationMode LocalizationMonitorNode::evaluate_mode() const
+LocalizationMode LocalizationMonitorNode::evaluate_mode(const bool gps_observation_fresh) const
 {
-  const bool gps_fresh = is_fresh(last_gps_stamp_, gps_timeout_);
-
-  // Ordered from best to worst; first matching rule wins.
-
-  if (gps_fresh && gps_rtk_fixed_)
-  {
-    return LocalizationMode::RTK_FIXED;
-  }
-
-  if (gps_fresh && gps_rtk_active_)
-  {
-    return LocalizationMode::RTK_FLOAT;
-  }
-
-  if (gps_fresh)
-  {
-    return LocalizationMode::GPS_ONLY;
-  }
-
-  return LocalizationMode::DEAD_RECKONING;
+  return EvaluateLocalizationMode(gps_observation_fresh, gps_rtk_active_, gps_rtk_fixed_);
 }
 
 std::string LocalizationMonitorNode::mode_to_string(const LocalizationMode mode)
@@ -241,6 +277,13 @@ bool LocalizationMonitorNode::is_fresh(const rclcpp::Time last_stamp,
 
   const rclcpp::Duration age = now() - last_stamp;
   return age.seconds() < timeout_sec;
+}
+
+std::int64_t LocalizationMonitorNode::steady_now_ns()
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
 }
 
 }  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/src/navsat_status_association.cpp
+++ b/ros2/src/mowgli_localization/src/navsat_status_association.cpp
@@ -1,0 +1,401 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mowgli_localization/navsat_status_association.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
+
+namespace mowgli_localization
+{
+
+NavSatStatusAssociation::NavSatStatusAssociation(const std::size_t maximum_pending_receipts,
+                                                 const std::int64_t association_window_ns,
+                                                 const std::int64_t maximum_provenance_age_ns)
+    : maximum_pending_receipts_(std::max<std::size_t>(maximum_pending_receipts, 1U)),
+      association_window_ns_(std::max<std::int64_t>(association_window_ns, 0)),
+      maximum_provenance_age_ns_(std::max<std::int64_t>(maximum_provenance_age_ns, 0))
+{
+}
+
+AssociationBatch NavSatStatusAssociation::AddFix(const sensor_msgs::msg::NavSatFix& fix,
+                                                 const std::int64_t receipt_time_ns,
+                                                 const std::int64_t ros_now_ns,
+                                                 const std::int64_t monotonic_now_ns)
+{
+  AssociationBatch batch;
+  batch.event_receipt_time_ns = receipt_time_ns;
+  if (!Prepare(ros_now_ns, monotonic_now_ns, batch))
+  {
+    return batch;
+  }
+  if (!ProvenanceIsValid(receipt_time_ns, ros_now_ns))
+  {
+    batch.event = AssociationEvent::kInvalidProvenance;
+    return batch;
+  }
+
+  auto entry = pending_.find(receipt_time_ns);
+  if (entry == pending_.end())
+  {
+    if (!ReceiptCanStart(receipt_time_ns, batch))
+    {
+      return batch;
+    }
+    entry = CreatePending(receipt_time_ns, monotonic_now_ns, batch);
+  }
+
+  if (entry->second.fix.has_value())
+  {
+    batch.event = AssociationEvent::kDuplicateFix;
+    return batch;
+  }
+
+  entry->second.fix = fix;
+  if (batch.event == AssociationEvent::kNone)
+  {
+    batch.event = AssociationEvent::kWaiting;
+  }
+  return batch;
+}
+
+AssociationBatch NavSatStatusAssociation::AddStatus(
+    const mowgli_interfaces::msg::GnssStatus& status,
+    const std::int64_t receipt_time_ns,
+    const std::int64_t ros_now_ns,
+    const std::int64_t monotonic_now_ns)
+{
+  AssociationBatch batch;
+  batch.event_receipt_time_ns = receipt_time_ns;
+  if (!Prepare(ros_now_ns, monotonic_now_ns, batch))
+  {
+    return batch;
+  }
+  if (!ProvenanceIsValid(receipt_time_ns, ros_now_ns))
+  {
+    batch.event = AssociationEvent::kInvalidProvenance;
+    return batch;
+  }
+
+  const std::uint64_t sequence = status.position_observation_sequence;
+  auto entry = pending_.find(receipt_time_ns);
+
+  // Universal GNSS always supplies a non-zero position sequence. Accepting a
+  // legacy zero here would make same-stamp distinct observations impossible to
+  // disambiguate, so typed RTK authority fails closed instead.
+  if (sequence == 0)
+  {
+    if (entry != pending_.end())
+    {
+      CloseAndErase(entry);
+    }
+    else
+    {
+      CloseReceipt(receipt_time_ns);
+    }
+    batch.event = AssociationEvent::kInvalidIdentity;
+    return batch;
+  }
+
+  if (ReceiptIsClosed(receipt_time_ns) && entry == pending_.end())
+  {
+    batch.event = AssociationEvent::kClosedReceipt;
+    return batch;
+  }
+
+  if (entry != pending_.end() && entry->second.status.has_value())
+  {
+    if (entry->second.status->position_observation_sequence == sequence)
+    {
+      batch.event = AssociationEvent::kCachedStatus;
+    }
+    else
+    {
+      entry->second.status.reset();
+      entry->second.ambiguous = true;
+      batch.event = AssociationEvent::kAmbiguousReceipt;
+    }
+    return batch;
+  }
+
+  bool source_restart = false;
+  if (latest_status_sequence_ && latest_status_receipt_ns_)
+  {
+    const std::uint64_t latest_sequence = *latest_status_sequence_;
+    const std::int64_t latest_receipt = *latest_status_receipt_ns_;
+
+    // The SAME position observation, re-published under a LATER receipt stamp.
+    // This is the receiver's normal steady state, not an identity violation:
+    // Universal GNSS publishes fix+status together on a timer (publish_rate_hz,
+    // 10 Hz by default) while the receipt clock advances on ANY accepted field
+    // merge — a satellite-count or CN0 update is enough — whereas
+    // position_observation_sequence advances only on an accepted POSITION
+    // observation. So between two fixes the stamp moves and the sequence does
+    // not, and treating that as ambiguous silenced /gps/absolute_pose and
+    // /gps/pose_cov completely (100 % of observations dropped at 10 Hz publish
+    // / 5 Hz position rate). Handle it exactly like a cached status: emit
+    // nothing for this receipt — one output per PHYSICAL observation is the
+    // point of the whole gate — and leave other pending associations alone.
+    if (sequence == latest_sequence && receipt_time_ns > latest_receipt)
+    {
+      if (entry != pending_.end())
+      {
+        CloseAndErase(entry);
+      }
+      else
+      {
+        CloseReceipt(receipt_time_ns);
+      }
+      latest_status_receipt_ns_ = receipt_time_ns;
+      batch.event = AssociationEvent::kCachedStatus;
+      return batch;
+    }
+
+    // A repeated sequence on an EARLIER stamp, or two sequences on one stamp,
+    // does violate the upstream identity invariant. Mark any still-pending
+    // counterpart as ambiguous and never guess which observation the fix
+    // represents.
+    if ((sequence == latest_sequence && receipt_time_ns < latest_receipt) ||
+        (sequence != latest_sequence && receipt_time_ns == latest_receipt))
+    {
+      auto prior = pending_.find(latest_receipt);
+      if (prior != pending_.end())
+      {
+        prior->second.status.reset();
+        prior->second.ambiguous = true;
+      }
+      if (entry != pending_.end())
+      {
+        entry->second.status.reset();
+        entry->second.ambiguous = true;
+      }
+      else
+      {
+        CloseReceipt(receipt_time_ns);
+      }
+      batch.event = AssociationEvent::kAmbiguousReceipt;
+      return batch;
+    }
+
+    // A lower sequence with a later receipt is an explicit receiver restart.
+    // Preserve only a fix already waiting on this exact new receipt; every
+    // older association belongs to the previous source epoch.
+    source_restart = sequence < latest_sequence && receipt_time_ns > latest_receipt;
+    if (source_restart)
+    {
+      std::optional<PendingObservation> exact_waiting_fix;
+      if (entry != pending_.end() && entry->second.fix.has_value() && !entry->second.ambiguous)
+      {
+        exact_waiting_fix = std::move(entry->second);
+      }
+      ResetAssociationEpoch();
+      if (exact_waiting_fix)
+      {
+        pending_.emplace(receipt_time_ns, std::move(*exact_waiting_fix));
+        greatest_receipt_seen_ns_ = receipt_time_ns;
+      }
+      entry = pending_.find(receipt_time_ns);
+      batch.event = AssociationEvent::kSourceRestart;
+    }
+    else if (sequence > latest_sequence && receipt_time_ns < latest_receipt)
+    {
+      // A continuing sequence whose receipt time moves backward is neither a
+      // valid backlog observation nor a restart. Isolate this receipt only.
+      if (entry != pending_.end())
+      {
+        CloseAndErase(entry);
+      }
+      else
+      {
+        CloseReceipt(receipt_time_ns);
+      }
+      batch.event = AssociationEvent::kReceiptRewind;
+      return batch;
+    }
+  }
+
+  if (entry == pending_.end())
+  {
+    if (!ReceiptCanStart(receipt_time_ns, batch))
+    {
+      return batch;
+    }
+    entry = CreatePending(receipt_time_ns, monotonic_now_ns, batch);
+  }
+
+  entry->second.status = status;
+  if (!latest_status_receipt_ns_ || receipt_time_ns > *latest_status_receipt_ns_ || source_restart)
+  {
+    latest_status_sequence_ = sequence;
+    latest_status_receipt_ns_ = receipt_time_ns;
+  }
+  if (batch.event == AssociationEvent::kNone)
+  {
+    batch.event = AssociationEvent::kWaiting;
+  }
+  return batch;
+}
+
+AssociationBatch NavSatStatusAssociation::Poll(const std::int64_t ros_now_ns,
+                                               const std::int64_t monotonic_now_ns)
+{
+  AssociationBatch batch;
+  Prepare(ros_now_ns, monotonic_now_ns, batch);
+  return batch;
+}
+
+void NavSatStatusAssociation::Reset()
+{
+  ResetAssociationEpoch();
+  last_ros_now_ns_.reset();
+  last_monotonic_now_ns_.reset();
+}
+
+bool NavSatStatusAssociation::Prepare(const std::int64_t ros_now_ns,
+                                      const std::int64_t monotonic_now_ns,
+                                      AssociationBatch& batch)
+{
+  if ((last_ros_now_ns_ && ros_now_ns < *last_ros_now_ns_) ||
+      (last_monotonic_now_ns_ && monotonic_now_ns < *last_monotonic_now_ns_))
+  {
+    ResetAssociationEpoch();
+    last_ros_now_ns_ = ros_now_ns;
+    last_monotonic_now_ns_ = monotonic_now_ns;
+    batch.event = AssociationEvent::kClockDiscontinuity;
+    return false;
+  }
+
+  last_ros_now_ns_ = ros_now_ns;
+  last_monotonic_now_ns_ = monotonic_now_ns;
+  CollectDue(ros_now_ns, monotonic_now_ns, batch);
+  return true;
+}
+
+void NavSatStatusAssociation::CollectDue(const std::int64_t ros_now_ns,
+                                         const std::int64_t monotonic_now_ns,
+                                         AssociationBatch& batch)
+{
+  for (auto entry = pending_.begin(); entry != pending_.end();)
+  {
+    const std::int64_t first_delivery = entry->second.first_delivery_time_ns;
+    if (monotonic_now_ns < first_delivery ||
+        monotonic_now_ns - first_delivery < association_window_ns_)
+    {
+      ++entry;
+      continue;
+    }
+
+    if (!ProvenanceIsValid(entry->first, ros_now_ns))
+    {
+      ++batch.expired_invalid_provenance;
+    }
+    else if (entry->second.ambiguous)
+    {
+      ++batch.expired_ambiguous;
+    }
+    else if (entry->second.fix && entry->second.status)
+    {
+      batch.ready.push_back(AssociatedNavSatObservation{std::move(*entry->second.fix),
+                                                        std::move(*entry->second.status)});
+    }
+    else if (entry->second.fix)
+    {
+      batch.fix_only_fallbacks.push_back(std::move(*entry->second.fix));
+    }
+    else
+    {
+      ++batch.expired_incomplete;
+    }
+
+    CloseReceipt(entry->first);
+    entry = pending_.erase(entry);
+  }
+}
+
+NavSatStatusAssociation::PendingMap::iterator NavSatStatusAssociation::CreatePending(
+    const std::int64_t receipt_time_ns,
+    const std::int64_t monotonic_now_ns,
+    AssociationBatch& batch)
+{
+  if (pending_.size() >= maximum_pending_receipts_)
+  {
+    const auto oldest = std::min_element(pending_.begin(),
+                                         pending_.end(),
+                                         [](const auto& lhs, const auto& rhs)
+                                         {
+                                           if (lhs.second.first_delivery_time_ns !=
+                                               rhs.second.first_delivery_time_ns)
+                                           {
+                                             return lhs.second.first_delivery_time_ns <
+                                                    rhs.second.first_delivery_time_ns;
+                                           }
+                                           return lhs.first < rhs.first;
+                                         });
+    CloseAndErase(oldest);
+    ++batch.capacity_evictions;
+    batch.event = AssociationEvent::kCapacityEviction;
+  }
+
+  greatest_receipt_seen_ns_ = greatest_receipt_seen_ns_
+                                  ? std::max(*greatest_receipt_seen_ns_, receipt_time_ns)
+                                  : receipt_time_ns;
+  return pending_
+      .emplace(receipt_time_ns,
+               PendingObservation{monotonic_now_ns, std::nullopt, std::nullopt, false})
+      .first;
+}
+
+void NavSatStatusAssociation::CloseAndErase(const PendingMap::iterator entry)
+{
+  CloseReceipt(entry->first);
+  pending_.erase(entry);
+}
+
+void NavSatStatusAssociation::CloseReceipt(const std::int64_t receipt_time_ns)
+{
+  greatest_closed_receipt_ns_ = greatest_closed_receipt_ns_
+                                    ? std::max(*greatest_closed_receipt_ns_, receipt_time_ns)
+                                    : receipt_time_ns;
+}
+
+void NavSatStatusAssociation::ResetAssociationEpoch()
+{
+  pending_.clear();
+  greatest_receipt_seen_ns_.reset();
+  greatest_closed_receipt_ns_.reset();
+  latest_status_sequence_.reset();
+  latest_status_receipt_ns_.reset();
+}
+
+bool NavSatStatusAssociation::ReceiptIsClosed(const std::int64_t receipt_time_ns) const
+{
+  return greatest_closed_receipt_ns_ && receipt_time_ns <= *greatest_closed_receipt_ns_;
+}
+
+bool NavSatStatusAssociation::ReceiptCanStart(const std::int64_t receipt_time_ns,
+                                              AssociationBatch& batch) const
+{
+  if (ReceiptIsClosed(receipt_time_ns))
+  {
+    batch.event = AssociationEvent::kClosedReceipt;
+    return false;
+  }
+  if (greatest_receipt_seen_ns_ && receipt_time_ns < *greatest_receipt_seen_ns_)
+  {
+    batch.event = AssociationEvent::kReceiptRewind;
+    return false;
+  }
+  return true;
+}
+
+bool NavSatStatusAssociation::ProvenanceIsValid(const std::int64_t receipt_time_ns,
+                                                const std::int64_t ros_now_ns) const
+{
+  return mowgli_interfaces::gnss_observation_freshness::IsReceiptFresh(receipt_time_ns,
+                                                                       ros_now_ns,
+                                                                       maximum_provenance_age_ns_);
+}
+
+}  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
+++ b/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
@@ -26,8 +26,9 @@
  * sufficient for a garden robot mower operating within a few hundred metres.
  *
  * NavSatFix carries the coordinates/covariance. The typed RTK/fix-state comes
- * from /gps/status when available, with NavSatFix status used only as a
- * conservative fallback during bring-up.
+ * only from the /gps/status observation with the exact same receiver-receipt
+ * stamp. Independently delivered callbacks are held in a bounded monotonic
+ * association window; no latest-status fallback is authoritative.
  *
  * Universal GNSS owns the typed /gps/status contract. This node only projects
  * /gps/fix into the Mowgli-local absolute-pose topics consumed by the GUI,
@@ -42,6 +43,8 @@
 #include <cstdint>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
+#include <utility>
 
 #include "mowgli_localization/navsat_projection_utils.hpp"
 #include "tf2/LinearMath/Matrix3x3.h"
@@ -59,13 +62,19 @@ static constexpr double DEG_TO_RAD = M_PI / 180.0;
 /// Metres per degree of latitude (approximate, at the equator).
 static constexpr double METERS_PER_DEG = EARTH_RADIUS_M * DEG_TO_RAD;
 
-/// Monotonic delivery clock. Kept strictly separate from the ROS clock used
-/// for receipt provenance — the freshness policy never mixes the two domains.
+static constexpr std::int64_t NANOSECONDS_PER_SECOND = 1000000000LL;
+
 static std::int64_t steady_now_ns()
 {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();
+}
+
+static std::int64_t stamp_to_nanoseconds(const builtin_interfaces::msg::Time& stamp)
+{
+  return static_cast<std::int64_t>(stamp.sec) * NANOSECONDS_PER_SECOND +
+         static_cast<std::int64_t>(stamp.nanosec);
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +86,10 @@ NavSatToAbsolutePoseNode::NavSatToAbsolutePoseNode(const rclcpp::NodeOptions& op
 {
   declare_parameters();
   cos_datum_lat_ = std::cos(datum_lat_ * DEG_TO_RAD);
+  status_association_ = std::make_unique<NavSatStatusAssociation>(
+      status_pairing_capacity_,
+      static_cast<std::int64_t>(status_pairing_window_s_ * NANOSECONDS_PER_SECOND),
+      static_cast<std::int64_t>(status_pairing_max_provenance_age_s_ * NANOSECONDS_PER_SECOND));
   create_publishers();
   create_subscribers();
   create_services();
@@ -113,6 +126,19 @@ void NavSatToAbsolutePoseNode::declare_parameters()
   pos_accuracy_inflation_factor_ = declare_parameter<double>("pos_accuracy_inflation_factor", 10.0);
   pos_accuracy_reject_threshold_m_ =
       declare_parameter<double>("pos_accuracy_reject_threshold_m", 0.500);
+
+  status_pairing_window_s_ = declare_parameter<double>("status_pairing_window_s", 0.25);
+  status_pairing_max_provenance_age_s_ =
+      declare_parameter<double>("status_pairing_max_provenance_age_s", 2.0);
+  const int status_pairing_capacity = declare_parameter<int>("status_pairing_capacity", 32);
+  if (!std::isfinite(status_pairing_window_s_) || status_pairing_window_s_ <= 0.0 ||
+      !std::isfinite(status_pairing_max_provenance_age_s_) ||
+      status_pairing_max_provenance_age_s_ <= 0.0 || status_pairing_capacity <= 0)
+  {
+    throw std::invalid_argument(
+        "GNSS status pairing window, provenance age, and capacity must be positive");
+  }
+  status_pairing_capacity_ = static_cast<std::size_t>(status_pairing_capacity);
 }
 
 void NavSatToAbsolutePoseNode::create_publishers()
@@ -140,9 +166,13 @@ void NavSatToAbsolutePoseNode::create_subscribers()
       rclcpp::QoS(10),
       [this](mowgli_interfaces::msg::GnssStatus::ConstSharedPtr msg)
       {
-        last_status_ = *msg;
-        has_status_ = true;
+        on_gnss_status(msg);
       });
+  association_timer_ = create_wall_timer(std::chrono::milliseconds(20),
+                                         [this]()
+                                         {
+                                           on_association_timer();
+                                         });
 }
 
 // ---------------------------------------------------------------------------
@@ -206,29 +236,91 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   last_fix_ = *msg;
   has_fix_ = true;
 
-  // Receiver-observation identity, evaluated before anything is published.
-  // A frozen receiver still produces callbacks: the adapter republishes the
-  // last accepted fix on its own timer with the receipt stamp unchanged, so
-  // arrival time says "live" while the physical observation behind it is
-  // minutes old. Compare provenance, never callback time and never
-  // coordinates (a stationary robot legitimately repeats coordinates).
+  const std::int64_t receipt_time_ns = stamp_to_nanoseconds(msg->header.stamp);
   const rclcpp::Time ros_now = now();
-  const rclcpp::Time receipt_stamp(msg->header.stamp, get_clock()->get_clock_type());
-  const auto observation_update = fix_observation_tracker_.Observe(0,
-                                                                   receipt_stamp.nanoseconds(),
-                                                                   ros_now.nanoseconds(),
-                                                                   steady_now_ns());
-  using mowgli_interfaces::gnss_observation_freshness::IsAcceptedObservation;
-  using mowgli_interfaces::gnss_observation_freshness::ObservationUpdate;
-  const bool observation_is_new = IsAcceptedObservation(observation_update);
-  if (!observation_is_new && observation_update == ObservationUpdate::kInvalidProvenance)
+  handle_association_batch(
+      status_association_->AddFix(*msg, receipt_time_ns, ros_now.nanoseconds(), steady_now_ns()));
+}
+
+void NavSatToAbsolutePoseNode::on_gnss_status(
+    mowgli_interfaces::msg::GnssStatus::ConstSharedPtr msg)
+{
+  const std::int64_t receipt_time_ns = stamp_to_nanoseconds(msg->header.stamp);
+  const rclcpp::Time ros_now = now();
+  handle_association_batch(status_association_->AddStatus(
+      *msg, receipt_time_ns, ros_now.nanoseconds(), steady_now_ns()));
+}
+
+void NavSatToAbsolutePoseNode::on_association_timer()
+{
+  const rclcpp::Time ros_now = now();
+  handle_association_batch(status_association_->Poll(ros_now.nanoseconds(), steady_now_ns()));
+}
+
+void NavSatToAbsolutePoseNode::handle_association_batch(AssociationBatch batch)
+{
+  if (batch.expired_incomplete > 0 || batch.expired_ambiguous > 0 ||
+      batch.expired_invalid_provenance > 0)
   {
     RCLCPP_WARN_THROTTLE(get_logger(),
                          *get_clock(),
                          5000,
-                         "GNSS receipt stamp is zero/future; /gps/pose_cov withheld");
+                         "GNSS association expired: %zu incomplete, %zu ambiguous, %zu stale",
+                         batch.expired_incomplete,
+                         batch.expired_ambiguous,
+                         batch.expired_invalid_provenance);
   }
 
+  switch (batch.event)
+  {
+    case AssociationEvent::kAmbiguousReceipt:
+      RCLCPP_ERROR(get_logger(),
+                   "GNSS association ambiguous at receipt %lld ns; projection withheld",
+                   static_cast<long long>(batch.event_receipt_time_ns));
+      break;
+    case AssociationEvent::kClockDiscontinuity:
+      RCLCPP_WARN(get_logger(), "GNSS association clock epoch reset; triggering delivery dropped");
+      break;
+    case AssociationEvent::kSourceRestart:
+      RCLCPP_WARN(get_logger(),
+                  "GNSS receiver sequence restarted at receipt %lld ns; old pairing state cleared",
+                  static_cast<long long>(batch.event_receipt_time_ns));
+      break;
+    case AssociationEvent::kCapacityEviction:
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "GNSS association capacity reached; oldest pending receipt dropped");
+      break;
+    case AssociationEvent::kInvalidProvenance:
+    case AssociationEvent::kInvalidIdentity:
+    case AssociationEvent::kReceiptRewind:
+      RCLCPP_WARN_THROTTLE(get_logger(),
+                           *get_clock(),
+                           5000,
+                           "GNSS association rejected invalid/future/rewound provenance at %lld ns",
+                           static_cast<long long>(batch.event_receipt_time_ns));
+      break;
+    default:
+      break;
+  }
+
+  for (auto& observation : batch.ready)
+  {
+    auto fix = std::make_shared<sensor_msgs::msg::NavSatFix>(std::move(observation.fix));
+    project_observation(fix, std::make_optional(std::move(observation.status)));
+  }
+  for (auto& fallback_fix : batch.fix_only_fallbacks)
+  {
+    auto fix = std::make_shared<sensor_msgs::msg::NavSatFix>(std::move(fallback_fix));
+    project_observation(fix, std::nullopt);
+  }
+}
+
+void NavSatToAbsolutePoseNode::project_observation(
+    sensor_msgs::msg::NavSatFix::ConstSharedPtr msg,
+    const std::optional<mowgli_interfaces::msg::GnssStatus>& authoritative_status)
+{
   using AbsPose = mowgli_interfaces::msg::AbsolutePose;
   using NavSat = sensor_msgs::msg::NavSatFix;
   using NavStatus = sensor_msgs::msg::NavSatStatus;
@@ -244,19 +336,13 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   double north = 0.0;
   wgs84_to_enu(msg->latitude, msg->longitude, east, north);
 
-  // Build AbsolutePose. Stamp with the GPS fix time, not wall-clock now(), so
-  // the pose isn't tagged with the GPS pipeline latency (which misassociates it
-  // in time downstream). Fall back to now() only if the driver left the stamp
-  // unset (sec==0 && nanosec==0).
+  // Build AbsolutePose. The association gate already rejected unset, future,
+  // stale, or rewound receipt provenance, so preserve the fix stamp exactly.
   AbsPose out;
-  out.header.stamp = (msg->header.stamp.sec != 0 || msg->header.stamp.nanosec != 0)
-                         ? rclcpp::Time(msg->header.stamp)
-                         : now();
+  out.header.stamp = rclcpp::Time(msg->header.stamp);
   out.header.frame_id = "map";
   out.source = AbsPose::SOURCE_GPS;
 
-  const std::optional<mowgli_interfaces::msg::GnssStatus> authoritative_status =
-      has_status_ ? std::make_optional(last_status_) : std::nullopt;
   out.flags = ResolveAbsolutePoseFlags(authoritative_status, msg->status.status);
 
   // Position in local ENU frame. Note: ROS REP-103 map frame is
@@ -370,17 +456,10 @@ void NavSatToAbsolutePoseNode::on_navsat_fix(sensor_msgs::msg::NavSatFix::ConstS
   out.pose.pose.position.y = base_y;
   pose_pub_->publish(out);
 
-  // Freshness gate on the localization-fusion twin only. /gps/absolute_pose
-  // above stays a faithful mirror of what the driver delivered (it carries
-  // its own stamp and flags, and the GUI reasons about both), but
-  // /gps/pose_cov is consumed as an ABSOLUTE ANCHOR — map_server averages it
-  // into the dock pose. Re-emitting a frozen observation there manufactures
-  // fresh-looking evidence out of one old measurement: the averaging window
-  // fills with copies of a single sample, so its spread collapses and the
-  // result looks more confident the longer the receiver has been dead.
-  // Arrival-time staleness checks downstream cannot see this, because the
-  // republication makes arrival time current.
-  if (!observation_is_new)
+  // A NavSatFix-only observation remains useful to AbsolutePose consumers via
+  // its own standard status, but it must never gain typed RTK authority for the
+  // localization-fusion twin. /gps/pose_cov requires an exact status pair.
+  if (!authoritative_status)
   {
     return;
   }

--- a/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
+++ b/ros2/src/mowgli_localization/src/navsat_to_absolute_pose_node.cpp
@@ -127,7 +127,23 @@ void NavSatToAbsolutePoseNode::declare_parameters()
   pos_accuracy_reject_threshold_m_ =
       declare_parameter<double>("pos_accuracy_reject_threshold_m", 0.500);
 
-  status_pairing_window_s_ = declare_parameter<double>("status_pairing_window_s", 0.25);
+  // Hold-back before a complete fix/status pair is released, so a late
+  // conflicting status on the same receipt can still fail it closed.
+  //
+  // Sized from the MEASURED delivery skew, not a guess. /gps/fix comes
+  // straight from universal_gnss's receiver_node while /gps/status takes an
+  // extra hop through mowgli_gnss_bridge, so the two are genuinely offset.
+  // Sampled on the robot 2026-09-06, 225 matched pairs over 45 s:
+  // p50 1.12 ms, p95 3.38 ms, max 8.25 ms. 50 ms is ~6x the worst case,
+  // with headroom for CPU load while mowing.
+  //
+  // This is NOT free latency: /gps/absolute_pose feeds gps_dock_detection_node
+  // (use_gps_dock_detection defaults true), where a stale robot position makes
+  // the dock compute FURTHER away than it is and the approach overshoot by
+  // roughly window x approach speed. The original 0.25 s was 30x the measured
+  // worst case and cost ~4 cm at 0.16 m/s. Do not raise it without re-measuring
+  // the skew and accounting for that error.
+  status_pairing_window_s_ = declare_parameter<double>("status_pairing_window_s", 0.05);
   status_pairing_max_provenance_age_s_ =
       declare_parameter<double>("status_pairing_max_provenance_age_s", 2.0);
   const int status_pairing_capacity = declare_parameter<int>("status_pairing_capacity", 32);

--- a/ros2/src/mowgli_localization/test/test_cog_observation_timing.cpp
+++ b/ros2/src/mowgli_localization/test/test_cog_observation_timing.cpp
@@ -1,0 +1,305 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+#include "mowgli_localization/cog_observation_timing.hpp"
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using mowgli_localization::CogObservationTiming;
+using mowgli_localization::CogObservationTimingDecision;
+using mowgli_localization::DeriveMaximumCogObservationIntervalSeconds;
+using mowgli_localization::StationaryLatchClock;
+using mowgli_localization::StationaryLatchState;
+
+constexpr std::int64_t kSecond = 1000000000LL;
+constexpr double kToleranceFactor = 1.5;
+
+std::int64_t Seconds(const double seconds)
+{
+  return static_cast<std::int64_t>(std::llround(seconds * static_cast<double>(kSecond)));
+}
+
+CogObservationTiming TimingForRate(const double rate_hz)
+{
+  return CogObservationTiming(0.05,
+                              DeriveMaximumCogObservationIntervalSeconds(rate_hz, kToleranceFactor),
+                              2.0);
+}
+
+// Minimal moving-baseline harness around the production timing gate. A heading
+// is counted only when a timing-accepted observation can pair with a retained,
+// spatially distinct anchor. This directly exposes the old 1 Hz failure: a gap
+// decision reseeds and therefore cannot publish from the previous position.
+class MovingCogHarness
+{
+public:
+  explicit MovingCogHarness(const double rate_hz) : timing_(TimingForRate(rate_hz))
+  {
+  }
+
+  CogObservationTimingDecision Deliver(const std::int64_t receipt_ns,
+                                       const std::int64_t ros_now_ns,
+                                       const double position_m)
+  {
+    const auto result = timing_.Observe(receipt_ns, ros_now_ns);
+    switch (result.decision)
+    {
+      case CogObservationTimingDecision::kSeed:
+      case CogObservationTimingDecision::kGapReseed:
+        anchor_m_ = position_m;
+        ++physical_observations_;
+        break;
+      case CogObservationTimingDecision::kAdvance:
+        ++physical_observations_;
+        if (!anchor_m_)
+        {
+          anchor_m_ = position_m;
+        }
+        else if (std::abs(position_m - *anchor_m_) >= 0.10)
+        {
+          ++headings_;
+          anchor_m_ = position_m;
+        }
+        break;
+      case CogObservationTimingDecision::kInvalidProvenance:
+      case CogObservationTimingDecision::kReceiptRewind:
+      case CogObservationTimingDecision::kRosTimeDiscontinuity:
+        anchor_m_.reset();
+        break;
+      case CogObservationTimingDecision::kDuplicate:
+      case CogObservationTimingDecision::kTooSoon:
+        break;
+    }
+    return result.decision;
+  }
+
+  int physical_observations() const
+  {
+    return physical_observations_;
+  }
+
+  int headings() const
+  {
+    return headings_;
+  }
+
+private:
+  CogObservationTiming timing_;
+  std::optional<double> anchor_m_;
+  int physical_observations_{0};
+  int headings_{0};
+};
+
+TEST(CogObservationTimingTest, GenuineOneHertzMovingObservationsProduceHeading)
+{
+  MovingCogHarness harness(1.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0), CogObservationTimingDecision::kSeed);
+  EXPECT_EQ(harness.Deliver(Seconds(2.0), Seconds(2.0), 0.20),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, GenuineFiveHertzBehaviorRemainsValid)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.2), Seconds(1.2), 0.20),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, GenuineSevenHertzMovingObservationsProduceHeading)
+{
+  MovingCogHarness harness(7.0);
+  const std::int64_t period = Seconds(1.0 / 7.0);
+  harness.Deliver(kSecond, kSecond, 0.0);
+  EXPECT_EQ(harness.Deliver(kSecond + period, kSecond + period, 0.20),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, GenuineTenHertzMovingObservationsProduceHeading)
+{
+  MovingCogHarness harness(10.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.1), Seconds(1.1), 0.20),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, CachedReceiptWithSameCoordinatesDoesNotAdvance)
+{
+  MovingCogHarness harness(1.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.0), Seconds(1.1), 0.0),
+            CogObservationTimingDecision::kDuplicate);
+  EXPECT_EQ(harness.physical_observations(), 1);
+  EXPECT_EQ(harness.headings(), 0);
+}
+
+TEST(CogObservationTimingTest, TenHertzCachedPublicationAroundOneHertzReceiverIsIgnored)
+{
+  MovingCogHarness harness(1.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  for (int callback = 1; callback < 10; ++callback)
+  {
+    EXPECT_EQ(harness.Deliver(Seconds(1.0), Seconds(1.0 + 0.1 * callback), 0.0),
+              CogObservationTimingDecision::kDuplicate);
+  }
+  harness.Deliver(Seconds(2.0), Seconds(2.0), 0.20);
+
+  EXPECT_EQ(harness.physical_observations(), 2);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, SameCoordinatesWithNewReceiptAreGenuineObservation)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.2), Seconds(1.2), 0.0),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.physical_observations(), 2);
+  EXPECT_EQ(harness.headings(), 0);
+}
+
+TEST(CogObservationTimingTest, IntervalInsideFiftyPercentJitterToleranceIsRetained)
+{
+  auto timing = TimingForRate(5.0);
+  EXPECT_EQ(timing.Observe(Seconds(1.0), Seconds(1.0)).decision,
+            CogObservationTimingDecision::kSeed);
+  EXPECT_EQ(timing.Observe(Seconds(1.299), Seconds(1.299)).decision,
+            CogObservationTimingDecision::kAdvance);
+}
+
+TEST(CogObservationTimingTest, ExistingMinimumIntervalStillRejectsTooFastNewStamp)
+{
+  auto timing = TimingForRate(10.0);
+  EXPECT_EQ(timing.Observe(Seconds(1.0), Seconds(1.0)).decision,
+            CogObservationTimingDecision::kSeed);
+  EXPECT_EQ(timing.Observe(Seconds(1.049), Seconds(1.049)).decision,
+            CogObservationTimingDecision::kTooSoon);
+  EXPECT_EQ(timing.Observe(Seconds(1.1), Seconds(1.1)).decision,
+            CogObservationTimingDecision::kAdvance);
+}
+
+TEST(CogObservationTimingTest, IntervalBeyondPhysicalGapLimitReseeds)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.301), Seconds(1.301), 0.20),
+            CogObservationTimingDecision::kGapReseed);
+  EXPECT_EQ(harness.headings(), 0);
+  EXPECT_EQ(harness.Deliver(Seconds(1.501), Seconds(1.501), 0.40),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, DelayedDuplicateIsIgnoredWithoutBreakingBaseline)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  harness.Deliver(Seconds(1.2), Seconds(1.2), 0.20);
+  EXPECT_EQ(harness.Deliver(Seconds(1.0), Seconds(1.25), 0.0),
+            CogObservationTimingDecision::kDuplicate);
+  EXPECT_EQ(harness.Deliver(Seconds(1.4), Seconds(1.4), 0.40),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 2);
+}
+
+TEST(CogObservationTimingTest, UnseenReceiptRewindFailsClosedAndNextSampleSeeds)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  harness.Deliver(Seconds(1.2), Seconds(1.2), 0.20);
+  EXPECT_EQ(harness.Deliver(Seconds(1.1), Seconds(1.25), 0.10),
+            CogObservationTimingDecision::kReceiptRewind);
+  EXPECT_EQ(harness.Deliver(Seconds(1.3), Seconds(1.3), 0.30), CogObservationTimingDecision::kSeed);
+  EXPECT_EQ(harness.Deliver(Seconds(1.5), Seconds(1.5), 0.50),
+            CogObservationTimingDecision::kAdvance);
+  EXPECT_EQ(harness.headings(), 2);
+}
+
+TEST(CogObservationTimingTest, ZeroFutureAndLargeForwardJumpCannotReuseOldBaseline)
+{
+  MovingCogHarness harness(5.0);
+  EXPECT_EQ(harness.Deliver(0, Seconds(1.0), 0.0),
+            CogObservationTimingDecision::kInvalidProvenance);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(5.0), Seconds(2.0), 0.20),
+            CogObservationTimingDecision::kInvalidProvenance);
+  EXPECT_EQ(harness.Deliver(Seconds(2.0), Seconds(2.0), 0.20), CogObservationTimingDecision::kSeed);
+  EXPECT_EQ(harness.Deliver(Seconds(5.0), Seconds(5.0), 0.50),
+            CogObservationTimingDecision::kGapReseed);
+  EXPECT_EQ(harness.headings(), 0);
+}
+
+TEST(CogObservationTimingTest, RosClockRewindDropsTriggerAndStartsCleanEpoch)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(10.0), Seconds(10.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(9.0), Seconds(9.0), 0.20),
+            CogObservationTimingDecision::kRosTimeDiscontinuity);
+  EXPECT_EQ(harness.Deliver(Seconds(9.1), Seconds(9.1), 0.30), CogObservationTimingDecision::kSeed);
+}
+
+TEST(CogObservationTimingTest, ReceiverReconnectGapSeedsBeforeProducingAgain)
+{
+  MovingCogHarness harness(5.0);
+  harness.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  EXPECT_EQ(harness.Deliver(Seconds(3.0), Seconds(3.0), 0.20),
+            CogObservationTimingDecision::kGapReseed);
+  EXPECT_EQ(harness.headings(), 0);
+  harness.Deliver(Seconds(3.2), Seconds(3.2), 0.40);
+  EXPECT_EQ(harness.headings(), 1);
+}
+
+TEST(CogObservationTimingTest, PublicationCadenceCannotChangePhysicalGapPolicy)
+{
+  // Fast callbacks carrying the same 1 Hz receipt do not advance.
+  MovingCogHarness one_hertz(1.0);
+  one_hertz.Deliver(Seconds(1.0), Seconds(1.0), 0.0);
+  one_hertz.Deliver(Seconds(1.0), Seconds(1.1), 0.0);
+  EXPECT_EQ(one_hertz.physical_observations(), 1);
+
+  // Conversely, receiving only every tenth 10 Hz observation yields a real
+  // one-second provenance gap. Callback frequency cannot widen the 0.15 s
+  // physical policy, so the visible sample safely reseeds.
+  auto ten_hertz = TimingForRate(10.0);
+  ten_hertz.Observe(Seconds(1.0), Seconds(1.0));
+  EXPECT_EQ(ten_hertz.Observe(Seconds(2.0), Seconds(2.0)).decision,
+            CogObservationTimingDecision::kGapReseed);
+}
+
+TEST(CogStationaryLatchClockTest, NegativeRosAgeAndRewindAreNeverFresh)
+{
+  StationaryLatchClock latch(10.0);
+  ASSERT_TRUE(latch.Latch(Seconds(100.0), Seconds(100.0), Seconds(50.0)));
+  const auto rewound = latch.Check(Seconds(99.0), Seconds(51.0));
+  EXPECT_EQ(rewound.state, StationaryLatchState::kClockDiscontinuity);
+  EXPECT_FALSE(rewound.fresh());
+  EXPECT_EQ(latch.Check(Seconds(101.0), Seconds(52.0)).state, StationaryLatchState::kNoLatch);
+}
+
+TEST(CogStationaryLatchClockTest, MonotonicAgeExpiresEvenWhenRosTimePauses)
+{
+  StationaryLatchClock latch(10.0);
+  ASSERT_TRUE(latch.Latch(Seconds(100.0), Seconds(100.0), Seconds(50.0)));
+  const auto expired = latch.Check(Seconds(100.0), Seconds(61.0));
+  EXPECT_EQ(expired.state, StationaryLatchState::kExpired);
+  EXPECT_FALSE(expired.fresh());
+}
+
+TEST(CogObservationTimingTest, InvalidConfigurationFailsVisibly)
+{
+  EXPECT_THROW(DeriveMaximumCogObservationIntervalSeconds(0.0, 1.5), std::invalid_argument);
+  EXPECT_THROW(DeriveMaximumCogObservationIntervalSeconds(5.0, 0.9), std::invalid_argument);
+  EXPECT_THROW(CogObservationTiming(0.05, 0.05, 2.0), std::invalid_argument);
+}
+
+}  // namespace

--- a/ros2/src/mowgli_localization/test/test_localization_monitor_freshness.cpp
+++ b/ros2/src/mowgli_localization/test/test_localization_monitor_freshness.cpp
@@ -1,0 +1,244 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <cstdint>
+
+#include "mowgli_interfaces/gnss_observation_freshness.hpp"
+#include "mowgli_localization/localization_monitor_policy.hpp"
+#include <gtest/gtest.h>
+
+namespace freshness = mowgli_interfaces::gnss_observation_freshness;
+namespace ml = mowgli_localization;
+
+namespace
+{
+
+constexpr std::int64_t kSecond = 1000000000LL;
+
+TEST(LocalizationMonitorFreshness, GenuineFixedObservationReportsFresh)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  const bool fresh = tracker.ObservationIsFresh(10 * kSecond, 1 * kSecond, 2 * kSecond);
+  EXPECT_EQ(ml::EvaluateLocalizationMode(fresh, true, true), ml::LocalizationMode::RTK_FIXED);
+}
+
+TEST(LocalizationMonitorFreshness, RepeatedCallbacksDoNotRefreshObservation)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(0, 10 * kSecond, 11 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  EXPECT_EQ(tracker.Observe(0, 10 * kSecond, 12 * kSecond, 3 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  EXPECT_EQ(tracker.last_receipt_time_ns(), 10 * kSecond);
+}
+
+TEST(LocalizationMonitorFreshness, CachedDeliveryEventuallyReportsDeadReckoning)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+
+  EXPECT_FALSE(fresh);
+  EXPECT_TRUE(tracker.DeliveryIsLive(4 * kSecond, 1 * kSecond));
+  EXPECT_EQ(ml::EvaluateLocalizationMode(fresh, true, true), ml::LocalizationMode::DEAD_RECKONING);
+}
+
+TEST(LocalizationMonitorFreshness, GenuineObservationRestoresMode)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_FALSE(tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond));
+  ASSERT_EQ(tracker.Observe(0, 13 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  const bool fresh = tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond);
+  EXPECT_EQ(ml::EvaluateLocalizationMode(fresh, true, true), ml::LocalizationMode::RTK_FIXED);
+}
+
+TEST(LocalizationMonitorPolicy, FreshFloatAndGpsOnlySemanticsAreUnchanged)
+{
+  EXPECT_EQ(ml::EvaluateLocalizationMode(true, true, false), ml::LocalizationMode::RTK_FLOAT);
+  EXPECT_EQ(ml::EvaluateLocalizationMode(true, false, false), ml::LocalizationMode::GPS_ONLY);
+  EXPECT_EQ(ml::EvaluateLocalizationMode(false, true, true), ml::LocalizationMode::DEAD_RECKONING);
+}
+
+TEST(PhysicalObservationFreshness, StartupBeforeFirstObservationIsStale)
+{
+  freshness::PhysicalObservationTracker tracker;
+  EXPECT_FALSE(tracker.ObservationIsFresh(10 * kSecond, 1 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, SamePayloadNewSequenceIsGenuine)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(10, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(11, 10 * kSecond, 10 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.last_sequence(), 11U);
+  EXPECT_TRUE(tracker.ObservationIsFresh(10 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, DelayedDuplicateDoesNotRefresh)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(10, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(11, 11 * kSecond, 11 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(10, 10 * kSecond, 12 * kSecond, 3 * kSecond),
+            freshness::ObservationUpdate::kOutOfOrder);
+  EXPECT_FALSE(tracker.ObservationIsFresh(14 * kSecond, 5 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, ZeroProvenanceInvalidatesAuthority)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(2, 0, 10 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kInvalidProvenance);
+  EXPECT_FALSE(tracker.ObservationIsFresh(10 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, FutureProvenanceInvalidatesAuthority)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(2, 12 * kSecond, 11 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kInvalidProvenance);
+  EXPECT_FALSE(tracker.ObservationIsFresh(11 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, ReceiptOnlyRewindFailsClosed)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(0, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(0, 9 * kSecond, 11 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kOutOfOrder);
+  EXPECT_FALSE(tracker.ObservationIsFresh(11 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, RosRewindDuringCallbackResetsEpoch)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(5, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(5, 5 * kSecond, 5 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kRosTimeDiscontinuity);
+  EXPECT_FALSE(tracker.ObservationIsFresh(5 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, RosRewindDuringEvaluationResetsEpoch)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(5, 100 * kSecond, 100 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_FALSE(tracker.ObservationIsFresh(5 * kSecond, 2 * kSecond, 2 * kSecond));
+  EXPECT_FALSE(tracker.last_receipt_time_ns().has_value());
+  EXPECT_TRUE(tracker.ConsumeEpochReset());
+  EXPECT_FALSE(tracker.ConsumeEpochReset());
+}
+
+TEST(PhysicalObservationFreshness, ReceiverSequenceRestartUsesNewEpochObservation)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(50, 50 * kSecond, 50 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(1, 51 * kSecond, 51 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kSourceRestart);
+  EXPECT_EQ(tracker.last_sequence(), 1U);
+  EXPECT_EQ(tracker.last_receipt_time_ns(), 51 * kSecond);
+  EXPECT_TRUE(tracker.ObservationIsFresh(51 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, LargeForwardJumpExpiresAuthority)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_FALSE(tracker.ObservationIsFresh(1000 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, OneHertzPhysicalTenHertzCallbacksFollowsPhysicalIdentity)
+{
+  freshness::PhysicalObservationTracker tracker;
+  std::uint64_t sequence = 1;
+  std::int64_t receipt = 10 * kSecond;
+  std::int64_t cached_callbacks = 0;
+  for (std::int64_t tenth = 0; tenth <= 20; ++tenth)
+  {
+    const std::int64_t ros_now = 10 * kSecond + tenth * (kSecond / 10);
+    if (tenth > 0 && tenth % 10 == 0)
+    {
+      ++sequence;
+      receipt = ros_now;
+      EXPECT_EQ(tracker.Observe(sequence, receipt, ros_now, tenth * (kSecond / 10)),
+                freshness::ObservationUpdate::kNewObservation);
+    }
+    else if (tenth == 0)
+    {
+      EXPECT_EQ(tracker.Observe(sequence, receipt, ros_now, 0),
+                freshness::ObservationUpdate::kNewObservation);
+    }
+    else
+    {
+      ++cached_callbacks;
+      EXPECT_EQ(tracker.Observe(sequence, receipt, ros_now, tenth * (kSecond / 10)),
+                freshness::ObservationUpdate::kCachedPublication);
+    }
+  }
+  EXPECT_EQ(cached_callbacks, 18);
+  EXPECT_EQ(tracker.last_sequence(), 3U);
+  EXPECT_TRUE(tracker.ObservationIsFresh(12 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, SparsePublicationDoesNotInferAcquisitionCadence)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(10, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.Observe(20, 11 * kSecond, 11 * kSecond, 2 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_EQ(tracker.last_sequence(), 20U);
+  EXPECT_TRUE(tracker.ObservationIsFresh(11 * kSecond, 2 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, DeliveryLivenessRemainsSeparateFromObservationFreshness)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 13 * kSecond, 4 * kSecond),
+            freshness::ObservationUpdate::kCachedPublication);
+  EXPECT_TRUE(tracker.DeliveryIsLive(4 * kSecond, 1 * kSecond));
+  EXPECT_FALSE(tracker.ObservationIsFresh(13 * kSecond, 4 * kSecond, 2 * kSecond));
+}
+
+TEST(PhysicalObservationFreshness, MonotonicRewindResetsAuthority)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 10 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_FALSE(tracker.ObservationIsFresh(10 * kSecond, 9 * kSecond, 2 * kSecond));
+  EXPECT_FALSE(tracker.last_receipt_time_ns().has_value());
+}
+
+TEST(PhysicalObservationFreshness, NegativeMaximumAgeCannotAuthorize)
+{
+  freshness::PhysicalObservationTracker tracker;
+  ASSERT_EQ(tracker.Observe(1, 10 * kSecond, 10 * kSecond, 1 * kSecond),
+            freshness::ObservationUpdate::kNewObservation);
+  EXPECT_FALSE(tracker.ObservationIsFresh(10 * kSecond, 1 * kSecond, -1));
+}
+
+}  // namespace

--- a/ros2/src/mowgli_localization/test/test_navsat_status_association.cpp
+++ b/ros2/src/mowgli_localization/test/test_navsat_status_association.cpp
@@ -1,0 +1,414 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "mowgli_localization/navsat_projection_utils.hpp"
+#include "mowgli_localization/navsat_status_association.hpp"
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using mowgli_interfaces::msg::AbsolutePose;
+using mowgli_interfaces::msg::GnssStatus;
+using mowgli_localization::AssociatedNavSatObservation;
+using mowgli_localization::AssociationBatch;
+using mowgli_localization::AssociationEvent;
+using mowgli_localization::NavSatStatusAssociation;
+using sensor_msgs::msg::NavSatFix;
+using sensor_msgs::msg::NavSatStatus;
+
+constexpr std::int64_t kWindow = 10;
+constexpr std::int64_t kMaximumAge = 1000;
+
+NavSatFix MakeFix(const double latitude = 48.0,
+                  const double longitude = 2.0,
+                  const std::int8_t navsat_status = NavSatStatus::STATUS_FIX)
+{
+  NavSatFix fix;
+  fix.latitude = latitude;
+  fix.longitude = longitude;
+  fix.status.status = navsat_status;
+  fix.position_covariance_type = NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+  fix.position_covariance[0] = 0.0001;
+  fix.position_covariance[4] = 0.0001;
+  return fix;
+}
+
+GnssStatus MakeStatus(const std::uint64_t sequence,
+                      const std::uint8_t fix_type,
+                      const std::uint8_t rtk_mode)
+{
+  GnssStatus status;
+  status.position_observation_sequence = sequence;
+  status.fix_valid = fix_type != GnssStatus::FIX_TYPE_NO_FIX;
+  status.fix_type = fix_type;
+  status.rtk_mode = rtk_mode;
+  return status;
+}
+
+GnssStatus Fixed(const std::uint64_t sequence)
+{
+  return MakeStatus(sequence, GnssStatus::FIX_TYPE_RTK_FIXED, GnssStatus::RTK_MODE_FIXED);
+}
+
+GnssStatus Float(const std::uint64_t sequence)
+{
+  return MakeStatus(sequence, GnssStatus::FIX_TYPE_RTK_FLOAT, GnssStatus::RTK_MODE_FLOAT);
+}
+
+GnssStatus NoFix(const std::uint64_t sequence)
+{
+  return MakeStatus(sequence, GnssStatus::FIX_TYPE_NO_FIX, GnssStatus::RTK_MODE_NONE);
+}
+
+std::uint8_t Flags(const AssociatedNavSatObservation& observation)
+{
+  return mowgli_localization::ResolveAbsolutePoseFlags(std::make_optional(observation.status),
+                                                       observation.fix.status.status);
+}
+
+void AppendReady(AssociationBatch batch, std::vector<AssociatedNavSatObservation>& output)
+{
+  for (auto& observation : batch.ready)
+  {
+    output.push_back(std::move(observation));
+  }
+}
+
+TEST(NavSatStatusAssociationTest, FixFirstThenMatchingStatusProjectsExactlyOnce)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  EXPECT_EQ(association.AddFix(MakeFix(), 100, 100, 0).event, AssociationEvent::kWaiting);
+  EXPECT_EQ(association.AddStatus(Fixed(1), 100, 100, 1).event, AssociationEvent::kWaiting);
+
+  auto ready = association.Poll(100, 10);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_NE(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FIXED, 0U);
+  EXPECT_TRUE(association.Poll(100, 11).ready.empty());
+}
+
+TEST(NavSatStatusAssociationTest, StatusFirstThenMatchingFixProjectsExactlyOnce)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Fixed(1), 100, 100, 0);
+  association.AddFix(MakeFix(), 100, 100, 1);
+
+  auto ready = association.Poll(100, 10);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_EQ(ready.ready.front().status.position_observation_sequence, 1U);
+}
+
+TEST(NavSatStatusAssociationTest, NewFloatEpochCannotInheritOlderFixedStatus)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  association.AddStatus(Fixed(1), 100, 100, 1);
+  ASSERT_EQ(association.Poll(100, 10).ready.size(), 1U);
+
+  association.AddFix(MakeFix(), 101, 101, 11);
+  association.AddStatus(Float(2), 101, 101, 12);
+  auto ready = association.Poll(101, 21);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_NE(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FLOAT, 0U);
+  EXPECT_EQ(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FIXED, 0U);
+}
+
+TEST(NavSatStatusAssociationTest, NewFixedEpochCannotInheritOlderFloatStatus)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Float(1), 100, 100, 0);
+  association.AddFix(MakeFix(), 100, 100, 1);
+  ASSERT_EQ(association.Poll(100, 10).ready.size(), 1U);
+
+  association.AddStatus(Fixed(2), 101, 101, 11);
+  association.AddFix(MakeFix(), 101, 101, 12);
+  auto ready = association.Poll(101, 21);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_NE(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FIXED, 0U);
+  EXPECT_EQ(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FLOAT, 0U);
+}
+
+TEST(NavSatStatusAssociationTest, CachedStatusDoesNotCreateAnotherAssociation)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Fixed(7), 100, 100, 0);
+  EXPECT_EQ(association.AddStatus(Fixed(7), 100, 100, 1).event, AssociationEvent::kCachedStatus);
+  association.AddFix(MakeFix(), 100, 100, 2);
+
+  EXPECT_EQ(association.Poll(100, 10).ready.size(), 1U);
+  EXPECT_EQ(association.AddStatus(Fixed(7), 100, 100, 11).event, AssociationEvent::kClosedReceipt);
+  EXPECT_TRUE(association.Poll(100, 20).ready.empty());
+}
+
+TEST(NavSatStatusAssociationTest, DuplicateFixProducesOneProjectedObservation)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  EXPECT_EQ(association.AddFix(MakeFix(), 100, 100, 1).event, AssociationEvent::kDuplicateFix);
+  association.AddStatus(Fixed(1), 100, 100, 2);
+  EXPECT_EQ(association.Poll(100, 10).ready.size(), 1U);
+}
+
+TEST(NavSatStatusAssociationTest, SameCoordinatesWithNewReceiptAndSequenceAreNew)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  std::vector<AssociatedNavSatObservation> output;
+  const NavSatFix identical_fix = MakeFix(48.123, 2.456);
+
+  association.AddFix(identical_fix, 100, 100, 0);
+  association.AddStatus(Fixed(1), 100, 100, 1);
+  AppendReady(association.Poll(100, 10), output);
+
+  association.AddFix(identical_fix, 101, 101, 11);
+  association.AddStatus(Fixed(2), 101, 101, 12);
+  AppendReady(association.Poll(101, 21), output);
+
+  ASSERT_EQ(output.size(), 2U);
+  EXPECT_DOUBLE_EQ(output[0].fix.latitude, output[1].fix.latitude);
+  EXPECT_NE(output[0].status.position_observation_sequence,
+            output[1].status.position_observation_sequence);
+}
+
+TEST(NavSatStatusAssociationTest, UnrelatedStaleStatusNeverAuthorizesNewerFix)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Fixed(1), 100, 101, 0);
+  association.AddFix(MakeFix(), 101, 101, 1);
+
+  auto expired = association.Poll(101, 11);
+  EXPECT_TRUE(expired.ready.empty());
+  ASSERT_EQ(expired.fix_only_fallbacks.size(), 1U);
+  EXPECT_EQ(expired.expired_incomplete, 1U);
+  EXPECT_EQ(expired.fix_only_fallbacks.front().status.status, NavSatStatus::STATUS_FIX);
+}
+
+TEST(NavSatStatusAssociationTest, ExactDelayedStatusWinsAfterUnrelatedStatus)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 101, 0);
+  association.AddStatus(Float(2), 101, 101, 1);
+  association.AddStatus(Fixed(1), 100, 101, 2);
+
+  auto ready = association.Poll(101, 10);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_EQ(ready.ready.front().status.position_observation_sequence, 1U);
+  EXPECT_NE(Flags(ready.ready.front()) & AbsolutePose::FLAG_GPS_RTK_FIXED, 0U);
+}
+
+TEST(NavSatStatusAssociationTest, MissingCounterpartExpiresAndCannotBeResurrected)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  auto expired = association.Poll(100, 10);
+  EXPECT_EQ(expired.expired_incomplete, 0U);
+  EXPECT_TRUE(expired.ready.empty());
+  EXPECT_EQ(expired.fix_only_fallbacks.size(), 1U);
+
+  EXPECT_EQ(association.AddStatus(Fixed(1), 100, 100, 11).event, AssociationEvent::kClosedReceipt);
+  EXPECT_TRUE(association.Poll(100, 21).ready.empty());
+}
+
+TEST(NavSatStatusAssociationTest, StatusThatExpiresCannotBeResurrectedByLateFix)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Fixed(1), 100, 100, 0);
+  EXPECT_EQ(association.Poll(100, 10).expired_incomplete, 1U);
+  EXPECT_EQ(association.AddFix(MakeFix(), 100, 100, 11).event, AssociationEvent::kClosedReceipt);
+}
+
+TEST(NavSatStatusAssociationTest, CapacityOverflowEvictsOldestDeterministically)
+{
+  NavSatStatusAssociation association(2, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 102, 0);
+  association.AddFix(MakeFix(), 101, 102, 1);
+  auto overflow = association.AddFix(MakeFix(), 102, 102, 2);
+  EXPECT_EQ(overflow.event, AssociationEvent::kCapacityEviction);
+  EXPECT_EQ(overflow.capacity_evictions, 1U);
+  EXPECT_EQ(association.pending_size(), 2U);
+  EXPECT_EQ(association.AddStatus(Fixed(1), 100, 102, 3).event, AssociationEvent::kClosedReceipt);
+
+  association.AddStatus(Fixed(2), 101, 102, 4);
+  association.AddStatus(Fixed(3), 102, 102, 5);
+  auto ready = association.Poll(102, 12);
+  ASSERT_EQ(ready.ready.size(), 2U);
+  EXPECT_EQ(ready.ready[0].status.position_observation_sequence, 2U);
+  EXPECT_EQ(ready.ready[1].status.position_observation_sequence, 3U);
+}
+
+TEST(NavSatStatusAssociationTest, ReceiptAndRosClockRewindsFailClosed)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  EXPECT_EQ(association.AddFix(MakeFix(), 99, 100, 1).event, AssociationEvent::kReceiptRewind);
+
+  EXPECT_EQ(association.AddStatus(Fixed(1), 5, 5, 2).event, AssociationEvent::kClockDiscontinuity);
+  EXPECT_EQ(association.pending_size(), 0U);
+
+  association.AddFix(MakeFix(), 6, 6, 3);
+  association.AddStatus(Fixed(1), 6, 6, 4);
+  EXPECT_EQ(association.Poll(6, 13).ready.size(), 1U);
+}
+
+TEST(NavSatStatusAssociationTest, FutureAndInvalidProvenanceProduceNoProjection)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  EXPECT_EQ(association.AddFix(MakeFix(), 101, 100, 0).event, AssociationEvent::kInvalidProvenance);
+  EXPECT_EQ(association.AddStatus(Fixed(1), 0, 100, 1).event, AssociationEvent::kInvalidProvenance);
+  EXPECT_EQ(association.AddStatus(Fixed(0), 100, 100, 2).event, AssociationEvent::kInvalidIdentity);
+  EXPECT_TRUE(association.Poll(100, 20).ready.empty());
+}
+
+TEST(NavSatStatusAssociationTest, RosForwardJumpCannotReleaseNowStalePair)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  association.AddStatus(Fixed(1), 100, 100, 1);
+
+  auto expired = association.Poll(1101, 10);
+  EXPECT_TRUE(expired.ready.empty());
+  EXPECT_EQ(expired.expired_invalid_provenance, 1U);
+}
+
+TEST(NavSatStatusAssociationTest, ConflictingSequencesOnSameReceiptAreAmbiguous)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  association.AddStatus(Fixed(10), 100, 100, 1);
+  EXPECT_EQ(association.AddStatus(Float(11), 100, 100, 2).event,
+            AssociationEvent::kAmbiguousReceipt);
+
+  auto expired = association.Poll(100, 10);
+  EXPECT_TRUE(expired.ready.empty());
+  EXPECT_EQ(expired.expired_ambiguous, 1U);
+}
+
+TEST(NavSatStatusAssociationTest, FixedFloatNoFixFixedTransitionsStayEpochLocal)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  std::vector<AssociatedNavSatObservation> output;
+
+  association.AddFix(MakeFix(), 100, 100, 0);
+  association.AddStatus(Fixed(1), 100, 100, 1);
+  AppendReady(association.Poll(100, 10), output);
+
+  association.AddFix(MakeFix(), 101, 101, 11);
+  association.AddStatus(Float(2), 101, 101, 12);
+  AppendReady(association.Poll(101, 21), output);
+
+  association.AddFix(MakeFix(48.0, 2.0, NavSatStatus::STATUS_NO_FIX), 102, 102, 22);
+  association.AddStatus(NoFix(3), 102, 102, 23);
+  AppendReady(association.Poll(102, 32), output);
+
+  association.AddFix(MakeFix(), 103, 103, 33);
+  association.AddStatus(Fixed(4), 103, 103, 34);
+  AppendReady(association.Poll(103, 43), output);
+
+  ASSERT_EQ(output.size(), 4U);
+  EXPECT_EQ(output[0].status.fix_type, GnssStatus::FIX_TYPE_RTK_FIXED);
+  EXPECT_EQ(output[1].status.fix_type, GnssStatus::FIX_TYPE_RTK_FLOAT);
+  EXPECT_EQ(output[2].status.fix_type, GnssStatus::FIX_TYPE_NO_FIX);
+  EXPECT_EQ(output[3].status.fix_type, GnssStatus::FIX_TYPE_RTK_FIXED);
+  EXPECT_EQ(output[3].status.position_observation_sequence, 4U);
+}
+
+TEST(NavSatStatusAssociationTest, LaterReceiptWithResetSequenceStartsNewSourceEpoch)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddStatus(Fixed(50), 100, 100, 0);
+  association.AddFix(MakeFix(), 101, 101, 1);
+
+  auto restart = association.AddStatus(Fixed(1), 101, 101, 2);
+  EXPECT_EQ(restart.event, AssociationEvent::kSourceRestart);
+  EXPECT_EQ(association.pending_size(), 1U);
+
+  auto ready = association.Poll(101, 11);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_EQ(ready.ready.front().status.position_observation_sequence, 1U);
+}
+
+TEST(NavSatStatusAssociationTest, RepeatedSequenceOnLaterReceiptIsCachedNotAmbiguous)
+{
+  // Universal GNSS advances the receipt stamp on ANY accepted field merge
+  // (satellite count, CN0, jamming state), but position_observation_sequence
+  // only on an accepted POSITION observation. The same physical observation
+  // therefore reappears under a newer stamp. That is a cached republication,
+  // not an identity violation, and it must not poison the association.
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 100, 100, 0);
+  association.AddStatus(Fixed(7), 100, 100, 1);
+
+  association.AddFix(MakeFix(), 101, 101, 2);
+  EXPECT_EQ(association.AddStatus(Fixed(7), 101, 101, 3).event, AssociationEvent::kCachedStatus);
+
+  // The original observation still projects exactly once; the republication
+  // contributes nothing and nothing is reported ambiguous.
+  auto ready = association.Poll(101, 12);
+  ASSERT_EQ(ready.ready.size(), 1U);
+  EXPECT_EQ(ready.ready.front().status.position_observation_sequence, 7U);
+  EXPECT_EQ(ready.expired_ambiguous, 0U);
+  EXPECT_TRUE(ready.fix_only_fallbacks.empty());
+}
+
+TEST(NavSatStatusAssociationTest, RepeatedSequenceOnEarlierReceiptStaysAmbiguous)
+{
+  NavSatStatusAssociation association(8, kWindow, kMaximumAge);
+  association.AddFix(MakeFix(), 101, 101, 0);
+  association.AddStatus(Fixed(7), 101, 101, 1);
+
+  // Same observation identity claimed on an OLDER stamp: still a violation.
+  EXPECT_EQ(association.AddStatus(Fixed(7), 100, 101, 2).event,
+            AssociationEvent::kAmbiguousReceipt);
+
+  auto expired = association.Poll(101, 12);
+  EXPECT_TRUE(expired.ready.empty());
+  EXPECT_EQ(expired.expired_ambiguous, 1U);
+}
+
+TEST(NavSatStatusAssociationTest, TimerPublishFasterThanPositionRateProjectsEveryObservationOnce)
+{
+  // Regression for the real receiver cadence: fix+status are published
+  // together on a 10 Hz timer while the position rate is 5 Hz, so the stamp
+  // advances every tick and the sequence every other tick. Every physical
+  // observation must project exactly once — no drops, no duplicates.
+  NavSatStatusAssociation association(32, kWindow, kMaximumAge);
+
+  std::int64_t clock = 100;
+  std::uint64_t sequence = 1;
+  std::size_t projected = 0;
+  std::size_t ambiguous = 0;
+  std::size_t fix_only = 0;
+
+  for (int tick = 0; tick < 20; ++tick)
+  {
+    if (tick > 0 && tick % 2 == 0)
+    {
+      ++sequence;
+    }
+    const std::int64_t receipt = clock;
+    association.AddFix(MakeFix(), receipt, clock, clock);
+    association.AddStatus(Fixed(sequence), receipt, clock, clock);
+
+    clock += 1;
+    const AssociationBatch batch = association.Poll(clock, clock);
+    projected += batch.ready.size();
+    ambiguous += batch.expired_ambiguous;
+    fix_only += batch.fix_only_fallbacks.size();
+  }
+
+  clock += kWindow + 1;
+  const AssociationBatch drain = association.Poll(clock, clock);
+  projected += drain.ready.size();
+  ambiguous += drain.expired_ambiguous;
+  fix_only += drain.fix_only_fallbacks.size();
+
+  EXPECT_EQ(projected, 10U);  // 20 publish ticks, 10 position observations
+  EXPECT_EQ(ambiguous, 0U);
+  EXPECT_EQ(fix_only, 0U);
+}
+
+}  // namespace


### PR DESCRIPTION
**Split 3 of 3 of #534** — the GNSS observation-identity audit contributed by @Pepeuch. Landing the audit in tiers rather than merging it wholesale.

- **Split 1** (merged): `mowgli_interfaces/gnss_observation_freshness.hpp` + its `fusion_graph` / `mowgli_behavior` / `mowgli_hardware` consumers and the `position_observation_sequence` field.
- **Split 2** (in flight, `feat/gnss-correction-diagnostics`): `mowgli_gnss_bridge` correction diagnostics + the `correction_*` fields.
- **Split 3** (this PR): the `mowgli_localization` consumers and their launch injection. No message changes, so it is independent of split 2.

Three commits, one per subsystem, so they review and revert independently.

## 1. `cog_observation_timing` — COG sample timing from the receiver's physical rate

`cog_to_imu` dropped its baseline anchor whenever two `/gps/fix` samples were more than a hardcoded `max_sample_dt_s = 0.50` apart, measured on **callback arrival**. At `gnss_profile_rate_hz = 1` every sample exceeds it, so the anchor reset on arrival and COG yaw never accumulated a baseline; at 10 Hz the same constant spans five receiver periods, so a genuinely missed cycle folded silently into the baseline.

`navigation.launch.py` now reads the existing `gnss_profile_rate_hz` install-time key (the same value `start_gps.sh` uses to configure the receiver) and injects it as `physical_gnss_observation_rate_hz`; the deadline is derived as `1.5 / rate`. `max_sample_dt_s` stays an operator override but is validated against the physical period.

The decision moved onto **receipt provenance**, never arrival: a bounded receipt history separates a delayed duplicate (ignored) from an unseen stamp rewind (epoch reset). `StationaryLatchClock` gives the stationary-yaw latch two explicit clocks — ROS receipt for validity, steady elapsed for expiry — so a paused or rewound ROS clock can no longer keep a dead latch alive.

## 2. `navsat_status_association` — pair a fix with its own status

`navsat_to_absolute_pose_node` held one "latest status" and stamped whichever `GnssStatus` arrived most recently onto whatever `NavSatFix` it was projecting. The two topics are delivered independently, so the pairing was only accidentally correct. It fails one-directionally and silently: a stale status keeps asserting RTK-Fixed over a degraded fix, and `/gps/pose_cov` — which `map_server` averages into the dock pose under an RTK-quality gate — inherits authority the receiver never granted for that measurement.

Replaced with a bounded rendez-vous keyed on receipt provenance and nothing else (coordinates are never compared — a stationary robot legitimately repeats them). A pair is released only once its monotonic window closes, so one receipt seen with two different `position_observation_sequence` values fails closed instead of publishing the first arrival. There is deliberately **no** latest-status fallback: an unmatched fix still yields `/gps/absolute_pose` from its own `NavSatFix` status, but never typed RTK authority, so `/gps/pose_cov` stays silent. `test_navsat_status_universal` now pins exactly that.

### One deliberate deviation from #534 — with a reproduction

As contributed, the rule *"a repeated `position_observation_sequence` on a different receipt stamp is an identity violation"* fires on the receiver's **normal steady state**.

I checked the vendored driver rather than assuming. Universal GNSS publishes fix + status together from **one snapshot** on a timer (`publish_rate_hz`, 10 Hz default) — both stamps come from the same `GnssRuntimeState::timestamp_ns` through the same `ToRosTime()`, so they are bit-identical and the stamp is a valid join key. But that receipt clock advances on **any** accepted field merge — a satellite-count or CN0 update is enough (`gnss_runtime_aggregator.hpp`: `applied && update.timestamp_ns.has_value()`) — whereas `position_observation_sequence` advances only on an accepted **position** observation. Between two fixes the stamp therefore moves and the sequence does not.

Replaying that cadence (10 Hz publish / 5 Hz position) through the association as contributed:

```
ready(pose_cov)=0  fix_only(abs_pose)=0  ambiguous=100
```

**100 % of deliveries classified ambiguous** — both `/gps/absolute_pose` and `/gps/pose_cov` permanently silent, one unthrottled `RCLCPP_ERROR` per tick. That would have taken out `localization_monitor`, the GUI's GPS display and the dock-calibration gate on real hardware.

That case is a cached republication, which the design already names, so it is now classified `kCachedStatus`: the receipt is closed, nothing is emitted for it, and no other pending association is touched. The genuine violations still fail closed — a repeated sequence on an **earlier** stamp, and two sequences on one stamp. Same replay after the fix:

```
ready(pose_cov)=10  ambiguous=0   (10 physical observations over 20 publish ticks)
```

Three regression tests cover it, including the 10 Hz-publish / 5 Hz-position cadence end to end.

Worth noting as intended behaviour: `/gps/absolute_pose` now runs at the **position** rate (5 Hz) rather than the publish rate (10 Hz), and both pose topics gain the association window (`status_pairing_window_s`, 0.25 s) of latency. Stamps are preserved, and `fusion_graph` is unaffected (it subscribes to `/gps/fix` directly per Invariant 1).

## 3. `localization_monitor_policy` — receipt freshness vs delivery liveness

The monitor decided `DEAD_RECKONING` from the arrival stamp of the last `/gps/absolute_pose`. Delivery and physical observation are not the same signal here: the adapter republishes its last accepted fix on a timer with the receipt stamp unchanged, so a frozen receiver keeps the published mode looking healthy indefinitely.

`ObservationIsFresh()` now drives the mode while `DeliveryIsLive()` only shapes the log line, which distinguishes *"physical observations stale while cached message delivery remains active"* (frozen receiver) from *"observations and delivery both stale"* (dead link) — different operator actions. A clock-epoch break bypasses the `mode_debounce_sec_` hysteresis: it is not mode flicker, so the safe mode commits immediately. The mode ordering moved to a free function in `localization_monitor_policy.hpp` so it is unit-testable without a node.

## Verified

Built and tested in a `ros:kilted-ros-base` container (`colcon build --packages-up-to mowgli_localization`, Release):

| | result |
|---|---|
| `colcon test --packages-select mowgli_localization` | **171 tests, 0 failures, 0 errors**, 30 skipped (all skips are `cppcheck`, absent from the container) |
| new `test_cog_observation_timing` | 19 passed |
| new `test_localization_monitor_freshness` | 20 passed |
| `test_navsat_status_association` | 21 passed (18 from #534 + 3 new regressions) |
| `mowgli_bringup/test/test_launch_injection.py` | 7 passed |
| `mowgli_bringup/test/test_navsat_status_universal.launch.py` | 2 + shutdown, OK (live node, real DDS) |
| `ros2/scripts/format.sh` (clang-format **18.1.8**) | all 12 C++ files in this PR clean |

## Deliberately excluded

Nothing from `.agent/`, `AGENTS.md`, `README.md`, `MOWGLINEXT_GNSS_AUDIT.md`, `docs/status/`, `scripts/update_backlog_status.py`, `gui/`, `sensors/`, `.gitignore`, `.gitmodules`, `fusion_graph`, `mowgli_behavior`, `mowgli_hardware`, or `mowgli_interfaces`.

**The submodule gitlink `ros2/src/external/universal-gnss` is untouched** — `git diff origin/dev...HEAD -- ros2/src/external` is empty.

Two small notes:

- `navsat_to_absolute_pose_node.cpp`'s two TU-local helpers kept their `static` (the original dropped it, giving them external linkage in `namespace mowgli_localization`).
- `aa97b157 chore: auto-format C++ files` was generated by the repo's own pre-push hook, not by me. It reformats two **pre-existing** clang-format-18 violations in `mowgli_hardware/{src/serial_port.cpp, test/test_serial_port.cpp}` that are unrelated to this PR — any push from any branch triggers it. Whitespace only. Drop it if you'd rather it landed separately.

## Test plan

- [ ] Field: confirm `/gps/absolute_pose` and `/gps/pose_cov` keep publishing at the configured `gnss_profile_rate_hz` (the deviation above is reproduced in tests but has not run on hardware).
- [ ] Field: confirm `/localization/mode_id` still reports RTK-Fixed under a healthy receiver and drops to DEAD_RECKONING when the receiver is unplugged.
- [ ] Field: confirm COG yaw (`/imu/cog_heading`) still accumulates a baseline at the installed `gnss_profile_rate_hz`.
- [ ] Confirm one-click dock calibration still passes its `/gps/pose_cov` RTK gate.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
