### PR TITLE
fix(hardware): stop clang-format 18 fighting serial_port.cpp on every push

### DIFF
--- a/ros2/src/mowgli_hardware/src/serial_port.cpp
+++ b/ros2/src/mowgli_hardware/src/serial_port.cpp
@@ -72,7 +72,7 @@ bool SerialPort::open()
     return false;
   }
 
-  struct termios tty{};
+  struct termios tty = {};
   if (::tcgetattr(fd_, &tty) != 0)
   {
     ::close(fd_);
@@ -205,7 +205,7 @@ ssize_t SerialPort::write_all(const uint8_t* data, std::size_t len)
     if ((errno == EAGAIN || errno == EWOULDBLOCK) && backpressure_retries < kMaxBackpressureRetries)
     {
       ++backpressure_retries;
-      struct pollfd pfd{};
+      struct pollfd pfd = {};
       pfd.fd = fd_;
       pfd.events = POLLOUT;
       const int poll_result = ::poll(&pfd, 1, kPollTimeoutMs);

--- a/ros2/src/mowgli_hardware/test/test_serial_port.cpp
+++ b/ros2/src/mowgli_hardware/test/test_serial_port.cpp
@@ -44,7 +44,7 @@ TEST(SerialPort, WriteAllWritesCompleteSmallFrameToPty)
   const std::vector<uint8_t> frame{0x00, 0x11, 0x22, 0x33, 0x00};
   EXPECT_EQ(port.write_all(frame.data(), frame.size()), static_cast<ssize_t>(frame.size()));
 
-  struct pollfd pfd{};
+  struct pollfd pfd = {};
   pfd.fd = master_fd;
   pfd.events = POLLIN;
   ASSERT_GT(::poll(&pfd, 1, 100), 0) << std::strerror(errno);


### PR DESCRIPTION
## The symptom

Every push from every branch appends a stray `chore: auto-format C++ files` commit reflowing two files nobody touched. PR #546 collected one while doing unrelated localization work; reverting it just made the hook recreate it.

## The cause

`struct termios tty{};` reads to clang-format 18 as a struct **definition**, not a variable with brace-init, so it explodes the initializer:

```c++
-  struct termios tty{};
+  struct termios tty
+  {
+  };
```

Three sites hit it (`serial_port.cpp:75`, `:208`, `test_serial_port.cpp:47`). Since nothing on `dev` is stored in that shape, the opt-in `.githooks/pre-push` hook reformats them on **every** push and commits the result to whatever PR is in flight.

CI never caught the drift because the `Formatting (clang-format)` job gates only the **changed lines** against the merge-base with `origin/main` — these lines were never changed, so they were never checked, while the hook formats whole files.

## The fix

`struct X y = {};` is the same value-initialization and clang-format 18 parses it correctly. Verified directly with **18.1.8** (the version CI pins) against `ros2/.clang-format`:

```
struct termios tty{};        ->  exploded into 3 lines
struct termios tty2 = {};    ->  left alone
```

Both files are now clang-format-18 clean end to end, so the hook has nothing left to reformat.

Fixing the source rather than committing the formatter's output, because the output is worse to read and would drift back the moment anyone typed the natural form again. Note the `std::array<...> x{}` sites in the same files are **not** affected — only declarations starting with the `struct` keyword confuse the parser.

No behaviour change: `= {}` and `{}` are both value-initialization here.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ