### PR TITLE
perf(gui): subscribe to /imu/data only while the Sensors panel is open

### DIFF
--- a/gui/web/src/hooks/useImu.ts
+++ b/gui/web/src/hooks/useImu.ts
@@ -1,4 +1,9 @@
 import {Imu} from "../types/ros.ts";
 import {useTopic} from "./useTopic.ts";
 
-export const useImu = (): Imu => useTopic<Imu>("imu", {}).data;
+/**
+ * Live IMU sample. Pass `enabled=false` while nothing on screen shows it:
+ * /imu/data runs at ~90 Hz and foxglove_bridge serialises every message for
+ * as long as the upstream subscription exists.
+ */
+export const useImu = (enabled = true): Imu => useTopic<Imu>("imu", {}, {enabled}).data;

--- a/gui/web/src/hooks/useTopic.test.ts
+++ b/gui/web/src/hooks/useTopic.test.ts
@@ -1,0 +1,58 @@
+import {act, renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const subscribe = vi.fn();
+const unsubscribe = vi.fn();
+vi.mock('./multiplexedSocket.ts', () => ({
+    getMultiplexedSocket: () => ({subscribe}),
+}));
+
+import {useTopic} from './useTopic';
+
+// The upstream foxglove subscription opens on the first subscriber for a topic
+// and closes on the last. A page that only shows a high-rate topic inside one
+// collapsed panel must be able to hold NO subscription while it is hidden —
+// /imu/data runs at ~90 Hz and foxglove_bridge serialises every message for as
+// long as anyone is subscribed, whatever the client-side throttle.
+describe('useTopic enabled flag', () => {
+    beforeEach(() => {
+        subscribe.mockReset();
+        unsubscribe.mockReset();
+        subscribe.mockImplementation(() => unsubscribe);
+    });
+
+    it('holds no subscription while disabled', () => {
+        renderHook(() => useTopic('imu', {}, {enabled: false}));
+        expect(subscribe).not.toHaveBeenCalled();
+    });
+
+    it('subscribes by default', () => {
+        renderHook(() => useTopic('imu', {}));
+        expect(subscribe).toHaveBeenCalledTimes(1);
+        expect(subscribe.mock.calls[0][0]).toBe('imu');
+    });
+
+    it('subscribes when enabled turns on, and releases plus resets when it turns off', () => {
+        let listener: ((raw: unknown) => void) | undefined;
+        subscribe.mockImplementation((_topic: string, cb: (raw: unknown) => void) => {
+            listener = cb;
+            return unsubscribe;
+        });
+        const initial = {};
+        const {result, rerender} = renderHook(
+            ({enabled}) => useTopic<Record<string, unknown>>('imu', initial, {enabled}),
+            {initialProps: {enabled: false}},
+        );
+        expect(subscribe).not.toHaveBeenCalled();
+
+        rerender({enabled: true});
+        expect(subscribe).toHaveBeenCalledTimes(1);
+        act(() => listener?.({angular_velocity: {z: 0.5}}));
+        expect(result.current.data).toEqual({angular_velocity: {z: 0.5}});
+
+        rerender({enabled: false});
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        // A hidden panel must not keep showing the last live sample as current.
+        expect(result.current.data).toBe(initial);
+    });
+});

--- a/gui/web/src/hooks/useTopic.ts
+++ b/gui/web/src/hooks/useTopic.ts
@@ -16,6 +16,16 @@ export interface UseTopicOptions<T> {
      * message, so closures over refs are safe.
      */
     select?: (raw: unknown) => T | undefined;
+    /**
+     * When false, hold no subscription at all. The upstream foxglove
+     * subscription is opened on the first subscriber for a topic and closed
+     * on the last, so a page that only needs a topic while one panel is
+     * visible should gate it here rather than subscribe unconditionally —
+     * foxglove_bridge serialises high-rate topics (e.g. /imu/data at 90 Hz)
+     * at full rate for as long as anyone is subscribed, whatever the
+     * client-side throttle. Defaults to true.
+     */
+    enabled?: boolean;
 }
 
 export interface TopicState<T> {
@@ -43,7 +53,14 @@ export const useTopic = <T>(
     const optsRef = useRef(opts);
     optsRef.current = opts;
 
+    const enabled = opts?.enabled !== false;
     useEffect(() => {
+        if (!enabled) {
+            // Drop back to the initial value so a hidden panel does not keep
+            // showing the last live sample as if it were current.
+            setState({data: initial, lastMessageAt: null});
+            return;
+        }
         let lastEmitAt = 0;
         let pendingTimer: number | null = null;
         let latest: { data: T; at: number } | null = null;
@@ -87,7 +104,8 @@ export const useTopic = <T>(
             if (pendingTimer !== null) window.clearTimeout(pendingTimer);
             unsubscribe();
         };
-    }, [topic]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `initial` is a literal at every call site
+    }, [topic, enabled]);
 
     return state;
 };

--- a/gui/web/src/pages/DiagnosticsPage.tsx
+++ b/gui/web/src/pages/DiagnosticsPage.tsx
@@ -44,7 +44,6 @@ import {useGPS} from "../hooks/useGPS.ts";
 import {useGnssStatus} from "../hooks/useGnssStatus.ts";
 import {useFusionOdom} from "../hooks/useFusionOdom.ts";
 import {useBTLog, isBTNodeStale} from "../hooks/useBTLog.ts";
-import {useImu} from "../hooks/useImu.ts";
 import {useCogHeading} from "../hooks/useCogHeading.ts";
 import {useMagYaw} from "../hooks/useMagYaw.ts";
 import {useCalibrationStatus} from "../hooks/useCalibrationStatus.ts";
@@ -71,6 +70,7 @@ import {useFusionGraphDiagnostics} from "../hooks/useFusionGraphDiagnostics.ts";
 import {useRosbag, RosbagRecording} from "../hooks/useRosbag.ts";
 import {useFirmwareDebugLogs} from "../hooks/useFirmwareDebugLogs.ts";
 import {useMowerAction} from "../components/MowerActions.tsx";
+import {useImu} from "../hooks/useImu.ts";
 import {useImuYawCalibration} from "../hooks/useImuYawCalibration.ts";
 import {AsyncButton} from "../components/AsyncButton.tsx";
 import {TelemetryStat} from "../components/TelemetryStat.tsx";
@@ -166,7 +166,6 @@ export const DiagnosticsPage = () => {
     const gnssStatus = useGnssStatus();
     const pose = useFusionOdom();
     const btNodeStates = useBTLog();
-    const imu = useImu();
     const {imu: cogImu, lastMessageAt: cogLastAt} = useCogHeading();
     const {imu: magImu, lastMessageAt: magLastAt} = useMagYaw();
     const wheelOdom = useWheelOdom();
@@ -183,6 +182,11 @@ export const DiagnosticsPage = () => {
     const {modal} = App.useApp();
     const {snapshot, loading, error: snapshotError, refresh} = useDiagnosticsSnapshot();
     const {diagnostics} = useDiagnostics();
+    // Panels are collapsed by default; track which are open so high-rate
+    // sensor subscriptions exist only while their panel is on screen.
+    const [openPanels, setOpenPanels] = useState<string[]>([]);
+    const sensorsPanelOpen = openPanels.includes("sensors");
+    const imu = useImu(sensorsPanelOpen);
     const {settings} = useSettings();
     const guiApi = useApi();
     const wheelRpm = useWheelRpm({wheelRadiusM: settings?.wheel_radius ?? 0.04475});
@@ -388,6 +392,19 @@ export const DiagnosticsPage = () => {
     const scansReceivedRaw = fusionStats?.values?.["scans_received"];
     const scansReceivedSince = useValueSince(scansReceivedRaw);
     const lidarStreaming = scansReceivedSince !== null && (nowMs - scansReceivedSince) < 15_000;
+    // IMU liveness comes from diagnostics_node's 1 Hz "IMU" status, not from a
+    // live /imu/data subscription. This page only ever needed a boolean, yet
+    // useImu() held a 90 Hz upstream foxglove subscription open for as long as
+    // the page was, and that stream is serialised by foxglove_bridge at full
+    // rate regardless of client-side decimation. Measured on the docked robot
+    // 2026-09-06 it was a visible slice of GUI + bridge CPU. The diagnostics
+    // status is also more honest: useTopic kept the last IMU message forever,
+    // so imuOk stayed true after the IMU died until a page reload.
+    const imuStatus = diagnostics?.status?.find((s) => s.name === "IMU");
+    const imuAlive =
+        imuStatus != null &&
+        imuStatus.level < 2 && // OK or WARN; ERROR (2) / STALE (3) mean no fresh data
+        (nowMs - imuStatus.receivedAt) < 15_000;
     const anatomyInputs = {
         batteryPct: batteryPercent,
         vBattery: power.v_battery ?? 0,
@@ -396,7 +413,7 @@ export const DiagnosticsPage = () => {
         gpsLabel: anatomyGps.label,
         gpsOk: anatomyGps.percent >= 50,
         imuYawDeg: yaw,
-        imuOk: imu != null && imu.angular_velocity != null,
+        imuOk: imuAlive,
         lidarOk: lidarEnabled === false ? false : (lidarStreaming ? true : undefined),
         // Mowgli is rear-axle drive: only the rear wheels are encoded (the
         // fronts are unencoded casters whose RPM is always 0).
@@ -1881,7 +1898,8 @@ export const DiagnosticsPage = () => {
                 {healthBar}
                 {sectionAlerts}
                 <Collapse
-                    defaultActiveKey={[]}
+                    activeKey={openPanels}
+                    onChange={(keys) => setOpenPanels(Array.isArray(keys) ? keys.map(String) : [String(keys)])}
                     size="small"
                     items={[
                         {


### PR DESCRIPTION
Part of the idle-CPU work for the Rpi4 release target.

## What was measured

Docked robot, 2026-09-06: `foxglove_bridge` at 10–16 % and the GUI backend at 20–50 % of a core, with the browser on the Diagnostics page. `ros2 topic info -v` showed `foxglove_bridge` subscribed to `/imu/data`, measured at **90.4 Hz**. The GUI's CPU was spread evenly across six Go threads — a continuous decode stream, not a hot handler.

The Diagnostics page called `useImu()` unconditionally. Every panel on that page is collapsed by default (`defaultActiveKey={[]}`), and the IMU card that displays those values lives inside the `sensors` panel — so the subscription was held for a card nobody was looking at.

## Why the fix has to be "not subscribed"

The provider already opens the upstream foxglove subscription on the first subscriber and closes it on the last (`ensureFoxgloveSubscribed` / `maybeUnsubscribeFoxglove`), with an 80 ms client-side decimation. But foxglove has no server-side throttle: `foxglove_bridge` serialises every message at full rate for as long as anyone is subscribed. Decimation saves decode, not the bridge. The only lever is the subscription itself.

## Change

- `useTopic` gains `enabled?: boolean`. When false it holds no subscription and resets to the initial value, so a hidden panel never shows a stale sample as current.
- `useImu(enabled = true)` forwards it.
- `DiagnosticsPage` makes the Collapse controlled, tracks open panels, and passes `openPanels.includes("sensors")` to `useImu`.
- `imuOk` now derives from `diagnostics_node`'s 1 Hz `"IMU"` status (level < ERROR, received within 15 s). Strictly better: `useTopic` kept the last message forever, so the old `imuOk` stayed true after the IMU died until a reload.

The same `enabled` flag is now available to any page that only needs a high-rate topic while one panel is visible.

## Verified

- `tsc --noEmit`: 0 errors. `eslint` on the four files: 0 errors.
- New `useTopic.test.ts`: no subscription while disabled; subscribes by default; subscribes on enable, and on disable releases and resets. **3/3.**
- Full web suite: **51 files, 386 tests, all passing.**

Before/after CPU on the robot to follow once the image is built.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ