### PR TITLE
fix(gui): make expert-mode flashing work on ST-Link V2 as well as V3

### DIFF
--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -19,13 +19,43 @@ RUN apt-get install -y rpi.gpio-common  || true
 # is frequently unreachable (504 / timeouts) and hard-fails the image build.
 # Redirect that submodule to a GitHub mirror (verified to carry the pinned
 # commit) and retry the clone a few times for transient blips.
+# PINNED, and it must stay pinned. `--branch rpi-common --depth=1` tracked a
+# MOVING branch, so the OpenOCD in the image was whatever that branch happened
+# to be on build day. Two robots installed weeks apart got materially different
+# flashing behaviour with no commit in this repo to explain it — which is
+# exactly how users hit "Debug adapter doesn't support 'swd' transport" while
+# the maintainer could not reproduce it.
+#
+# This binary is what BOTH flash paths in gui/pkg/providers/firmware.go run
+# (bare `openocd`, resolved on PATH), so its ST-Link support decides whether a
+# user can flash at all.
+ARG OPENOCD_REF=acff23ffd100479d6481a1155123774b79a990b9
 RUN git config --global url."https://github.com/syntacore/libjaylink.git".insteadOf "https://gitlab.zapb.de/libjaylink/libjaylink.git" \
  && for i in 1 2 3; do \
       rm -rf openocd && \
-      git clone --recursive --branch rpi-common --depth=1 https://github.com/raspberrypi/openocd.git && break || \
+      git clone --branch rpi-common https://github.com/raspberrypi/openocd.git && \
+      git -C openocd checkout --detach "$OPENOCD_REF" && \
+      git -C openocd submodule update --init --recursive && break || \
       { echo "openocd clone attempt $i failed, retrying..."; sleep 10; }; \
     done
 RUN cd openocd && ./bootstrap with-submodules && ./configure --enable-ftdi --enable-sysfsgpio --enable-bcm2835gpio && make -j$(nproc) && make install && cd .. && rm -rf openocd
+# Fail the BUILD, not the user's robot. An OPENOCD_REF bump that loses ST-Link
+# support, or ships a driver with no SWD transport at all, would break flashing
+# for every user with no other warning. Accepts `swd` (dapdirect) OR `hla_swd`
+# on purpose: we deliberately let openocd negotiate the transport rather than
+# forcing one, because dapdirect SWD needs recent dongle firmware on an ST-Link
+# V2 while a V3 always has it. Requiring `swd` here would re-impose exactly the
+# V2 incompatibility this setup exists to avoid.
+#
+# `transport list` only prints the driver's capabilities and never initialises
+# the adapter, so this is safe with no hardware attached.
+RUN transports="$(openocd -f interface/stlink.cfg -c 'transport list' -c shutdown 2>&1)"; \
+    echo "$transports"; \
+    echo "$transports" | grep -qE '^[[:space:]]*(hla_)?swd$' || { \
+      echo "FATAL: this openocd's ST-Link driver offers no SWD transport."; \
+      echo "Neither 'swd' nor 'hla_swd' was advertised, so no ST-Link V2 or V3"; \
+      echo "could flash the board. Pick a different OPENOCD_REF."; \
+      exit 1; }
 RUN curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py &&    python3 get-platformio.py
 RUN mkdir -p /usr/local/bin &&    ln -s ~/.platformio/penv/bin/platformio /usr/local/bin/platformio &&    ln -s ~/.platformio/penv/bin/pio /usr/local/bin/pio &&    ln -s ~/.platformio/penv/bin/piodebuggdb /usr/local/bin/piodebuggdb
 

--- a/gui/pkg/providers/firmware.go
+++ b/gui/pkg/providers/firmware.go
@@ -11,10 +11,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/mowglinext/mowglinext/pkg/types"
-	"github.com/mowglinext/mowglinext/pkg/msgs/mowgli"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/mowglinext/mowglinext/pkg/msgs/mowgli"
+	"github.com/mowglinext/mowglinext/pkg/types"
 	"golang.org/x/sys/execabs"
 	"golang.org/x/xerrors"
 )
@@ -158,7 +158,7 @@ func (fp *FirmwareProvider) flashMowgli(writer io.Writer, config types.FirmwareC
 	}
 	_, _ = writer.Write([]byte("------> board.h built\n"))
 	//Build firmware
-	_, _ = writer.Write([]byte("------> Building and uploading firmware...\n"))
+	_, _ = writer.Write([]byte("------> Building firmware...\n"))
 	pioEnv := "Yardforce500"
 	switch config.BoardType {
 	case "BOARD_YARDFORCE500B":
@@ -166,16 +166,37 @@ func (fp *FirmwareProvider) flashMowgli(writer io.Writer, config types.FirmwareC
 	case "BOARD_LUV1000RI":
 		pioEnv = "LUV1000RI"
 	}
-	cmd := execabs.Command("/bin/bash", "-c", "platformio run -e "+pioEnv+" -t upload")
+	// BUILD ONLY — deliberately not `-t upload`. PlatformIO's uploader forces
+	// `transport select swd`, which excludes ST-Link V2 dongles without recent
+	// firmware; see openocdProgramCmd. Expert mode exists to compile a custom
+	// board.h, not to own the flashing transport, so it now hands the artifact
+	// to the same openocd command the prebuilt path uses.
+	cmd := execabs.Command("/bin/bash", "-c", "platformio run -e "+pioEnv)
 	cmd.Dir = pioProjectDir
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	err = cmd.Run()
 	if err != nil {
-		_, _ = writer.Write([]byte("------> Error while building and uploading firmware: " + err.Error() + "\n"))
+		_, _ = writer.Write([]byte("------> Error while building firmware: " + err.Error() + "\n"))
+		return xerrors.Errorf("error while building firmware: %w", err)
+	}
+	_, _ = writer.Write([]byte("------> Firmware built\n"))
+
+	// The .elf carries its own load addresses, so no offset is passed here.
+	elfPath := pioProjectDir + "/.pio/build/" + pioEnv + "/firmware.elf"
+	if _, statErr := os.Stat(elfPath); statErr != nil {
+		_, _ = writer.Write([]byte("------> Build produced no firmware.elf at " + elfPath + "\n"))
+		return xerrors.Errorf("firmware.elf not found after build: %w", statErr)
+	}
+	_, _ = writer.Write([]byte("------> Flashing firmware (openocd program+verify)...\n"))
+	cmd = execabs.Command("/bin/bash", "-c", openocdProgramCmd(config.BoardType, elfPath))
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err = cmd.Run(); err != nil {
+		_, _ = writer.Write([]byte("------> Error while flashing firmware: " + err.Error() + "\n"))
 		return xerrors.Errorf("error while flashing firmware: %w", err)
 	}
-	_, _ = writer.Write([]byte("------> Firmware flashed\n"))
+	_, _ = writer.Write([]byte("------> Firmware flashed and byte-verified\n"))
 	return nil
 }
 
@@ -233,6 +254,28 @@ func (fp *FirmwareProvider) flashVermut(writer io.Writer, config types.FirmwareC
 	return nil
 }
 
+// openocdProgramCmd builds the ONE openocd invocation every flash path uses.
+//
+// It deliberately passes NO `transport select`, and that is the whole point.
+// PlatformIO's ststm32 platform hardcodes `-c "transport select swd"`
+// (platform.py), which means dapdirect SWD: an ST-Link **V3** always offers it,
+// but an ST-Link **V2** only does with recent dongle firmware. On an older V2 —
+// perfectly good hardware that flashes fine otherwise — openocd refuses with
+// "Debug adapter doesn't support 'swd' transport". Letting openocd negotiate
+// the transport with whatever adapter is actually plugged in is what makes a
+// single command work on V2 and V3 alike.
+//
+// interface/stlink.cfg covers both generations: its vid_pid list carries the
+// V2, V2-1 and V3 product IDs.
+//
+// programArg is passed to openocd's `program` verbatim, so callers append a
+// load address for a raw .bin and pass a bare path for an .elf (which carries
+// its own addresses).
+func openocdProgramCmd(board, programArg string) string {
+	return "openocd -f interface/stlink.cfg -f " + openocdTargetCfg(board) +
+		" -c \"program " + programArg + " verify reset exit\""
+}
+
 // openocdTargetCfg maps a board to its OpenOCD target config. YardForce 500 is a
 // STM32F103 (f1x); the 500B is a STM32F401 (f4x). Different MCU family = different
 // target cfg, so flashing with the wrong one simply fails — itself a guard.
@@ -288,9 +331,8 @@ func (fp *FirmwareProvider) flashPrebuilt(writer io.Writer, config types.Firmwar
 	// reset=10) are Broadcom BCM numbers that land on the wrong RK3588 pins, and
 	// /dev/gpiomem does not exist. The GPIO `export` also fails EBUSY on retry
 	// because sysfs export state is kernel-global and leaks across attempts.
-	openocdCmd := "openocd -f interface/stlink.cfg -f " + openocdTargetCfg(entry.Board) +
-		" -c \"program " + binPath + " 0x08000000 verify reset exit\""
-	cmd := execabs.Command("/bin/bash", "-c", openocdCmd)
+	cmd := execabs.Command("/bin/bash", "-c",
+		openocdProgramCmd(entry.Board, binPath+" 0x08000000"))
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	if err := cmd.Run(); err != nil {

--- a/gui/pkg/providers/firmware_test.go
+++ b/gui/pkg/providers/firmware_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mowglinext/mowglinext/pkg/types"
@@ -95,4 +96,48 @@ func chdirToGuiRoot(t *testing.T) {
 		t.Fatalf("expected asserts/ at gui root: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+// The GUI's expert flash path used to run `platformio run -t upload`, whose
+// ststm32 platform hardcodes `-c "transport select swd"`. That is dapdirect
+// SWD: an ST-Link V3 always has it, an ST-Link V2 only with recent dongle
+// firmware, so users with a V2 got "Debug adapter doesn't support 'swd'
+// transport" and could not flash at all. Both paths now share one openocd
+// command that forces no transport and lets the adapter negotiate.
+func TestOpenocdProgramCmdForcesNoTransport(t *testing.T) {
+	for _, board := range []string{"BOARD_YARDFORCE500", "BOARD_YARDFORCE500B", ""} {
+		cmd := openocdProgramCmd(board, "/tmp/firmware.elf")
+		if strings.Contains(cmd, "transport select") {
+			t.Errorf("board %q: openocd command must not select a transport, "+
+				"that is what breaks ST-Link V2: %s", board, cmd)
+		}
+		if !strings.Contains(cmd, "interface/stlink.cfg") {
+			t.Errorf("board %q: must use interface/stlink.cfg, whose vid_pid list "+
+				"covers ST-Link V2, V2-1 and V3: %s", board, cmd)
+		}
+		if !strings.Contains(cmd, "verify") {
+			t.Errorf("board %q: the flashed bytes must be verified: %s", board, cmd)
+		}
+	}
+}
+
+// A wrong target cfg simply fails to flash, which is itself a guard — but only
+// if the mapping is right in the first place. The 500 is an STM32F103, the
+// 500B an STM32F401.
+func TestOpenocdProgramCmdPicksTheBoardTarget(t *testing.T) {
+	if got := openocdProgramCmd("BOARD_YARDFORCE500B", "/tmp/f.elf"); !strings.Contains(got, "target/stm32f4x.cfg") {
+		t.Errorf("500B is an STM32F401 and needs stm32f4x.cfg: %s", got)
+	}
+	if got := openocdProgramCmd("BOARD_YARDFORCE500", "/tmp/f.elf"); !strings.Contains(got, "target/stm32f1x.cfg") {
+		t.Errorf("500 is an STM32F103 and needs stm32f1x.cfg: %s", got)
+	}
+}
+
+// The prebuilt path flashes a raw .bin, which carries no addresses, so its
+// load offset must survive refactors of the shared command.
+func TestOpenocdProgramCmdKeepsTheBinLoadAddress(t *testing.T) {
+	got := openocdProgramCmd("BOARD_YARDFORCE500", "/tmp/fw.bin 0x08000000")
+	if !strings.Contains(got, "program /tmp/fw.bin 0x08000000 verify reset exit") {
+		t.Errorf("raw .bin must be programmed at the STM32 flash base: %s", got)
+	}
 }


### PR DESCRIPTION
## The report

Users on the **expert (custom build)** path cannot flash at all:

```
Error: Debug adapter doesn't support 'swd' transport
```

The default prebuilt path works fine for the same people on the same hardware. That asymmetry is the whole clue.

## Cause

Expert mode ran `platformio run -t upload`. PlatformIO's `ststm32` platform hardcodes the transport (`platform.py`, unconditional):

```python
"-f", "interface/%s.cfg" % link,
"-c", "transport select swd",
"-f", "target/%s.cfg" % debug.get("openocd_target")
```

That `swd` is **dapdirect** SWD. An ST-Link **V3** always offers it; an ST-Link **V2** only with recent dongle firmware. On an older V2 — hardware that flashes perfectly well otherwise — openocd refuses.

`flashPrebuilt` never hit this, and the reason is exactly that it passes **no** `transport select` and lets openocd negotiate with whatever adapter is plugged in. So the repo had two flashing implementations and only one of them worked everywhere.

## The fix

There is now one. `openocdProgramCmd` is shared by both paths, forces no transport, and uses `interface/stlink.cfg` — whose vid_pid list carries the V2, V2-1 **and** V3 product IDs, so a single command genuinely serves both generations.

Expert mode builds with PlatformIO (`platformio run`, no `-t upload`) and hands the resulting `firmware.elf` to that command. It keeps everything expert mode is actually for — cloning a branch, rendering `board.h.template`, the full parameter surface, `DisableEmergency` — and stops owning the flashing transport, which was never its job.

`.elf` carries its own load addresses, so no offset; the prebuilt path still passes `0x08000000` for its raw `.bin`, and a test pins that.

## Verified

- `go build ./...`, `gofmt` clean, **all Go packages pass**.
- Three new tests: no transport is selected, the board→target-cfg mapping is right (500 = F103, 500B = F401), and the `.bin` load address survives.
- **Negative control run**: re-adding `-c "transport select swd"` to the shared command fails `TestOpenocdProgramCmdForcesNoTransport`, and removing it restores green. The guard actually guards.

## Also: the image stopped being reproducible

`gui/Dockerfile` cloned `raspberrypi/openocd` branch `rpi-common` at `--depth=1` with **no pinned ref**, so the OpenOCD inside the image was whatever that branch held on build day. Two robots installed weeks apart could get materially different flashing behaviour with no commit here to explain it — which is why this was hard to reproduce.

Pinned to `acff23ffd100479d6481a1155123774b79a990b9`. That is the branch's current head, verified via the API, so **nothing changes today**; it only stops future drift.

A build-time check now fails the image if the ST-Link driver advertises neither `swd` nor `hla_swd`. It accepts **either** deliberately: requiring `swd` would re-impose the exact V2 incompatibility this PR removes. Verified against real `transport list` output for both the swd-capable and hla-only cases, and against a driver with neither.

## Note for affected users

They still need to update the container to get this. Until then, the default (prebuilt) path works if their board has a binary in the manifest — it just cannot set custom `board.h` values.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ