### PR TITLE
fix(map): return obstacles only with their owning area

### DIFF
--- a/ros2/src/mowgli_map/src/area_manager.cpp
+++ b/ros2/src/mowgli_map/src/area_manager.cpp
@@ -593,34 +593,19 @@ void MapServerNode::on_get_mowing_area(
       res->area.obstacle_info.push_back(info);
     }
 
-    // Also include persistent tracked obstacles from the obstacle tracker
-    // so the coverage planner can avoid them in the initial plan. Skip the
-    // ones already listed above: apply_promoted_obstacle writes a promoted
-    // keepout into BOTH stores, so without this the same hole was handed to
-    // F2C twice — and with obstacle_info it would also arrive a second time
-    // wearing the wrong identity (a pending dig looking like an accepted
-    // tracker obstacle).
-    const auto n_static = res->area.obstacles.size();
-    for (const auto& obs_poly : obstacle_polygons_)
-    {
-      if (obs_poly.points.size() >= 3 &&
-          !has_duplicate_obstacle(res->area.obstacles, obs_poly, kObstacleDedupEpsilonM))
-      {
-        res->area.obstacles.push_back(obs_poly);
-        mowgli_interfaces::msg::MapObstacleInfo info;
-        info.source = mowgli_interfaces::msg::MapObstacleInfo::SOURCE_TRACKER;
-        res->area.obstacle_info.push_back(info);
-      }
-    }
+    // Area entries own every obstacle, including pending digs and promoted
+    // tracker observations. obstacle_polygons_ is only a flat keepout cache
+    // for navigation; appending it here leaks other areas' obstacles into
+    // this response. With three lawns that drew one dig three times, and the
+    // extra copies lost their id/name/pending provenance. Return the owning
+    // area's entries only; the global keepout mask still protects every spot.
 
     res->success = true;
     RCLCPP_INFO(get_logger(),
-                "GetMowingArea[%u]: area='%s', %zu obstacles (%zu static + %zu tracked)",
+                "GetMowingArea[%u]: area='%s', %zu obstacles",
                 req->index,
                 entry.name.c_str(),
-                res->area.obstacles.size(),
-                n_static,
-                res->area.obstacles.size() - n_static);
+                res->area.obstacles.size());
   }
   else
   {

--- a/ros2/src/mowgli_map/test/test_map_server.cpp
+++ b/ros2/src/mowgli_map/test/test_map_server.cpp
@@ -1032,6 +1032,33 @@ protected:
     node_->on_dig_event_for_test(msg);
   }
 
+  void add_other_areas()
+  {
+    // Three lawns reproduce the three GUI copies. Include an overlapping
+    // navigation area too: ownership must not depend on geometric containment.
+    for (uint32_t i = 1; i <= 3; ++i)
+    {
+      auto req = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Request>();
+      req->area.name = "other_" + std::to_string(i);
+      req->is_navigation_area = i == 3;
+      req->area.area = i == 3 ? make_rect(-2, -2, 2, 2) : make_rect(4 * i, -3, 4 * i + 3, 3);
+      auto res = std::make_shared<mowgli_interfaces::srv::AddMowingArea::Response>();
+      node_->add_area_for_test(req, res);
+      ASSERT_TRUE(res->success);
+    }
+  }
+
+  void expect_other_areas_empty()
+  {
+    for (uint32_t i = 1; i <= 3; ++i)
+    {
+      SCOPED_TRACE(i);
+      const auto area = fetch_area(i);
+      EXPECT_TRUE(area.obstacles.empty()) << "another area's keepout leaked into this response";
+      EXPECT_TRUE(area.obstacle_info.empty());
+    }
+  }
+
   mowgli_interfaces::msg::MapArea fetch_area(uint32_t index)
   {
     auto req = std::make_shared<mowgli_interfaces::srv::GetMowingArea::Request>();
@@ -1081,6 +1108,80 @@ TEST_F(DigProposalTest, PendingDigStillProtectsTheSpotThisSession)
   const auto mask = node_->build_keepout_mask_for_test();
   ASSERT_FALSE(mask.data.empty());
   EXPECT_EQ(mask_at(mask, 1.0, 1.0), 100) << "the dig spot must be lethal for this session";
+}
+
+TEST_F(DigProposalTest, PendingDigIsReturnedOnlyWithItsOwningArea)
+{
+  add_lawn();
+  add_other_areas();
+  dig_at(1.0, 1.0);
+  const auto info = node_->obstacle_info_for_test(0, 0);
+
+  // Repeated GUI polls must return one polygon with its original identity.
+  for (int poll = 0; poll < 2; ++poll)
+  {
+    const auto owner = fetch_area(0);
+    ASSERT_EQ(owner.obstacles.size(), 1u);
+    ASSERT_EQ(owner.obstacle_info.size(), 1u);
+    EXPECT_EQ(owner.obstacle_info[0].id, info.id);
+    EXPECT_EQ(owner.obstacle_info[0].name, info.name);
+    EXPECT_EQ(owner.obstacle_info[0].source, mowgli_interfaces::msg::MapObstacleInfo::SOURCE_DIG);
+    EXPECT_TRUE(owner.obstacle_info[0].pending);
+    expect_other_areas_empty();
+  }
+  EXPECT_EQ(mask_at(node_->build_keepout_mask_for_test(), 1.0, 1.0), 100);
+
+  auto req = std::make_shared<mowgli_interfaces::srv::ClearObstacle::Request>();
+  req->obstacle_id = info.id;
+  auto res = std::make_shared<mowgli_interfaces::srv::ClearObstacle::Response>();
+  node_->discard_obstacle_for_test(req, res);
+  ASSERT_TRUE(res->success);
+  EXPECT_TRUE(fetch_area(0).obstacles.empty());
+  expect_other_areas_empty();
+  EXPECT_EQ(node_->obstacle_polygon_count_for_test(), 0u);
+}
+
+TEST_F(DigProposalTest, AcceptedDigKeepsItsAreaAndProvenanceBeforeAndAfterReload)
+{
+  add_lawn();
+  add_other_areas();
+  dig_at(1.0, 1.0);
+  auto req = std::make_shared<mowgli_interfaces::srv::PromoteObstacle::Request>();
+  req->pending_id = node_->obstacle_info_for_test(0, 0).id;
+  req->name = "dig patch";
+  auto res = std::make_shared<mowgli_interfaces::srv::PromoteObstacle::Response>();
+  node_->promote_obstacle_for_test(req, res);
+  ASSERT_TRUE(res->success);
+
+  for (bool reload : {false, true})
+  {
+    if (reload)
+      node_->load_areas_for_test(areas_path_);
+    const auto owner = fetch_area(0);
+    ASSERT_EQ(owner.obstacles.size(), 1u);
+    ASSERT_EQ(owner.obstacle_info.size(), 1u);
+    EXPECT_FALSE(owner.obstacle_info[0].pending);
+    EXPECT_EQ(owner.obstacle_info[0].name, "dig patch");
+    EXPECT_EQ(owner.obstacle_info[0].source, mowgli_interfaces::msg::MapObstacleInfo::SOURCE_DIG);
+    expect_other_areas_empty();
+    EXPECT_EQ(mask_at(node_->build_keepout_mask_for_test(), 1.0, 1.0), 100);
+  }
+}
+
+TEST_F(DigProposalTest, PromotedPolygonIsReturnedOnlyWithItsOwningArea)
+{
+  add_lawn();
+  add_other_areas();
+  const auto polygon = make_rect(0.5, 0.5, 1.5, 1.5);
+  ASSERT_TRUE(node_->apply_promoted_obstacle_for_test(0, polygon));
+  const auto owner = fetch_area(0);
+  ASSERT_EQ(owner.obstacles.size(), 1u);
+  EXPECT_EQ(owner.obstacles[0], polygon);
+  ASSERT_EQ(owner.obstacle_info.size(), 1u);
+  EXPECT_EQ(owner.obstacle_info[0].source, mowgli_interfaces::msg::MapObstacleInfo::SOURCE_USER);
+  EXPECT_FALSE(owner.obstacle_info[0].pending);
+  expect_other_areas_empty();
+  EXPECT_EQ(mask_at(node_->build_keepout_mask_for_test(), 1.0, 1.0), 100);
 }
 
 TEST_F(DigProposalTest, AcceptingAProposalPersistsItWithItsProvenance)


### PR DESCRIPTION
## Summary

With three mowing areas, one dig could appear as three overlapping obstacles in the GUI. `get_mowing_area` appended the global keepout cache to every area's response, giving copies in other areas a new anonymous tracker identity and losing their pending status.

Return each area's own obstacle entries, which already contain pending digs and promoted observations with their original metadata.

**Safety-critical review:** this response also feeds coverage planning. The global keepout cache and navigation mask are unchanged; tests verify the original dig location remains lethal before and after acceptance. No drive, blade, firmware or detection changes.

## Changes

- Remove the global-cache append from `get_mowing_area`; preserve owning-area IDs, names, sources and pending flags.
- Add three multi-area regression tests covering pending/discarded digs, accepted digs before and after reload, and promoted polygons. Include three lawns and an overlapping navigation area.
- Document the ownership/cache distinction in the handler.

Expiry policy and GUI accept/discard controls are outside this PR.

## Component

- [x] ROS2 Stack (`ros2/`)

## Testing

- [x] Built successfully: `mowgli_interfaces` and `mowgli_map` in ROS Kilted, as a non-root user.
- [x] Unit tests pass: all 68 C++ tests across the four map-package suites, including the three new regressions.
- All three new tests failed against the unmodified implementation, then passed with this fix.
- `colcon test --packages-select mowgli_map --return-code-on-test-failure`: 94 reported checks, zero errors/failures, 17 skipped (ament disables cppcheck 2.13.0 due to known performance issues).
- Changed lines verified with clang-format 18.1.3 against the merge-base with `origin/main`; `git diff --check` passed.
- Not deployed to a mower or tested in simulation. Full workspace validation remains for CI.

## Checklist

- [x] Follows conventional commit format
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes
- [x] Physical behavior impact flagged for safety-critical review above
- [x] Changed C++ lines are clang-format 18 clean

