### PR TITLE
fix(gui): preserve NTRIP toggle state after saving

### DIFF
--- a/gui/pkg/api/gnss_runtime_config.go
+++ b/gui/pkg/api/gnss_runtime_config.go
@@ -218,6 +218,18 @@ func applyGNSSRuntimeFallback(flat map[string]any, explicitFlat map[string]any, 
 			return
 		}
 	}
+	if envKey == "GNSS_NTRIP_ENABLED" || envKey == "GNSS_NTRIP_GGA_ENABLED" {
+		// Environment values are strings, but settings switches require JSON
+		// booleans: the string "false" is truthy in JavaScript. Match the GPS
+		// startup script's normalize_bool, including its accepted spellings.
+		switch strings.ToLower(envValue) {
+		case "1", "true", "yes", "y", "on":
+			flat[targetKey] = true
+		default:
+			flat[targetKey] = false
+		}
+		return
+	}
 	flat[targetKey] = envValue
 }
 

--- a/gui/pkg/api/settings_test.go
+++ b/gui/pkg/api/settings_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mowglinext/mowglinext/pkg/types"
 	"github.com/gin-gonic/gin"
+	"github.com/mowglinext/mowglinext/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -878,6 +878,65 @@ func TestGetSettingsYAML_UsesEnvFallbackForFamilyDeviceAndBaudWhenYAMLIsMissing(
 	assert.Equal(t, "unicore", response["gnss_receiver_family"])
 	assert.Equal(t, "/dev/serial/by-id/usb-fallback", response["gnss_serial_device"])
 	assert.Equal(t, float64(460800), response["gnss_serial_baud"])
+}
+
+func TestGetSettingsYAML_NTRIPEnvFallbackIsBoolean(t *testing.T) {
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"false", false}, {"0", false}, {"off", false}, {"no", false},
+		{"true", true}, {"1", true}, {" ON ", true}, {"yes", true}, {"Y", true},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			yamlFile := createTempYAMLFile(t, "")
+			envFile := createTempConfigFile(t, "GNSS_NTRIP_ENABLED="+tc.value+"\nGNSS_NTRIP_GGA_ENABLED="+tc.value+"\n")
+			db := types.NewMockDBProvider()
+			db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+			db.Set("system.mower.runtimeEnvFile", []byte(envFile))
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/api/settings/yaml", nil)
+			setupSettingsRouter(db).ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			assert.Equal(t, tc.want, response["ntrip_enabled"])
+			assert.Equal(t, tc.want, response["gnss_ntrip_gga_enabled"])
+		})
+	}
+}
+
+func TestPostSettingsYAML_NTRIPDisableSurvivesReloadAfterDefaultPruning(t *testing.T) {
+	chdirToGuiRoot(t)
+	resetSchemaCache()
+	t.Cleanup(resetSchemaCache)
+	yamlFile := createTempYAMLFileAtGuiRoot(t, "mowgli:\n  ros__parameters:\n    ntrip_enabled: true\n")
+	envFile := createTempConfigFileAtGuiRoot(t, "GNSS_NTRIP_ENABLED=true\n")
+	db := types.NewMockDBProvider()
+	db.Set("system.mower.yamlConfigFile", []byte(yamlFile))
+	db.Set("system.mower.runtimeEnvFile", []byte(envFile))
+	router := setupSettingsRouter(db)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/settings/yaml", strings.NewReader(`{"ntrip_enabled":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	content, err := os.ReadFile(yamlFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "ntrip_enabled:")
+	env, err := os.ReadFile(envFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(env), "GNSS_NTRIP_ENABLED=false")
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/settings/yaml", nil)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, false, response["ntrip_enabled"])
 }
 
 func TestGetSettingsYAML_KeepsExplicitNTRIPDisableOverEnvFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

After disabling NTRIP and saving, the correction toggle can appear enabled again on reload even though the NTRIP client is stopped. Saving `ntrip_enabled: false` prunes the schema-default value from the sparse YAML and persists `GNSS_NTRIP_ENABLED=false` in the runtime environment. The settings API then returns that fallback as the string `"false"`, which the React switch treats as truthy.

Return JSON booleans for NTRIP and GGA environment fallbacks so the displayed state agrees with the saved configuration. Physical behavior is unaffected: this changes settings serialization, not receiver configuration or the correction client.

## Changes

- Convert `GNSS_NTRIP_ENABLED` and `GNSS_NTRIP_GGA_ENABLED` fallbacks to booleans using the same accepted spellings as `start_gps.sh`.
- Preserve explicit YAML precedence and existing numeric/string fallback handling.
- Add API tests for boolean spellings and a full save-off → default pruning → reload regression.

## Component

- [x] GUI (`gui/`)

## Testing

- [x] `go test ./pkg/api -count=1` passes in a non-root Go 1.24 container.
- [x] Changed files formatted with `gofmt`; `git diff --check` passes.
- [x] Pre-fix behavior confirmed on a running mower: the API returned `ntrip_enabled: "false"`, its GPS container had `GNSS_NTRIP_ENABLED=false`, and no `ntrip_node` was running.
- [ ] Fix deployed on hardware — not yet deployed.

## Checklist

- [x] Targets `dev`; conventional commit format.
- [x] No hardcoded secrets or unrelated changes.
- [x] Physical behavior (blades, motion, e-stop and safety gates) unaffected.
- No ROS interfaces, COBS wire format, configuration schema or documentation changes required.
