### PR TITLE
perf(lidar): slow the ldlidar node's bond heartbeat to 0.5 s

### DIFF
--- a/sensors/lidar-ldlidar/ldlidar_scan.launch.py
+++ b/sensors/lidar-ldlidar/ldlidar_scan.launch.py
@@ -31,7 +31,13 @@ def generate_launch_description() -> LaunchDescription:
         plugin="ldlidar::LdLidarComponent",
         name="ldlidar_node",
         namespace="",
-        parameters=[params_file],
+        # bond_heartbeat_period: the driver's side of its lifecycle bond. Left at
+        # bondcpp's 0.1 s default it publishes 10 Hz on the shared /bond topic —
+        # which EVERY bonded node in the system receives and deserialises. The
+        # Nav2 group already sets 0.5 s on its managed nodes; this matches it.
+        # (The manager's own side is hardcoded to 0.10 s in nav2's
+        # lifecycle_manager.cpp and cannot be configured.)
+        parameters=[params_file, {"bond_heartbeat_period": 0.5}],
         remappings=[
             ("~/scan", "/scan"),
         ],


### PR DESCRIPTION
Part of the idle-CPU work for the Rpi4 release target — the small, in-repo half of the bond finding.

## What was measured

`/bond` on the docked robot, 2026-09-06: **126.5 msg/s over 10 bonds**. Each Nav2 bond runs at ~12 Hz = 10 Hz from the manager + 2 Hz from the node. The ldlidar bond runs at **19.8 Hz** — 10 + 10 — because `ldlidar_scan.launch.py` never set `bond_heartbeat_period` on the node, while the Nav2 launch group sets 0.5 s on all of its managed nodes.

`/bond` is a single shared topic. Every bonded node subscribes to it and deserialises every heartbeat in the system to find its own — so each of the ~12 Nav2 nodes pays for all 126 msg/s. That is a plausible slice of the 4–7 % each shows at rest.

## Change

One line: the ldlidar component gets `bond_heartbeat_period: 0.5`, matching the Nav2 nodes. Halves the LiDAR's share.

## What this does not fix, and why

The manager's side is **hardcoded** in nav2 kilted — `lifecycle_manager.cpp:239`, `setHeartbeatPeriod(0.10)`; only `bond_timeout` and `bond_respawn_max_duration` are parameters. That is the remaining ~100 msg/s. Options are an upstream nav2 PR to expose it, or `bond_timeout: 0` locally, which disables bonds entirely and with them crash-respawn of managed nodes. Neither is a one-liner I should decide alone; raised separately.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ