### PR TITLE
fix(hardware): publish blade ESC current in amperes

### DIFF
--- a/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
+++ b/firmware/stm32/ros_usbnode/include/mowgli_protocol.h
@@ -595,7 +595,7 @@ typedef struct {
   uint8_t type;         /**< PKT_ID_BLADE_STATUS */
   uint8_t is_active;    /**< 1=running, 0=stopped */
   uint16_t rpm;         /**< Blade motor RPM */
-  uint16_t power_watts; /**< Power consumption [W] */
+  uint16_t power_watts; /**< ESC current [mA]; legacy field name, not watts */
   float temperature;    /**< Blade/motor temperature [C] */
   uint32_t error_count; /**< Cumulative error counter */
   uint16_t crc;         /**< CRC-16 CCITT over preceding bytes */

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/blade_telemetry.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/blade_telemetry.hpp
@@ -1,0 +1,22 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MOWGLI_HARDWARE__BLADE_TELEMETRY_HPP_
+#define MOWGLI_HARDWARE__BLADE_TELEMETRY_HPP_
+
+#include "mowgli_hardware/ll_datatypes.hpp"
+
+namespace mowgli_hardware
+{
+
+constexpr float blade_current_amps(const LlBladeStatus& packet)
+{
+  // The legacy wire name is misleading: Yardforce 500/500B firmware forwards
+  // ESC UART bytes 9-10 unchanged, in milliamps. Match the ROS1 conversion to
+  // amperes; this field is not electrical power and must not be divided by volts.
+  return static_cast<float>(packet.power_watts) / 1000.0f;
+}
+
+}  // namespace mowgli_hardware
+
+#endif  // MOWGLI_HARDWARE__BLADE_TELEMETRY_HPP_

--- a/ros2/src/mowgli_hardware/include/mowgli_hardware/ll_datatypes.hpp
+++ b/ros2/src/mowgli_hardware/include/mowgli_hardware/ll_datatypes.hpp
@@ -473,7 +473,7 @@ struct LlBladeStatus
   uint8_t type;  ///< Must equal PACKET_ID_LL_BLADE_STATUS
   uint8_t is_active;  ///< 1=running, 0=stopped
   uint16_t rpm;  ///< Blade motor RPM
-  uint16_t power_watts;  ///< Power consumption [W]
+  uint16_t power_watts;  ///< ESC current [mA]; legacy field name, not watts
   float temperature;  ///< Blade/motor temperature [C]
   uint32_t error_count;  ///< Cumulative error counter
   uint16_t crc;  ///< CRC-16 CCITT over all preceding bytes

--- a/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
+++ b/ros2/src/mowgli_hardware/src/hardware_bridge_node.cpp
@@ -62,6 +62,7 @@
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "mowgli_hardware/battery_state_semantics.hpp"
 #include "mowgli_hardware/blade_gate.hpp"
+#include "mowgli_hardware/blade_telemetry.hpp"
 #include "mowgli_hardware/clock_fit.hpp"
 #include "mowgli_hardware/cmd_vel_validation.hpp"
 #include "mowgli_hardware/dig_detector.hpp"
@@ -2609,7 +2610,7 @@ private:
     blade_rpm_ = static_cast<float>(pkt.rpm);
     blade_status_time_ = now();
     blade_temperature_ = pkt.temperature;
-    blade_esc_current_ = static_cast<float>(pkt.power_watts);
+    blade_esc_current_ = blade_current_amps(pkt);
   }
 
   // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_hardware/test/test_protocol.cpp
+++ b/ros2/src/mowgli_hardware/test/test_protocol.cpp
@@ -29,12 +29,39 @@
 #include <cstring>
 #include <vector>
 
+#include "mowgli_hardware/blade_telemetry.hpp"
 #include "mowgli_hardware/crc16.hpp"
 #include "mowgli_hardware/ll_datatypes.hpp"
 #include "mowgli_hardware/packet_handler.hpp"
 #include <gtest/gtest.h>
 
 using namespace mowgli_hardware;
+
+TEST(BladeTelemetry, LegacyWireCurrentIsConvertedToAmps)
+{
+  // A decoded 16-byte blade packet: active, 2444 RPM, 611 mA. The current
+  // remains a little-endian uint16 at offset 4 despite its legacy wire name.
+  const uint8_t payload[16] = {0x05, 0x01, 0x8c, 0x09, 0x63, 0x02};
+  LlBladeStatus packet{};
+  std::memcpy(&packet, payload, sizeof(packet));
+
+  EXPECT_EQ(packet.rpm, 2444u);
+  EXPECT_EQ(packet.power_watts, 611u);
+  EXPECT_FLOAT_EQ(blade_current_amps(packet), 0.611f);
+  EXPECT_EQ(std::memcmp(&packet, payload, sizeof(packet)), 0);
+}
+
+TEST(BladeTelemetry, CurrentRangePreservesSubAmpReadings)
+{
+  LlBladeStatus packet{};
+  EXPECT_FLOAT_EQ(blade_current_amps(packet), 0.0f);
+  packet.power_watts = 1;
+  EXPECT_FLOAT_EQ(blade_current_amps(packet), 0.001f);
+  packet.power_watts = 600;
+  EXPECT_FLOAT_EQ(blade_current_amps(packet), 0.6f);
+  packet.power_watts = 65535;
+  EXPECT_FLOAT_EQ(blade_current_amps(packet), 65.535f);
+}
 
 // ---------------------------------------------------------------------------
 // Size checks — ensure packed structs match expected wire sizes

--- a/wiki/Firmware.md
+++ b/wiki/Firmware.md
@@ -251,6 +251,12 @@ Current wire version: `MOWGLI_PROTOCOL_VERSION` **6**.
 | `0x06` | `pkt_reset_cause_t` | 5 | `reset_cause` (`RESET_CAUSE_*`), `last_stage_before_reset` (WWDG breadcrumb) |
 | `0x12` | `pkt_config_rsp_t` | 8 | `protocol_version`, `active_flags`, `fw_version_{major,minor,patch}` |
 
+The blade packet's legacy `power_watts` field contains **ESC current in milliamps**,
+not watts. Both Yardforce 500 and 500B forward ESC UART bytes 9–10 unchanged.
+The ROS2 hardware bridge divides this value by 1,000 for `Status.mower_esc_current`
+in amperes, matching the ROS1 bridge. The wire name and 16-byte layout are retained
+for compatibility; no firmware update or protocol version change is required.
+
 ### Host → Firmware
 
 | ID | Struct | Bytes | Contents |


### PR DESCRIPTION
## Summary

Blade current is published 1,000 times too high: a Yardforce ESC reading of 611 mA becomes `Status.mower_esc_current = 611` and the GUI displays 611 A. Convert milliamps to amperes at the ROS2 hardware bridge, giving 0.611 A. Physical behavior is unaffected.

## Changes

- Convert blade telemetry through a small tested helper before publishing ROS status, so GUI, diagnostics and MQTT receive amperes.
- Correct both protocol-header comments and the firmware wiki: `power_watts` is a misleading legacy name for raw ESC current in mA. Preserve the field, packet layout and protocol version.
- Add regression coverage for a literal 16-byte packet containing 611 mA, plus zero, 1 mA, 600 mA and the uint16 maximum.

### Unit evidence

Both Yardforce 500 and 500B use the [same ESC decoder](https://github.com/mowglinext/mowglinext/blob/3834fb810de777a0fd956a027fdd1901801ddcac/firmware/stm32/ros_usbnode/src/blademotor.c#L282), which reads UART bytes 9–10 into `BLADEMOTOR_u16Power`; the [firmware sender](https://github.com/mowglinext/mowglinext/blob/3834fb810de777a0fd956a027fdd1901801ddcac/firmware/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp#L1437) forwards that integer unchanged. Neither computes watts. The [ROS1 bridge explicitly divided the same value by 1,000](https://github.com/Nekraus/Mowgli/blob/50f31f603131e9da646ea412b719178ea6d667b5/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp#L598) for ESC current.

The same missing conversion is present on upstream dev/main and release tags v1.0.2 through v1.1.0. The simulator already publishes amperes directly and needs no change. This restores the existing firmware's interpretation; no reflash is needed.

## Component

- [x] ROS2 Stack (`ros2/`)
- [x] Firmware (`firmware/`) — comment only
- [x] Documentation (`wiki/`)

## Testing

- [x] Built `mowgli_hardware` against ROS Kilted as a non-root user.
- [x] Package tests: 247 reported checks, zero errors/failures; 44 cppcheck skips due to the installed cppcheck 2.13 performance exclusion. All 34 protocol tests pass, including both new tests.
- [x] clang-format 18 changed-line check against the merge-base with origin/main.
- [x] Protocol-version guard: v6 fingerprint unchanged, host and firmware agree.
- [x] `git diff --check`.
- [ ] Deployed fix on hardware — live pre-fix telemetry confirmed the 611 reading; this PR has not been deployed.

## Checklist

- [x] Targets `dev` and follows conventional commit format.
- [x] Documentation updated; no secrets or unrelated changes.
- [x] Physical behavior (blades, motion, e-stop and safety gates) unaffected.
- [x] C++ changed lines are clang-format 18 clean.
- Protocol headers have comment-only changes: no wire change or version bump.
- ROS interfaces and configuration schemas are unchanged.
