### PR TITLE
fix(install): make mowgli-pull reclaim the image it just superseded

### DIFF
--- a/install/lib/tools.sh
+++ b/install/lib/tools.sh
@@ -165,7 +165,18 @@ exec $dc ps"
 
   create_helper_script "/usr/local/bin/mowgli-pull" "#!/usr/bin/env bash
 cd \"$project_dir\" || exit 1
-exec $dc pull"
+$dc pull \"\$@\"
+rc=\$?
+# Every pull leaves the image it superseded behind, untagged. With a 3.67 GB
+# ROS2 image on a 58 GB SD card that fills the disk in about ten updates —
+# observed at 100 %, zero bytes free, on 2026-09-06, which stops the robot
+# writing logs or recordings and makes the next pull fail. Dangling images are
+# by definition superseded, and docker refuses to remove one that any existing
+# container uses, so this is safe to run unattended. Tagged images are left
+# alone: those are named rollback points and only the operator should drop them.
+docker image prune -f >/dev/null 2>&1 || true
+df -h / | awk 'NR==2 {printf \"Disk: %s free of %s (%s used)\\n\", \$4, \$2, \$5}'
+exit \$rc"
 
   create_helper_script "/usr/local/bin/mowgli-check" "#!/usr/bin/env bash
 cd \"$INSTALL_DIR\" || exit 1


### PR DESCRIPTION
## What happened

While measuring GNSS topic skew on the robot this morning, a plain `cat > /tmp/skew.py` failed:

```
cat: write error: No space left on device
```

The SD card was at **100 %** — 56 GB of 58, zero bytes free. No logs, no recordings, and the next `mowgli-pull` would have failed too, on the morning of a field test.

## Why

`mowgli-pull` was `docker compose pull` and nothing else. Every update leaves the image it replaced behind, untagged. With a 3.67 GB ROS2 image that is roughly ten updates to a full disk:

```
Images   49 total   6 active   19.6 GB   19.24 GB reclaimable (98%)
```

Pruning the dangling ones recovered **5.7 GB** immediately.

## The change

The prune runs after the pull, and only touches **dangling** images — by definition superseded, and docker refuses to remove any image an existing container uses, so it is safe unattended. **Tagged images are deliberately left alone**: those are named rollback points (`mowgli-ros2:feat-localization-guard-gnss-health` and friends) and only the operator should drop them. 11 GB is still sitting in those on the robot; that stays a manual call.

It also prints free space afterwards, so the disk filling up becomes visible while it is still cheap to fix, and it now forwards arguments and the pull's exit code — the old one-line `exec` form did both implicitly and a naive rewrite would have lost them.

## Verified

The helper is generated through a doubly-escaped shell string, which is easy to get subtly wrong, so I rendered it rather than eyeballing it — stubbing `create_helper_script`, extracting just this block, and syntax-checking the result:

```bash
#!/usr/bin/env bash
cd "/opt/mowgli" || exit 1
docker compose pull "$@"
rc=$?
docker image prune -f >/dev/null 2>&1 || true
df -h / | awk 'NR==2 {printf "Disk: %s free of %s (%s used)\n", $4, $2, $5}'
exit $rc
```

`bash -n` clean on both `tools.sh` and the generated script, and the `awk` line was run directly.

Only affects newly installed helpers; existing robots keep the old script until reinstalled, so the manual `docker image prune -f` is still worth knowing.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ