### PR TITLE
fix(gui): clarify vertex deletion and restore saved map rotation

### DIFF
--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -1581,6 +1581,8 @@
     "selectExactlyOneToSplit": "Select exactly 1 area to split",
     "selectionMustBePolygon": "Selection must be a polygon area",
     "drawLineAcrossArea": "Draw a line across the area to split it",
+    "deletePointsConfirmTitle": "Delete selected points?",
+    "deletePointsConfirmBody": "The selected points will be removed. If too few points remain to form a polygon, that shape will also be removed. You can undo before saving.",
     "deleteAreaConfirmTitle": "Delete this area?",
     "deleteAreaConfirmBody": "The selected area (and its obstacles) will be removed. You can undo before saving.",
     "deleteAreaConfirmOk": "Delete",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -1577,6 +1577,8 @@
     "selectExactlyOneToSplit": "Sélectionnez exactement 1 zone à découper",
     "selectionMustBePolygon": "La sélection doit être une zone polygonale",
     "drawLineAcrossArea": "Tracez une ligne à travers la zone pour la découper",
+    "deletePointsConfirmTitle": "Supprimer les points sélectionnés ?",
+    "deletePointsConfirmBody": "Les points sélectionnés seront supprimés. Si le nombre de points restants ne suffit plus pour former un polygone, cette forme sera également supprimée. Vous pouvez annuler avant de sauvegarder.",
     "deleteAreaConfirmTitle": "Supprimer cette zone ?",
     "deleteAreaConfirmBody": "La zone sélectionnée (et ses obstacles) sera supprimée. Vous pouvez annuler avant d’enregistrer.",
     "deleteAreaConfirmOk": "Supprimer",

--- a/gui/web/src/pages/MapPage.tsx
+++ b/gui/web/src/pages/MapPage.tsx
@@ -21,6 +21,7 @@ import {MowingFeature, MowingAreaFeature, DockFeatureBase, MowingFeatureBase, Na
 import {useMapEditHistory} from "./map/hooks/useMapEditHistory.ts";
 import {useMapOffset} from "./map/hooks/useMapOffset.ts";
 import {useMapBearing} from "./map/hooks/useMapBearing.ts";
+import {useMapBearingCamera} from "./map/hooks/useMapBearingCamera.ts";
 import {useManualMode} from "./map/hooks/useManualMode.ts";
 import {useMapEditing} from "./map/hooks/useMapEditing.ts";
 import {useMapStreams} from "./map/hooks/useMapStreams.ts";
@@ -121,9 +122,6 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     const robotPoseRef = useRef<{ x: number; y: number; heading: number } | null>(null)
     const mapInstanceRef = useRef<MapboxMap | null>(null)
     const drawRef = useRef<import('@mapbox/mapbox-gl-draw').default | null>(null);
-    // Stable ref to the 'rotateend' listener so it can be removed on unmount
-    // (StrictMode mounts twice, otherwise the handler stacks).
-    const rotateEndHandlerRef = useRef<(() => void) | null>(null);
 
     // Only include editable polygon features for DrawControl — exclude mower,
     // paths, and other display-only features so that frequent pose updates don't
@@ -146,17 +144,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
     const {offsetX, offsetY, handleOffsetX, handleOffsetY} = useMapOffset({config, setConfig, notification});
     const {bearing, handleBearing} = useMapBearing({config, setConfig, notification});
 
-    // Apply bearing imperatively when the user edits it from the rotation
-    // panel (slider/input/reset button). Mapbox-GL's `setBearing` rotates
-    // the camera without remounting the Map; using initialViewState alone
-    // would freeze the rotation at first paint and ignore later changes.
-    useEffect(() => {
-        const m = mapInstanceRef.current;
-        if (!m) return;
-        if (Math.abs(m.getBearing() - bearing) > 0.5) {
-            m.easeTo({bearing, duration: 200});
-        }
-    }, [bearing]);
+    const onMapLoad = useMapBearingCamera({mapInstanceRef, bearing, onBearingChange: handleBearing, interactive: !compact});
 
     const _datumLon = parseFloat(settings["datum_lon"] ?? 0)
     const _datumLat = parseFloat(settings["datum_lat"] ?? 0)
@@ -625,16 +613,6 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
         return () => window.removeEventListener("keydown", onKeyDown);
     }, [dockPlacementMode]);
 
-    // Remove the map's 'rotateend' listener on unmount (added in onLoad).
-    useEffect(() => {
-        return () => {
-            const m = mapInstanceRef.current;
-            if (m && rotateEndHandlerRef.current) {
-                m.off('rotateend', rotateEndHandlerRef.current);
-                rotateEndHandlerRef.current = null;
-            }
-        };
-    }, []);
 
     const handleMapClick = useCallback((e: {lngLat: {lng: number; lat: number}}) => {
         if (!dockPlacementMode) return;
@@ -755,6 +733,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                                                          style={{width: '100%', height: '100%'}}
                                                          mapStyle={useSatellite ? "mapbox://styles/mapbox/satellite-streets-v12" : "mapbox://styles/mapbox/dark-v11"}
                                                          interactive={false}
+                                                         onLoad={onMapLoad}
                                                          attributionControl={false}
                 >
                     {tileUri ? <Source type={"raster"} id={"custom-raster"} tiles={[tileUri]} tileSize={256}/> : null}
@@ -909,19 +888,7 @@ export const MapPage: React.FC<{compact?: boolean}> = ({compact = false}) => {
                                                          }}
                                                          style={{width: '100%', height: '100%'}}
                                                          mapStyle={useSatellite ? "mapbox://styles/mapbox/satellite-streets-v12" : "mapbox://styles/mapbox/dark-v11"}
-                                                         onLoad={(e) => {
-                                                             const m = e.target as unknown as MapboxMap;
-                                                             mapInstanceRef.current = m;
-                                                             // Capture user-driven rotation (right-click drag on
-                                                             // desktop, two-finger rotate on touch — both enabled
-                                                             // by default in mapbox-gl) and persist via the same
-                                                             // debounced handler the slider uses. Keep a stable ref
-                                                             // so the unmount effect can remove it (StrictMode
-                                                             // mounts twice, otherwise the handler stacks).
-                                                             const onRotateEnd = () => handleBearing(m.getBearing());
-                                                             rotateEndHandlerRef.current = onRotateEnd;
-                                                             m.on('rotateend', onRotateEnd);
-                                                         }}
+                                                         onLoad={onMapLoad}
                                                          onClick={handleMapClick}
                                                          interactiveLayerIds={DYN_OBSTACLE_INTERACTIVE_LAYERS}
                                                          onMouseMove={handleMapMouseMove}

--- a/gui/web/src/pages/map/hooks/useMapBearingCamera.test.ts
+++ b/gui/web/src/pages/map/hooks/useMapBearingCamera.test.ts
@@ -1,0 +1,68 @@
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import type {Map as MapboxMap} from 'mapbox-gl';
+import {useMapBearingCamera} from './useMapBearingCamera';
+
+function camera() {
+    let bearing = 0;
+    const map = {
+        getBearing: () => bearing,
+        setBearing: vi.fn((value: number) => { bearing = value; }),
+        easeTo: vi.fn((value: {bearing: number}) => { bearing = value.bearing; }),
+        on: vi.fn(), off: vi.fn(),
+    };
+    return {map, target: map as unknown as MapboxMap};
+}
+
+describe('saved map camera bearing', () => {
+    it.each([true, false])('restores config loaded before the map (interactive=%s)', interactive => {
+        const mapInstanceRef = {current: null as MapboxMap | null};
+        const onBearingChange = vi.fn();
+        const {result} = renderHook(() => useMapBearingCamera({mapInstanceRef, bearing: 47, interactive, onBearingChange}));
+        const {map, target} = camera();
+        act(() => result.current({target}));
+        expect(map.getBearing()).toBe(47);
+        expect(onBearingChange).not.toHaveBeenCalled();
+        expect(map.on).toHaveBeenCalledTimes(interactive ? 1 : 0);
+    });
+
+    it('applies a saved value arriving after map load', () => {
+        const mapInstanceRef = {current: null as MapboxMap | null};
+        const {result, rerender} = renderHook(({bearing}) => useMapBearingCamera({mapInstanceRef, bearing, interactive: true, onBearingChange: vi.fn()}), {initialProps: {bearing: 0}});
+        const {map, target} = camera();
+        act(() => result.current({target}));
+        rerender({bearing: -35});
+        expect(map.getBearing()).toBe(-35);
+    });
+
+    it('restores replacement maps and removes listeners when leaving the page', () => {
+        const mapInstanceRef = {current: null as MapboxMap | null};
+        const {result, unmount} = renderHook(() => useMapBearingCamera({mapInstanceRef, bearing: 73, interactive: true, onBearingChange: vi.fn()}));
+        const first = camera();
+        const second = camera();
+        act(() => result.current({target: first.target}));
+        act(() => result.current({target: second.target}));
+        expect(first.map.off).toHaveBeenCalledOnce();
+        expect(second.map.getBearing()).toBe(73);
+        unmount();
+        expect(second.map.off).toHaveBeenCalledOnce();
+        expect(mapInstanceRef.current).toBeNull();
+    });
+
+    it('saves gestures through the latest callback but ignores programmatic rotation', () => {
+        const mapInstanceRef = {current: null as MapboxMap | null};
+        const oldCallback = vi.fn();
+        const nextCallback = vi.fn();
+        const {result, rerender} = renderHook(({onBearingChange}) => useMapBearingCamera({mapInstanceRef, bearing: 20, interactive: true, onBearingChange}), {initialProps: {onBearingChange: oldCallback}});
+        const {map, target} = camera();
+        act(() => result.current({target}));
+        const rotateEnd = map.on.mock.calls[0][1] as (event: object) => void;
+        rotateEnd({});
+        expect(oldCallback).not.toHaveBeenCalled();
+        rerender({onBearingChange: nextCallback});
+        map.setBearing(82);
+        rotateEnd({originalEvent: {type: 'touchend'}});
+        expect(nextCallback).toHaveBeenCalledWith(82);
+        expect(oldCallback).not.toHaveBeenCalled();
+    });
+});

--- a/gui/web/src/pages/map/hooks/useMapBearingCamera.ts
+++ b/gui/web/src/pages/map/hooks/useMapBearingCamera.ts
@@ -1,0 +1,50 @@
+import {useCallback, useEffect, useRef, type RefObject} from 'react';
+import type {Map as MapboxMap} from 'mapbox-gl';
+
+interface Options {
+    mapInstanceRef: RefObject<MapboxMap | null>;
+    bearing: number;
+    onBearingChange: (bearing: number) => void;
+    interactive: boolean;
+}
+
+/** Restore the display camera regardless of whether config or the map loads first. */
+export function useMapBearingCamera({mapInstanceRef, bearing, onBearingChange, interactive}: Options) {
+    const detachRef = useRef<(() => void) | null>(null);
+    const onBearingChangeRef = useRef(onBearingChange);
+    useEffect(() => {
+        onBearingChangeRef.current = onBearingChange;
+    }, [onBearingChange]);
+
+    useEffect(() => {
+        const map = mapInstanceRef.current;
+        if (map && Math.abs(map.getBearing() - bearing) > 0.5) {
+            map.easeTo({bearing, duration: 200});
+        }
+    }, [bearing, mapInstanceRef]);
+
+    const onLoad = useCallback(({target}: {target: MapboxMap}) => {
+        detachRef.current?.();
+        mapInstanceRef.current = target;
+        // Setting a ref doesn't rerun the effect above. Bounds fitting and
+        // reused map instances can also start north-up despite initialViewState.
+        target.setBearing(bearing);
+        const onRotateEnd = (event: {originalEvent?: unknown}) => {
+            // Restoration and slider animations are already represented in
+            // config/state. Only gestures should initiate another save.
+            if (event.originalEvent) onBearingChangeRef.current(target.getBearing());
+        };
+        if (interactive) target.on('rotateend', onRotateEnd);
+        detachRef.current = () => {
+            if (interactive) target.off('rotateend', onRotateEnd);
+            if (mapInstanceRef.current === target) mapInstanceRef.current = null;
+        };
+    }, [bearing, interactive, mapInstanceRef]);
+
+    useEffect(() => () => {
+        detachRef.current?.();
+        detachRef.current = null;
+    }, []);
+
+    return onLoad;
+}

--- a/gui/web/src/pages/map/hooks/useMapEditing.test.ts
+++ b/gui/web/src/pages/map/hooks/useMapEditing.test.ts
@@ -1,0 +1,63 @@
+import {act, renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {useMapEditing, type UseMapEditingOptions} from './useMapEditing';
+
+interface DeleteDialog {
+    title: string;
+    content: string;
+    onOk: () => void;
+}
+const {confirm} = vi.hoisted(() => ({confirm: vi.fn<(dialog: DeleteDialog) => void>()}));
+vi.mock('antd', () => ({App: {useApp: () => ({modal: {confirm}})}}));
+vi.mock('react-i18next', () => ({useTranslation: () => ({t: (key: string) => key})}));
+
+describe('map delete confirmation', () => {
+    beforeEach(() => confirm.mockClear());
+
+    function setup(mode: string, points: number, selected = ['area-0']) {
+        const draw = {
+            getMode: () => mode,
+            getSelectedPoints: () => ({features: Array.from({length: points})}),
+            getSelectedIds: () => selected,
+            trash: vi.fn(),
+        };
+        const options = {
+            features: {}, setFeatures: vi.fn(), editMap: true, mowingAreas: [],
+            drawRef: {current: draw}, notification: {}, mapInstanceRef: {current: null},
+        } as unknown as UseMapEditingOptions;
+        const hook = renderHook(() => useMapEditing(options));
+        act(() => hook.result.current.handleTrash());
+        return draw;
+    }
+
+    it.each([1, 2])('describes deleting %i selected vertices and waits for confirmation', points => {
+        const draw = setup('direct_select', points);
+        const dialog = confirm.mock.calls[0][0];
+        expect(dialog.title).toBe('mapEditing.deletePointsConfirmTitle');
+        expect(dialog.content).toBe('mapEditing.deletePointsConfirmBody');
+        expect(draw.trash).not.toHaveBeenCalled();
+        act(() => dialog.onOk());
+        expect(draw.trash).toHaveBeenCalledOnce();
+    });
+
+    it('keeps the area warning for a complete feature selection', () => {
+        setup('simple_select', 0);
+        expect(confirm.mock.calls[0][0].content).toBe('mapEditing.deleteAreaConfirmBody');
+    });
+
+    it('does not offer deletion with no selected feature', () => {
+        const draw = setup('simple_select', 0, []);
+        expect(confirm).not.toHaveBeenCalled();
+        expect(draw.trash).not.toHaveBeenCalled();
+    });
+
+    it('describes direct-select deletion even before the selected-point cache updates', () => {
+        // The custom midpoint handler selects the new vertex internally before
+        // updating Draw's public getSelectedPoints cache.
+        const draw = setup('direct_select', 0);
+        const dialog = confirm.mock.calls[0][0];
+        expect(dialog.title).toBe('mapEditing.deletePointsConfirmTitle');
+        act(() => dialog.onOk());
+        expect(draw.trash).toHaveBeenCalledOnce();
+    });
+});

--- a/gui/web/src/pages/map/hooks/useMapEditing.ts
+++ b/gui/web/src/pages/map/hooks/useMapEditing.ts
@@ -897,11 +897,15 @@ export function useMapEditing({
     }, [drawRef, mapInstanceRef, notification, t]);
 
     const handleTrash = useCallback(() => {
-        // Deleting an area is destructive and (until saved) only reversible via
-        // undo — gate it behind a confirm so a mistap can't wipe a zone.
+        const draw = drawRef.current;
+        if (!draw) return;
+        // Draw's trash action depends on its mode: direct_select removes
+        // selected vertices; simple_select removes complete features.
+        const deletingPoints = draw.getMode() === 'direct_select';
+        if (!deletingPoints && draw.getSelectedIds().length === 0) return;
         modal.confirm({
-            title: t('mapEditing.deleteAreaConfirmTitle'),
-            content: t('mapEditing.deleteAreaConfirmBody'),
+            title: t(deletingPoints ? 'mapEditing.deletePointsConfirmTitle' : 'mapEditing.deleteAreaConfirmTitle'),
+            content: t(deletingPoints ? 'mapEditing.deletePointsConfirmBody' : 'mapEditing.deleteAreaConfirmBody'),
             okText: t('mapEditing.deleteAreaConfirmOk'),
             okType: 'danger',
             cancelText: t('mapEditing.deleteAreaConfirmCancel'),


### PR DESCRIPTION
## Summary

Deleting selected map vertices correctly removed points, but the confirmation claimed the entire area would be deleted. Choose point-specific confirmation text in Draw's direct-select mode, retaining the existing area warning for whole-feature selection. The point warning also explains that removing too many vertices can remove an invalid polygon.

A saved display bearing could appear in the rotation control while the map returned north-up: the bearing effect could run before the map loaded, and setting the map ref did not rerun it. Restore the bearing on map load as well as when the saved value arrives later.

## Changes

- Add English and French vertex-delete confirmation text, selected according to Draw's active mode (including a newly inserted midpoint whose public selection cache is not yet updated).
- Share camera synchronization between the full map and the compact dashboard map.
- Restore the bearing on load/replacement, remove old rotation listeners, and persist user gestures through the latest callback. Programmatic restoration does not trigger another save.
- Add 10 focused tests covering delete confirmations, load ordering, replacement/cleanup, and gesture versus programmatic rotation.

The existing GUI bearing setting and debounced persistence remain in use. This changes display rotation only; robot coordinates, map geometry, and mower motion are unaffected.

## Component

- [x] GUI (`gui/`)

## Testing

- [x] Built successfully: TypeScript check and Vite production build.
- [x] Unit tests pass: 383 tests across 50 files; final affected-test rerun 10/10 passed.
- ESLint repository target passed with zero errors; new camera and test files also checked with zero warnings.
- Translation key parity and `git diff --check` passed.
- Not deployed to a mower; no hardware or browser E2E run.

## Checklist

- [x] Follows conventional commit format
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes
- [x] Physical behavior unaffected

