### PR TITLE
fix(gui): restore IMU readings in Diagnostics Robot tab

### DIFF
--- a/gui/web/src/pages/DiagnosticsPage.tsx
+++ b/gui/web/src/pages/DiagnosticsPage.tsx
@@ -182,10 +182,11 @@ export const DiagnosticsPage = () => {
     const {modal} = App.useApp();
     const {snapshot, loading, error: snapshotError, refresh} = useDiagnosticsSnapshot();
     const {diagnostics} = useDiagnostics();
-    // Panels are collapsed by default; track which are open so high-rate
-    // sensor subscriptions exist only while their panel is on screen.
+    // Mobile uses collapsible panels; desktop shows sensors in the Robot tab.
+    // Subscribe to the high-rate IMU stream only in the visible sensor view.
     const [openPanels, setOpenPanels] = useState<string[]>([]);
-    const sensorsPanelOpen = openPanels.includes("sensors");
+    const [activeTab, setActiveTab] = useState("system");
+    const sensorsPanelOpen = isMobile ? openPanels.includes("sensors") : activeTab === "robot";
     const imu = useImu(sensorsPanelOpen);
     const {settings} = useSettings();
     const guiApi = useApi();
@@ -2003,7 +2004,7 @@ export const DiagnosticsPage = () => {
             {healthHero}
             {healthBar}
             {sectionAlerts}
-            <Tabs defaultActiveKey="system" items={tabItems} size="large"/>
+            <Tabs activeKey={activeTab} onChange={setActiveTab} items={tabItems} size="large"/>
         </Space>
     );
 };


### PR DESCRIPTION
Opening Diagnostics → Robot on desktop never enabled the IMU subscription because it depended only on the mobile Sensors accordion. Track the active desktop tab and enable the stream while Robot is visible; mobile still subscribes only while Sensors is open.

Validation: TypeScript check passed; useTopic subscription tests passed (3 tests); ESLint passed with 0 errors (37 existing warnings); git diff --check passed.