### PR TITLE
fix(gnss): a repeated observation sequence under a newer stamp is a cached publication, not invalid provenance

### DIFF
--- a/ros2/src/fusion_graph/test/test_gnss_observation_freshness.cpp
+++ b/ros2/src/fusion_graph/test/test_gnss_observation_freshness.cpp
@@ -125,3 +125,32 @@ TEST(GnssObservationFreshness, LaterReceiptWithResetSequenceStartsNewSourceEpoch
 }
 
 }  // namespace
+
+// The receiver stamps its status with the publication time and carries the
+// observation count as the sequence: a status published twice between two
+// receiver observations repeats the sequence under a NEWER stamp. That is a
+// cached publication — it must neither refresh the deadline nor invalidate
+// authority (field 2026-09-08: it paused mowing every few minutes).
+TEST(GnssObservationFreshness, RepeatedSequenceUnderNewerStampIsCachedNotInvalid)
+{
+  gnss::PhysicalObservationTracker tracker;
+  ASSERT_TRUE(IsAcceptedEvidence(tracker.Observe(41, 10 * kSecond, 10 * kSecond, 10 * kSecond)));
+  EXPECT_TRUE(tracker.ObservationIsFresh(10 * kSecond, 10 * kSecond, 5 * kSecond));
+
+  // Same sequence, stamp 200 ms newer: cached, authority intact.
+  EXPECT_EQ(tracker.Observe(
+                41, 10 * kSecond + 200000000, 10 * kSecond + 200000000, 10 * kSecond + 200000000),
+            gnss::ObservationUpdate::kCachedPublication);
+  EXPECT_TRUE(
+      tracker.ObservationIsFresh(10 * kSecond + 200000000, 10 * kSecond + 200000000, 5 * kSecond));
+
+  // ... but it did not refresh the deadline: with no new sequence the feed
+  // still goes stale at maximum_age after the last ACCEPTED observation.
+  EXPECT_EQ(tracker.Observe(41, 16 * kSecond, 16 * kSecond, 16 * kSecond),
+            gnss::ObservationUpdate::kCachedPublication);
+  EXPECT_FALSE(tracker.ObservationIsFresh(16 * kSecond, 16 * kSecond, 5 * kSecond));
+
+  // A genuinely new observation restores authority.
+  EXPECT_TRUE(IsAcceptedEvidence(tracker.Observe(42, 16 * kSecond, 16 * kSecond, 16 * kSecond)));
+  EXPECT_TRUE(tracker.ObservationIsFresh(16 * kSecond, 16 * kSecond, 5 * kSecond));
+}

--- a/ros2/src/mowgli_interfaces/include/mowgli_interfaces/gnss_observation_freshness.hpp
+++ b/ros2/src/mowgli_interfaces/include/mowgli_interfaces/gnss_observation_freshness.hpp
@@ -84,8 +84,17 @@ public:
     {
       if (sequence == last_sequence_)
       {
-        return receipt_time_ns == *last_receipt_time_ns_ ? ObservationUpdate::kCachedPublication
-                                                         : ObservationUpdate::kInvalidProvenance;
+        // Same observation again, whatever the stamp says. The universal_gnss
+        // receiver stamps its status with the publication time and carries
+        // the observation COUNT as the sequence, so a status published twice
+        // between two receiver observations repeats the sequence under a
+        // newer stamp several times an hour. That is a cached publication,
+        // not evidence of anything: it neither refreshes the deadline nor
+        // invalidates authority. A frozen receiver still fails closed when
+        // the deadline (maximum_age) runs out with no new sequence. Field
+        // 2026-09-08: classifying it as invalid provenance paused the mow
+        // for 2 s every few minutes and exhausted the five dispatch attempts.
+        return ObservationUpdate::kCachedPublication;
       }
 
       if (sequence > last_sequence_)


### PR DESCRIPTION
## What
`gnss_observation_freshness.hpp`: a repeated `position_observation_sequence` under a newer header stamp is a **cached publication**, not invalid provenance. It neither refreshes the deadline nor invalidates GNSS authority; a frozen receiver still fails closed at `maximum_age` with no new sequence.

## Why
Field 2026-09-08: `LocalizationGuard` paused mowing for 2 s every few minutes ("GNSS feed stale" + "GNSS receipt stamp is zero/future; authority denied" from both `behavior_tree_node` and `hardware_bridge` — 1260 times in 30 h, 205 pauses in one hour while docked). Each pause interrupts `FollowStrip` and consumes one of the five dispatch attempts; the mow gave up after three minutes with the robot on the lawn.

Caught live: at 09:25:48 `/gps/status` repeated sequence 1827777 under a newer stamp, and at that millisecond both consumers denied authority. The universal_gnss receiver stamps its status with the publication time and uses the observation **count** as the sequence, so a status published twice between two observations legitimately repeats the sequence.

## Test plan
- [x] `test_gnss_observation_freshness` 6/6 locally (new `RepeatedSequenceUnderNewerStampIsCachedNotInvalid`)
- [ ] CI ROS2 build & test
- [ ] Robot: no more "zero/future" warnings / "GNSS feed stale" pauses on the dock over an hour

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
