### PR TITLE
feat: make automatic dig keepouts optional in GUI

### DIFF
--- a/docs/claude/codemaps/mowgli_map.md
+++ b/docs/claude/codemaps/mowgli_map.md
@@ -126,7 +126,7 @@ Defaults: `ros2/src/mowgli_map/config/map_server.yaml` (`map_params`, `full_syst
 |-----------|---------|-------------|-------|
 | `resolution`, `map_size_x`, `map_size_y`, `map_frame` | 0.05, 20, 20, `map` | L55-58 | size overridden by `resize_map_to_areas` (+5 m margin) |
 | `tool_width` | 0.18 | L59 | mow-progress disc radius = `tool_width/2` (see CLAUDE.md Invariant 6) |
-| `dig_obstacle_enabled`, `dig_obstacle_size` | true, 0.60 | L70-71 | subscription only created when enabled; size floored at 0.05 |
+| `dig_obstacle_enabled`, `dig_obstacle_size` | true, 0.60 | L70-71 | subscription only created when enabled; `dig_obstacle_enabled` is injected from the robot template/GUI Settings → Obstacles by `full_system.launch.py` (restart required); size floored at 0.05 |
 | `areas_file_path` | `""` (yaml: `/ros2_ws/maps/areas.dat`) | L78 | empty = no persistence at all |
 | `datum_lat`, `datum_lon` | 0/0 | L83-84 | 0/0 disables stamp + migration |
 | `robot_yaml_path` | `/ros2_ws/config/mowgli_robot.yaml` | L85 | dock-pose splice target; tests redirect |

--- a/docs/claude/parameters.md
+++ b/docs/claude/parameters.md
@@ -35,6 +35,16 @@ Operator-facing rule of thumb: **the GUI only ever writes `mowgli_robot.yaml`.**
 
 All 158 template keys. `L###` = line in `ros2/src/mowgli_bringup/config/mowgli_robot.yaml`. **GUI** = present in `mower_config.schema.json` (section name), or `no` — a `no` key still shows up in Settings → *Advanced* once it exists in the installed file (`gui/web/src/hooks/useSettingsManager.ts:679` `advancedKeys`). **Life** = `launch` (injected at launch, restart to apply), `dynamic` (also honoured live via `ros2 param set`), `INERT` (never injected — node compiled default wins), `sidecar` (consumed outside ROS2).
 
+### Dig obstacle proposals
+
+| Key | Default | Consumer · where read | GUI | Life |
+|---|---|---|---|---|
+| `dig_obstacle_enabled` | true | `full_system.launch.py` → `map_server_node` subscription gate | Obstacles | launch |
+
+Disabling automatic dig keepouts prevents new session-only map proposals. Hardware dig
+stopping, bounded reverse and repeat-dig escalation remain active. Enabled proposals
+still require operator acceptance to persist. Save and restart ROS2 to apply.
+
 ### Chassis, wheels, encoder — feed the URDF and the Nav2 footprint
 
 | Key (L) | Default | Consumer · where read | GUI | Life |

--- a/gui/asserts/mower_config.schema.json
+++ b/gui/asserts/mower_config.schema.json
@@ -638,6 +638,12 @@
           "default": 1,
           "description": "Maximum lateral detour (m) around obstacles — drives both the coverage controller's skirting and the bypass give-up threshold."
         },
+        "dig_obstacle_enabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "Automatically create dig keepouts",
+          "description": "Create temporary keepout proposals for detected wheel-slip digs. Disabling this leaves dig detection and recovery active. Restart ROS2 to apply."
+        },
         "obstacle_margin": {
           "type": "number",
           "title": "Drawn Obstacle Margin",

--- a/gui/web/src/components/settings/ObstaclesSection.test.tsx
+++ b/gui/web/src/components/settings/ObstaclesSection.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ObstaclesSection } from "./ObstaclesSection.tsx";
+
+describe("dig obstacle setting", () => {
+    it.each([true, false, "false"])("renders %s and changes the map setting only", (value) => {
+        const onChange = vi.fn();
+        render(<ObstaclesSection values={{ dig_obstacle_enabled: value }} onChange={onChange} />);
+        const toggle = screen.getByRole("switch", { name: "Automatically create dig keepouts" });
+        const enabled = value === true;
+        expect(toggle).toHaveAttribute("aria-checked", String(enabled));
+        fireEvent.click(toggle);
+        expect(onChange).toHaveBeenCalledExactlyOnceWith("dig_obstacle_enabled", !enabled);
+        expect(screen.getByText(/dig detection, stopping and recovery remain active/)).toBeInTheDocument();
+    });
+});

--- a/gui/web/src/components/settings/ObstaclesSection.tsx
+++ b/gui/web/src/components/settings/ObstaclesSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Alert, Card, Col, Form, InputNumber, Row, Typography } from "antd";
+import { Alert, Card, Col, Form, InputNumber, Row, Switch, Typography } from "antd";
 import { useTranslation } from "react-i18next";
+import { parseBoolish } from "../../utils/settingsValues.ts";
 import { SettingFieldLabel } from "./SettingFieldLabel.tsx";
 
 const { Paragraph } = Typography;
@@ -14,7 +15,7 @@ type Props = {
 };
 
 /**
- * Obstacles section — operator-tunable obstacle-avoidance margins:
+ * Obstacles section — automatic dig keepouts and obstacle-avoidance margins:
  *   - obstacle_inflation_radius: local-costmap buffer around LiDAR-seen
  *     obstacles (trunks, legs, walls),
  *   - max_obstacle_avoidance_distance: max lateral detour for coverage
@@ -23,7 +24,7 @@ type Props = {
  *     coverage and transit planning (root zones the 2D LiDAR cannot see),
  *   - obstacle_slowdown_ratio: collision_monitor approach slowdown factor.
  * All keys live in mowgli_robot.yaml (sparse over template) and are injected
- * into Nav2/coverage params at launch — changes need a ROS2 restart.
+ * into map server/Nav2/coverage params at launch — changes need a ROS2 restart.
  */
 export const ObstaclesSection: React.FC<Props> = ({
     values,
@@ -52,6 +53,21 @@ export const ObstaclesSection: React.FC<Props> = ({
                 description={t("settingsObstacles.rootZoneHintDescription")}
                 style={{ marginBottom: 16 }}
             />
+
+            <Card size="small" title={t("settingsObstacles.digKeepouts")} style={{ marginBottom: 16 }}>
+                <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 12 }}>
+                    {t("settingsObstacles.digKeepoutsDescription")}
+                </Paragraph>
+                <Form layout="vertical" size="small">
+                    <Form.Item label={fieldLabel("dig_obstacle_enabled", t("settingsObstacles.digAutoPromotion"))}>
+                        <Switch
+                            aria-label={t("settingsObstacles.digAutoPromotion")}
+                            checked={parseBoolish(values.dig_obstacle_enabled) ?? false}
+                            onChange={(enabled) => onChange("dig_obstacle_enabled", enabled)}
+                        />
+                    </Form.Item>
+                </Form>
+            </Card>
 
             {/* Avoidance margins */}
             <Card size="small" title={t("settingsObstacles.avoidanceMargins")} style={{ marginBottom: 16 }}>

--- a/gui/web/src/hooks/useSettingsManager.ts
+++ b/gui/web/src/hooks/useSettingsManager.ts
@@ -197,7 +197,7 @@ const SECTION_DEFINITIONS: SectionMeta[] = [
             "obstacle_inflation_radius", "max_obstacle_avoidance_distance",
             "obstacle_clearance_margin", "obstacle_detection_range_m",
             "obstacle_wait_timeout_s",
-            "obstacle_margin", "obstacle_slowdown_ratio",
+            "obstacle_margin", "obstacle_slowdown_ratio", "dig_obstacle_enabled",
         ],
     },
     {

--- a/gui/web/src/i18n/locales/en.json
+++ b/gui/web/src/i18n/locales/en.json
@@ -2371,6 +2371,9 @@
     "temperatureThresholdsNote": "Blade-motor temperature is measured and reported only — no layer of the stack stops the blade on temperature. The warning and error thresholds used by the diagnostics (motor_temp_warn_c and motor_temp_error_c, in mowgli_monitoring/config/diagnostics.yaml) can be edited on the Parameters page."
   },
   "settingsObstacles": {
+    "digKeepouts": "Dig obstacles",
+    "digAutoPromotion": "Automatically create dig keepouts",
+    "digKeepoutsDescription": "Create a temporary keepout when wheel slip is detected in a mowing area. Accept the proposal on the map to keep it permanently. When disabled, no dig keepouts are created; dig detection, stopping and recovery remain active. Save and restart ROS2 to apply.",
     "rootZoneHintTitle": "Trees with large roots?",
     "rootZoneHintDescription": "The 2D LiDAR cannot see roots below its scan plane (~10–20 cm). Draw the tree as an obstacle in the map editor and raise the drawn obstacle margin so mowing and transit keep off the root zone.",
     "avoidanceMargins": "Avoidance Margins",

--- a/gui/web/src/i18n/locales/fr.json
+++ b/gui/web/src/i18n/locales/fr.json
@@ -2367,6 +2367,9 @@
     "temperatureThresholdsNote": "La température du moteur de lame est uniquement mesurée et rapportée — aucune couche de la pile n’arrête la lame en fonction de la température. Les seuils d’alerte et d’erreur utilisés par les diagnostics (motor_temp_warn_c et motor_temp_error_c, dans mowgli_monitoring/config/diagnostics.yaml) se modifient sur la page Paramètres."
   },
   "settingsObstacles": {
+    "digKeepouts": "Obstacles de patinage",
+    "digAutoPromotion": "Créer automatiquement des zones d’exclusion de patinage",
+    "digKeepoutsDescription": "Crée une zone d’exclusion temporaire lorsqu’un patinage est détecté dans une zone de tonte. Acceptez la proposition sur la carte pour la conserver. Si désactivé, aucune zone d’exclusion de patinage n’est créée ; la détection, l’arrêt et la récupération restent actifs. Enregistrez et redémarrez ROS2 pour appliquer.",
     "rootZoneHintTitle": "Arbres avec de grosses racines ?",
     "rootZoneHintDescription": "Le LiDAR 2D ne voit pas les racines sous son plan de scan (~10–20 cm). Dessinez l'arbre comme obstacle dans l'éditeur de carte et augmentez la marge des obstacles dessinés pour que la tonte et les transits restent hors de la zone de racines.",
     "avoidanceMargins": "Marges d'évitement",

--- a/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
+++ b/ros2/src/mowgli_bringup/config/mowgli_robot.yaml
@@ -669,6 +669,10 @@ mowgli:
     # -----------------------------------------------------------------
     # Obstacles (GUI: Settings → Obstacles)
     # -----------------------------------------------------------------
+    # Automatically create session-only PENDING keepouts from dig events.
+    # False disables map proposals, not hardware dig detection or recovery.
+    # Permanent persistence still requires operator acceptance. Restart ROS2.
+    dig_obstacle_enabled: true
     # How far the robot may deviate laterally from its path to skirt an
     # obstacle. ONE knob, TWO consumers (injected at launch):
     #   - FTCController max_lateral_deviation (coverage-time skirting)

--- a/ros2/src/mowgli_bringup/launch/full_system.launch.py
+++ b/ros2/src/mowgli_bringup/launch/full_system.launch.py
@@ -398,6 +398,10 @@ def generate_launch_description() -> LaunchDescription:
                     float(robot_params.get("chassis_width", 0.40)) / 2.0))},
             {"max_obstacle_avoidance_distance":
                 float(robot_params.get("max_obstacle_avoidance_distance", 2.0))},
+            # GUI toggle for session-only dig proposals; detection/recovery
+            # remain owned by hardware_bridge regardless of this map setting.
+            {"dig_obstacle_enabled": bool(
+                robot_params.get("dig_obstacle_enabled", True))},
             # Extra LETHAL margin grown around drawn obstacle polygons in the
             # keepout mask — mirrors coverage_server.obstacle_margin (injected
             # by navigation.launch.py) so the transit planner and the swath

--- a/ros2/src/mowgli_bringup/test/test_robot_config_util.py
+++ b/ros2/src/mowgli_bringup/test/test_robot_config_util.py
@@ -640,3 +640,36 @@ def test_circumscribed_radius_encloses_every_footprint_corner():
     for x in (front, rear):
         for y in (half_width, -half_width):
             assert math.hypot(x, y) <= radius + 1e-9
+
+
+@pytest.mark.parametrize("override", [None, False, True])
+def test_dig_keepout_toggle_reaches_map_server(override):
+    """The GUI's sparse boolean must override map_server.yaml's enabled default."""
+    import ast
+
+    path = _write_sparse({} if override is None else {"dig_obstacle_enabled": override})
+    try:
+        merged = load_robot_params(str(_PKG_DIR), runtime_path=path)
+    finally:
+        os.unlink(path)
+    expected = True if override is None else override
+    assert merged["dig_obstacle_enabled"] is expected
+
+    tree = ast.parse(_MAP_SERVER_LAUNCH.read_text())
+    map_server = next(
+        node.value for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "map_server_node"
+                for target in node.targets)
+    )
+    parameters = next(kw.value for kw in map_server.keywords if kw.arg == "parameters")
+    injected = {}
+    for parameter in parameters.elts:
+        if isinstance(parameter, ast.Dict):
+            for key, value in zip(parameter.keys, parameter.values):
+                if isinstance(key, ast.Constant) and key.value == "dig_obstacle_enabled":
+                    injected[key.value] = eval(
+                        compile(ast.Expression(value), "<launch parameter>", "eval"),
+                        {"robot_params": merged, "bool": bool},
+                    )
+    assert injected["dig_obstacle_enabled"] is expected

--- a/ros2/src/mowgli_map/config/map_server.yaml
+++ b/ros2/src/mowgli_map/config/map_server.yaml
@@ -31,6 +31,8 @@ map_server_node:
     # A dig outside every mowing area (transit / docking) is logged but NOT
     # stamped — there is no area to attach it to, and coverage never plans
     # there anyway.
+    # Overridden from mowgli_robot.yaml by full_system.launch.py; exposed in
+    # GUI Settings → Obstacles. False leaves dig detection/recovery active.
     dig_obstacle_enabled: true
     # Side of the square keepout stamped at the dig [m]. One chassis LENGTH
     # (the Nav2 footprint is 0.60 × 0.40 m). It used to be one tool width


### PR DESCRIPTION
## Summary

Settings → Obstacles now lets operators enable or disable automatic dig keepout creation. The existing `dig_obstacle_enabled` map-server switch is wired through the robot config and GUI, defaults to enabled, and takes effect after saving and restarting ROS2.

Safety-critical: disabling this setting removes automatic session-only dig keepouts. Hardware dig detection, stopping, bounded reverse and repeat-dig escalation remain active. Permanent obstacle persistence still requires operator acceptance.

## Changes

- Add an English/French toggle with default/reset support.
- Forward the sparse robot-config value into the map server at launch.
- Document the setting and cover both boolean values plus the default in regression tests.

## Component

- [x] ROS2 Stack (`ros2/`)
- [x] GUI (`gui/`)
- [x] Documentation (`docs/`, `wiki/`)

## Testing

- [x] Unit tests pass: 389 GUI tests; 46 robot-config tests; Go schema/template parity test.
- [x] TypeScript check, ESLint (0 errors), config drift check and git diff whitespace check pass.
- [ ] ROS2 build/integration tests: colcon/ROS2 unavailable locally.
- [ ] Tested on hardware
- [ ] Tested in simulation

## Checklist

- [x] Follows conventional commit format
- [x] Documentation updated
- [x] No hardcoded secrets or credentials
- [x] No unrelated changes
- [x] Physical behavior flagged as safety-critical above
- [x] Robot-config drift check passes; installed file remains sparse

No C++, interfaces, firmware or wire-protocol files changed.
