### PR TITLE
perf(fusion_graph): run the scan-between ICP once per new scan, not per tick

### DIFF
--- a/ros2/src/fusion_graph/CMakeLists.txt
+++ b/ros2/src/fusion_graph/CMakeLists.txt
@@ -217,6 +217,11 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_slip_window fusion_graph_core)
 
+  ament_add_gtest(test_scan_match_dedup
+    test/test_scan_match_dedup.cpp
+  )
+  target_link_libraries(test_scan_match_dedup fusion_graph_core)
+
   ament_add_gtest(test_loop_closure_gate
     test/test_loop_closure_gate.cpp
   )

--- a/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/fusion_graph_node.hpp
@@ -38,6 +38,7 @@
 #include "fusion_graph/dr_slip_veto.hpp"
 #include "fusion_graph/graph_manager.hpp"
 #include "fusion_graph/pose_extrapolator.hpp"
+#include "fusion_graph/scan_match_dedup.hpp"
 #include "fusion_graph/scan_matcher.hpp"
 #include <Eigen/Core>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -386,6 +387,12 @@ private:
   bool latest_scan_valid_ = false;
   std::vector<Eigen::Vector2d> prev_node_scan_;  // scan stored at last node
   bool prev_node_scan_valid_ = false;
+  // Identity of the scan-between ICP inputs, so OnTimer (25 Hz) does not
+  // realign the same (scan, prev-node scan) pair it already matched — the
+  // LiDAR runs at ~10 Hz. See scan_match_dedup.hpp.
+  uint64_t latest_scan_seq_ = 0;  // bumped in OnScan, under scan_mu_
+  uint64_t prev_node_scan_gen_ = 0;  // bumped when Tick stores prev_node_scan_
+  ScanMatchDedupGate scan_match_dedup_;
 
   // Frame names.
   std::string map_frame_ = "map";
@@ -568,6 +575,7 @@ private:
   uint64_t scans_received_ = 0;
   uint64_t scan_matches_ok_ = 0;
   uint64_t scan_matches_fail_ = 0;
+  uint64_t scan_matches_skipped_ = 0;  // ticks where the ICP inputs were unchanged
 
   // ICP-only odometry integration (see pub_icp_odom_). Seeded from the graph
   // pose at the first node with a scan-between, then advanced ONCE PER NODE by

--- a/ros2/src/fusion_graph/include/fusion_graph/scan_match_dedup.hpp
+++ b/ros2/src/fusion_graph/include/fusion_graph/scan_match_dedup.hpp
@@ -1,0 +1,62 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Gate that stops OnTimer re-running the scan-between ICP on input it has
+// already matched. Pure — no ROS / GTSAM — so it is unit-testable, same shape
+// as slip_window.hpp / loop_closure_gate.hpp.
+//
+// OnTimer runs at node_period_s (0.04 s → 25 Hz) and, every tick, copied
+// latest_scan_ and matched it against prev_node_scan_. The LiDAR publishes at
+// ~10 Hz. Measured on the docked robot 2026-09-06 over 10 s: 89 scans
+// received, 225 scan matches run — ~2.5 ICPs per scan, ~60 % of them on a
+// (scan, prev-node scan) pair that had not changed since the previous tick.
+// fusion_graph's main thread sat at 14 % of a core while stationary.
+//
+// The two inputs of that ICP are identified by counters: the scan sequence
+// (bumped in OnScan) and the prev-node generation (bumped when Tick stores a
+// new prev_node_scan_). If neither moved since the last match, the ICP would
+// realign the same two point clouds — the same physical measurement.
+//
+// Conservative on purpose: a SUCCESSFUL match on a pair is not repeated; a
+// FAILED one may be retried on the next tick. The init guess drifts with
+// odometry between ticks, and a match that fell to a guard rail on one tick
+// could clear it on the next, so retrying preserves that chance while
+// removing only the redundant successful recomputation.
+
+#pragma once
+
+#include <cstdint>
+
+namespace fusion_graph
+{
+
+class ScanMatchDedupGate
+{
+public:
+  // True when the ICP should run for this (scan, prev-node) pair.
+  bool ShouldMatch(uint64_t scan_seq, uint64_t prev_node_gen) const
+  {
+    if (!have_last_)
+      return true;
+    if (scan_seq != last_scan_seq_ || prev_node_gen != last_prev_node_gen_)
+      return true;
+    return !last_ok_;
+  }
+
+  // Record the outcome of a match that did run on this pair.
+  void RecordOutcome(uint64_t scan_seq, uint64_t prev_node_gen, bool ok)
+  {
+    have_last_ = true;
+    last_scan_seq_ = scan_seq;
+    last_prev_node_gen_ = prev_node_gen;
+    last_ok_ = ok;
+  }
+
+private:
+  bool have_last_ = false;
+  uint64_t last_scan_seq_ = 0;
+  uint64_t last_prev_node_gen_ = 0;
+  bool last_ok_ = false;
+};
+
+}  // namespace fusion_graph

--- a/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_b.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_callbacks_b.cpp
@@ -219,6 +219,7 @@ void FusionGraphNode::OnScan(sensor_msgs::msg::LaserScan::ConstSharedPtr msg)
   std::lock_guard<std::mutex> lock(scan_mu_);
   latest_scan_ = std::move(pts);
   latest_scan_valid_ = !latest_scan_.empty();
+  ++latest_scan_seq_;
   ++scans_received_;
 
   // Cold-boot relocalization: if we autoloaded a graph but never had

--- a/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_setup_comms.cpp
@@ -373,6 +373,7 @@ void FusionGraphNode::SetupCommunications(double node_period_s)
                           }
                           add("scans_received", std::to_string(scans_received_));
                           add("scan_matches_ok", std::to_string(scan_matches_ok_));
+                          add("scan_matches_skipped", std::to_string(scan_matches_skipped_));
                           add("scan_matches_fail", std::to_string(scan_matches_fail_));
                           // RTK-anchored keyframe map (use_keyframe_map): map
                           // size + scan-to-keyframe absolute-match health.

--- a/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
+++ b/ros2/src/fusion_graph/src/fusion_graph_node_timer.cpp
@@ -64,16 +64,27 @@ void FusionGraphNode::OnTimer()
   // when it creates a new node.
   std::vector<Eigen::Vector2d> curr_scan;
   bool curr_valid = false;
+  uint64_t curr_scan_seq = 0;
   {
     std::lock_guard<std::mutex> lock(scan_mu_);
     if (latest_scan_valid_)
     {
       curr_scan = latest_scan_;
       curr_valid = true;
+      curr_scan_seq = latest_scan_seq_;
     }
   }
 
-  if (use_scan_matching_ && scan_matcher_ && curr_valid && prev_node_scan_valid_)
+  // Skip the ICP when neither of its inputs moved since the last SUCCESSFUL
+  // match: this timer runs at 25 Hz against a ~10 Hz LiDAR, so most ticks
+  // would realign the same two point clouds. A failed match is retried.
+  const bool scan_match_ready =
+      use_scan_matching_ && scan_matcher_ && curr_valid && prev_node_scan_valid_;
+  if (scan_match_ready && !scan_match_dedup_.ShouldMatch(curr_scan_seq, prev_node_scan_gen_))
+  {
+    ++scan_matches_skipped_;
+  }
+  else if (scan_match_ready)
   {
     // ICP init guess: wheel translation + gyro rotation accumulated
     // since the previous node. PeekAccumulator returns the current
@@ -170,6 +181,7 @@ void FusionGraphNode::OnTimer()
     {
       ++scan_matches_fail_;
     }
+    scan_match_dedup_.RecordOutcome(curr_scan_seq, prev_node_scan_gen_, !drop);
   }
 
   // ── Scan-to-keyframe ABSOLUTE constraint (the RTK-Float carry) ───────
@@ -443,6 +455,7 @@ void FusionGraphNode::OnTimer()
     {
       prev_node_scan_ = std::move(curr_scan);
       prev_node_scan_valid_ = true;
+      ++prev_node_scan_gen_;  // the next ICP targets a different scan
     }
   }
 

--- a/ros2/src/fusion_graph/test/test_scan_match_dedup.cpp
+++ b/ros2/src/fusion_graph/test/test_scan_match_dedup.cpp
@@ -1,0 +1,74 @@
+// Copyright 2026 Mowgli Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fusion_graph/scan_match_dedup.hpp"
+#include <gtest/gtest.h>
+
+using fusion_graph::ScanMatchDedupGate;
+
+TEST(ScanMatchDedup, FirstCallAlwaysMatches)
+{
+  ScanMatchDedupGate g;
+  EXPECT_TRUE(g.ShouldMatch(0, 0));
+  EXPECT_TRUE(g.ShouldMatch(7, 3));
+}
+
+// The measured case: 25 Hz timer, ~10 Hz scans. Between two scans the pair
+// (scan, prev-node) is unchanged and the previous match succeeded — do not
+// realign the same two point clouds again.
+TEST(ScanMatchDedup, SkipsRepeatOfASuccessfulMatchOnUnchangedInputs)
+{
+  ScanMatchDedupGate g;
+  ASSERT_TRUE(g.ShouldMatch(1, 0));
+  g.RecordOutcome(1, 0, true);
+  EXPECT_FALSE(g.ShouldMatch(1, 0));
+  EXPECT_FALSE(g.ShouldMatch(1, 0));
+}
+
+// Conservative: a failed match may be retried on the next tick, because the
+// odometry-driven init guess drifts and a guard rail that tripped once may
+// clear.
+TEST(ScanMatchDedup, RetriesAfterAFailedMatch)
+{
+  ScanMatchDedupGate g;
+  ASSERT_TRUE(g.ShouldMatch(1, 0));
+  g.RecordOutcome(1, 0, false);
+  EXPECT_TRUE(g.ShouldMatch(1, 0));
+}
+
+TEST(ScanMatchDedup, MatchesAgainWhenANewScanArrives)
+{
+  ScanMatchDedupGate g;
+  g.RecordOutcome(1, 0, true);
+  EXPECT_FALSE(g.ShouldMatch(1, 0));
+  EXPECT_TRUE(g.ShouldMatch(2, 0));
+}
+
+// A new graph node stores a new prev_node_scan_: the same scan must now be
+// aligned against a DIFFERENT target, so it is a new measurement.
+TEST(ScanMatchDedup, MatchesAgainWhenThePrevNodeScanChanges)
+{
+  ScanMatchDedupGate g;
+  g.RecordOutcome(5, 2, true);
+  EXPECT_FALSE(g.ShouldMatch(5, 2));
+  EXPECT_TRUE(g.ShouldMatch(5, 3));
+}
+
+// Regression shape for the field measurement: 25 ticks, 10 distinct scans,
+// no new node, every match succeeds → exactly 10 ICPs, not 25.
+TEST(ScanMatchDedup, OneIcpPerDistinctScanWhenStationary)
+{
+  ScanMatchDedupGate g;
+  int icps = 0;
+  for (int tick = 0; tick < 25; ++tick)
+  {
+    const uint64_t scan_seq =
+        static_cast<uint64_t>(tick * 10 / 25);  // 10 Hz scans under a 25 Hz timer
+    if (g.ShouldMatch(scan_seq, 0))
+    {
+      ++icps;
+      g.RecordOutcome(scan_seq, 0, true);
+    }
+  }
+  EXPECT_EQ(icps, 10);
+}


### PR DESCRIPTION
Part of the idle-CPU work for the Rpi4 release target — the ROS2 side.

## What was measured

Docked robot, 2026-09-06, `/fusion_graph/diagnostics` deltas over 10 s while stationary:

| counter | Δ over 10 s |
|---|---|
| `scans_received` | **+89** (LiDAR at 9.9 Hz) |
| `scan_matches_ok` | **+225** |
| `total_nodes` | +2 |
| `kf_matches_ok` / `kf_matches_fail` | 0 / 16 |

**~2.5 ICPs per scan.** `OnTimer` runs at `node_period_s` = 0.04 s (25 Hz) and, every tick, copied `latest_scan_` and ran `scan_matcher_->Match(curr_scan, prev_node_scan_, …)` (`fusion_graph_node_timer.cpp:69-96`) with no check that either input had changed. With a ~10 Hz LiDAR, roughly 60 % of ticks realigned the same two point clouds. `fusion_graph`'s main thread sat at **14 % of a core** doing nothing useful, and that is a per-core cost that scales badly to an Rpi4.

## Change

Both ICP inputs get an identity: `latest_scan_seq_` (bumped in `OnScan`, under `scan_mu_`) and `prev_node_scan_gen_` (bumped where `Tick` stores a new `prev_node_scan_`). A pure `ScanMatchDedupGate` (`scan_match_dedup.hpp`, no ROS/GTSAM, same shape as `slip_window.hpp`) skips the match when neither moved since the last **successful** match on that pair.

**Deliberately conservative.** The odometry-driven `init_guess` drifts between ticks, and a match that fell to a guard rail (inliers / RMSE / sanity / divergence) on one tick could clear it on the next. So a *failed* match is still retried; only the redundant *successful* recomputation is removed. The keyframe-map ICP block is left untouched.

The queued between-factor is unchanged — it is the same physical measurement, consumed once per node exactly as before (`last_scan_between_delta_` latest-wins, as the existing comment describes). No parameter changes.

`scan_matches_skipped` is added to `/fusion_graph/diagnostics` so the effect is observable in the field and a regression is visible.

## Tests

Six unit tests on the gate, compiled and run locally against gtest: first call matches; a successful match on unchanged inputs is skipped; a failed one is retried; a new scan or a new prev-node re-arms it; and the measured shape — 25 ticks over 10 distinct scans, no new node → **exactly 10 ICPs**, not 25.

Full package build + the existing fusion_graph suite runs on CI (GTSAM is not available locally).

## Expected on the robot

`scan_matches_ok` should drop to ≈ `scans_received` while stationary (≈10/s instead of ≈22/s), `scan_matches_skipped` should climb at ≈15/s, and the main-thread CPU of `fusion_graph_node` should fall accordingly. Will measure after deploy.

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ