### PR TITLE
perf(gui): stop rosbag/status exec-ing into the ros2 container on an idle robot

### DIFF
--- a/gui/pkg/api/rosbag.go
+++ b/gui/pkg/api/rosbag.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mowglinext/mowglinext/pkg/types"
 	"github.com/gin-gonic/gin"
+	"github.com/mowglinext/mowglinext/pkg/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -146,7 +146,40 @@ func (m *rosbagManager) containerID(ctx context.Context) (string, error) {
 // is still alive, probed inside the ROS2 container. Any `.rosbag.pid` whose
 // process is gone is pruned so a crashed recorder does not read as "recording"
 // forever.
+// anyPidFilePresent reports whether at least one recording directory under
+// recordingsDir carries a pid file. The recordings root is the shared
+// mowgli_maps volume, mounted at the same path in both containers, so the
+// GUI can answer "could anything be recording?" with a local directory read
+// instead of a docker exec. The second return is false when the directory
+// cannot be read at all (volume not mounted, permissions), in which case the
+// caller must fall back to probing the ros2 container rather than reporting
+// "nothing is recording" on no evidence.
+func (m *rosbagManager) anyPidFilePresent() (bool, bool) {
+	entries, err := os.ReadDir(m.recordingsDir)
+	if err != nil {
+		return false, false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(m.recordingsDir, e.Name(), rosbagPidFile)); err == nil {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 func (m *rosbagManager) activeRecordingNames(ctx context.Context) ([]string, error) {
+	// The status endpoint is polled every 4 s by every open tab, and each call
+	// used to cost a docker exec session (~85 ms on the robot, measured
+	// 2026-09-06) just to run `kill -0` on pid files that, on an idle robot,
+	// do not exist. Only pay for the exec when a pid file is actually there;
+	// liveness and stale-pidfile cleanup still happen inside the ros2
+	// container, whose pid namespace owns the recorder.
+	if present, known := m.anyPidFilePresent(); known && !present {
+		return nil, nil
+	}
 	containerID, err := m.containerID(ctx)
 	if err != nil {
 		return nil, err

--- a/gui/pkg/api/rosbag_test.go
+++ b/gui/pkg/api/rosbag_test.go
@@ -13,9 +13,11 @@ import (
 	"strings"
 	"testing"
 
-	pkgtypes "github.com/mowglinext/mowglinext/pkg/types"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/gin-gonic/gin"
+	pkgtypes "github.com/mowglinext/mowglinext/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // rosbagFakeDocker is a minimal IDockerProvider whose ContainerExec is driven
@@ -119,6 +121,11 @@ func TestRosbagStatus_ReportsActiveFromProbe(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, "rosbag_live"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// A live recorder always has its pid file (buildRosbagStartCommand writes
+	// and verifies it); the status probe only execs when one exists.
+	if err := os.WriteFile(filepath.Join(dir, "rosbag_live", rosbagPidFile), []byte("4242\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/tools/rosbag/status", nil))
@@ -138,7 +145,15 @@ func TestRosbagStart_RejectsWhenAlreadyRecording(t *testing.T) {
 	docker.execFn = func(pkgtypes.ContainerExecSpec) (pkgtypes.ContainerExecResult, error) {
 		return pkgtypes.ContainerExecResult{ExitCode: 0, Stdout: "rosbag_busy\n"}, nil
 	}
-	r, _ := setupRosbagRouter(t, docker)
+	r, dir := setupRosbagRouter(t, docker)
+	if err := os.MkdirAll(filepath.Join(dir, "rosbag_busy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A live recorder always has its pid file (buildRosbagStartCommand writes
+	// and verifies it); the status probe only execs when one exists.
+	if err := os.WriteFile(filepath.Join(dir, "rosbag_busy", rosbagPidFile), []byte("4242\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/tools/rosbag/start", nil))
@@ -178,13 +193,14 @@ func TestRosbagStart_LaunchesRecordAndReturnsName(t *testing.T) {
 
 func TestRosbagStart_SurfacesRecorderFailure(t *testing.T) {
 	docker := rosbagWithContainer()
-	calls := 0
-	docker.execFn = func(pkgtypes.ContainerExecSpec) (pkgtypes.ContainerExecResult, error) {
-		calls++
-		if calls == 1 {
-			return pkgtypes.ContainerExecResult{ExitCode: 0, Stdout: ""}, nil
+	// Key the fake on what is being executed rather than on call order: the
+	// liveness probe is skipped entirely when no pid file exists, so the start
+	// command may well be the first exec this handler issues.
+	docker.execFn = func(spec pkgtypes.ContainerExecSpec) (pkgtypes.ContainerExecResult, error) {
+		if strings.Contains(strings.Join(spec.Cmd, " "), "ros2 bag record") {
+			return pkgtypes.ContainerExecResult{ExitCode: 1, Stdout: "recorder exited immediately\n"}, nil
 		}
-		return pkgtypes.ContainerExecResult{ExitCode: 1, Stdout: "recorder exited immediately\n"}, nil
+		return pkgtypes.ContainerExecResult{ExitCode: 0, Stdout: ""}, nil
 	}
 	r, _ := setupRosbagRouter(t, docker)
 
@@ -294,6 +310,13 @@ func TestRosbagDelete_RefusesActiveRecording(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// A live recording always carries its pid file: buildRosbagStartCommand
+	// writes `echo $! > .rosbag.pid` and refuses to report success without it.
+	// The status probe now only execs into the ros2 container when a pid file
+	// exists, so the fixture must reflect that invariant.
+	if err := os.WriteFile(filepath.Join(dir, name, rosbagPidFile), []byte("4242\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/tools/rosbag/"+name, nil))
@@ -321,4 +344,45 @@ func tarEntryNames(t *testing.T, body []byte) map[string]bool {
 		names[hdr.Name] = true
 	}
 	return names
+}
+
+// The status endpoint is polled every 4 s per tab. On an idle robot there is
+// no pid file anywhere under the recordings root, and the probe must not cost
+// a docker exec just to discover that.
+func TestRosbagStatus_SkipsExecWhenNoPidFileExists(t *testing.T) {
+	execCalls := 0
+	docker := &rosbagFakeDocker{
+		containers: []dockertypes.Container{{ID: "abc123", Names: []string{"/mowgli-ros2"}}},
+		execFn: func(spec pkgtypes.ContainerExecSpec) (pkgtypes.ContainerExecResult, error) {
+			execCalls++
+			return pkgtypes.ContainerExecResult{}, nil
+		},
+	}
+	r, dir := setupRosbagRouter(t, docker)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "finished_run", rosbagBagSubdir), 0o755))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/tools/rosbag/status", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, execCalls, "no pid file anywhere: the probe must not exec into the ros2 container")
+}
+
+// With a pid file present the recorder may still be alive, and only the ros2
+// container's pid namespace can say — the exec must still happen.
+func TestRosbagStatus_ExecsWhenAPidFileExists(t *testing.T) {
+	execCalls := 0
+	docker := &rosbagFakeDocker{
+		containers: []dockertypes.Container{{ID: "abc123", Names: []string{"/mowgli-ros2"}}},
+		execFn: func(spec pkgtypes.ContainerExecSpec) (pkgtypes.ContainerExecResult, error) {
+			execCalls++
+			return pkgtypes.ContainerExecResult{Stdout: "live_run\n"}, nil
+		},
+	}
+	r, dir := setupRosbagRouter(t, docker)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "live_run", rosbagBagSubdir), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "live_run", rosbagPidFile), []byte("4242\n"), 0o644))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/tools/rosbag/status", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, execCalls, "a pid file exists: liveness must still be probed in the ros2 container")
+	assert.Contains(t, w.Body.String(), `"active":true`)
 }


### PR DESCRIPTION
Part of the idle-CPU work for the Rpi4 release target.

## What was measured

On the docked robot (2026-09-06) the GUI backend averaged **48 % of a core** since start. Its GIN log showed `GET /api/tools/rosbag/status` every 4 s at **75–97 ms** each — because every call opened a docker exec session in `mowgli-ros2` to run `kill -0` on pid files that do not exist on an idle robot.

## Change

The recordings root (`/ros2_ws/maps/rosbags`) is the shared `mowgli_maps` volume, mounted identically in both containers (`install/compose/docker-compose.gui.yml`). The status probe now does a local `ReadDir` first and only execs when a `.rosbag.pid` is actually present. Liveness and stale-pidfile cleanup are unchanged and still run in the ros2 container. If the directory is unreadable (volume absent) it falls back to the exec — it never reports "nothing recording" on no evidence.

Net effect on an idle robot: **zero exec sessions**. While a recording is active: unchanged.

## Tests

Two new tests pin the gate (no pid file → 0 execs; pid file → 1 exec, active reported). Four existing fixtures simulated an active recorder **without** a pid file, which the real start command never produces — `buildRosbagStartCommand` writes `echo $! > .rosbag.pid` and fails without it — so they now carry one. `TestRosbagStart_SurfacesRecorderFailure` keyed its fake on exec call *order*; it now keys on the command content.

`go test ./pkg/...` green.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ