### PR TITLE
fix(behavior): a pass interrupted by a pausing guard does not burn the mow's dispatch attempts

### DIFF
--- a/docs/claude/codemaps/mowgli_behavior.md
+++ b/docs/claude/codemaps/mowgli_behavior.md
@@ -48,14 +48,14 @@
 | `trees/navigate_to_pose.xml` | 79 | Nav2 `bt_navigator` tree: ControllerSelector/GoalCheckerSelector/PlannerSelector + replan only if path invalid, RoundRobin recovery |
 | **`include/mowgli_behavior/`** | | |
 | `action_nodes.hpp` | 33 | Umbrella header; declares `registerAllNodes()` |
-| `bt_context.hpp` | 646 | `BTContext` shared via blackboard key `"context"`; `clearSingleAreaMode()` |
+| `bt_context.hpp` | ~680 | `BTContext` shared via blackboard key `"context"`; `clearSingleAreaMode()`; dispatch budgets `kMaxAreaAttempts=5`, `kMaxStartBlockedAttempts=3`, `kMaxGuardHaltedPasses=200` |
 | `condition_nodes.hpp` | 830 | 25 `BT::ConditionNode` classes + ports |
 | `coverage_nodes.hpp` | 600 | `FollowStrip`, `TransitToStrip`, `DetourAroundObstacle`, `GetNextUnmowedArea`, `PlanCoverageArea`; pure helpers `resolveResumeLocation`, `refreshSwathProgress`, `coveragePercentFromCursor`, `forwardSkipIndex`; `kMowAngleAutoDeg=-1` |
 | `navigation_nodes.hpp` | 389 | `StopMoving`, `ClearCostmap`, `SetNav2Lifecycle`, `NavigateToPose`, `BackUp`, `SetNavMode`, `NavigateInsideBoundary` (phase enum) |
 | `docking_nodes.hpp` | 147 | `DockRobot`, `UndockRobot`, `RecordResumeUndockFailure` |
 | `escape_nodes.hpp` | 147 | `EscapeStartBlocked` (`kBladeStateMaxAgeSec=2`, `kMaxTickDtSec=0.5`, `kSignalHoldoffSec=1`) |
 | `recording_nodes.hpp` | 203 | `RecordArea` (`kMinSampleSpacingM=0.05`, `kDefaultRecordRateHz=10`, preview 2 Hz) |
-| `status_nodes.hpp` | 161 | `PublishHighLevelStatus` (IDLE debounce 3 ticks), `WasRainingAtStart`, `ClearCommand`, `EndSession`, `IncrementSkippedSwaths` |
+| `status_nodes.hpp` | ~195 | `PublishHighLevelStatus` (IDLE debounce 3 ticks), `WasRainingAtStart`, `ClearCommand`, `MarkGuardHalt`(reason — sets `guard_halted_reason`), `EndSession`, `IncrementSkippedSwaths` |
 | `utility_nodes.hpp` | 192 | `SetMowerEnabled`, `WaitForDuration`, `WaitForGpsFix`, `SaveObstacles`, `ResetEmergency` |
 | `calibration_nodes.hpp` | 152 | `RecordUndockStart`, `CalibrateHeadingFromUndock`, `SeedYawFromMotion` |
 | `localization_health.hpp` | 328 | Header-only `LocalizationHealthMonitor` (GNSS accuracy / fix-lost / stale latches + σ_xy divergence backstop) |
@@ -86,7 +86,7 @@
 | `test_obstacle_recovery.cpp` | 305 | 13 tests: `IsObstacleStuck` timing/cap/cooldown against latched collision state |
 | `test_docking_boundary_exempt.cpp` | 232 | 8 tests: `IsDocking` + BoundaryGuard blade-off dock-transit exemption |
 | `test_set_nav2_lifecycle.cpp` | 243 | 7 tests: `SetNav2Lifecycle` gating + fake `manage_nodes` transition |
-| `test_get_next_unmowed_area.cpp` | 459 | 11 tests: nav-only areas skipped, targeted (`~/start_in_area`) runs stay clipped, `EndSession` boundary |
+| `test_get_next_unmowed_area.cpp` | ~640 | 17 tests: nav-only areas skipped, START_OCCUPIED + guard-halted (`MarkGuardHalt`) passes exempt from the no-progress budget, targeted (`~/start_in_area`) runs stay clipped, `EndSession` boundary |
 | `test_start_occupied_retry.cpp` | 348 | 13 tests: `classifyTransitFailure`, consume-once `IsCoverageStartBlocked`, structural check of `StartPoseBlockedRetry` in `main_tree.xml` |
 | `test_coverage_persistence.cpp` | 248 | 10 tests: round-trip, header/version, malformed rows, `current_command` restore |
 | `test_gnss_status_authority.cpp` | 56 | 2 tests: `mowgli_interfaces::gnss_status_utils` fix-type mapping the BT relies on |
@@ -97,7 +97,7 @@
 | `test_start_blocked_escape.cpp` | 382 | 20 tests: escape direction, stand-downs, bounds, ceilings (safety-critical) |
 | `test_localization_health.cpp` | 419 | 16 tests: pivot σ inflation must NOT pause; plain-GPS fallback must; stale feed |
 | `test_battery_critical_resume.cpp` | 225 | 3 tests: critical-battery tail auto-continues, only dead charger ends session |
-| `test_guard_fallthrough.cpp` | 327 | 5 tests: guard handlers return FAILURE + structural `<AlwaysFailure/>` check on every blocking guard in `main_tree.xml` |
+| `test_guard_fallthrough.cpp` | ~360 | 6 tests: guard handlers return FAILURE + structural `<AlwaysFailure/>` check on every blocking guard in `main_tree.xml` + `<MarkGuardHalt/>` is the first handler child in `SensorSafetyGuard` / `LocalizationGuard` |
 | `test_high_level_status_snapshot.cpp` | 156 | 6 tests: republished status carries live battery/progress, tree-owned state untouched |
 | `test_battery_filter.cpp` | 243 | 13 tests: sag immunity, rate independence, invalid reading never → 0 % |
 | `test_dock_alignment.cpp` | 191 | 11 tests: along/cross decomposition, yaw-drift band |
@@ -165,7 +165,7 @@ Clients (node → file:line):
 | Utility — `utility_nodes.{hpp,cpp}` | `SetMowerEnabled`(enabled), `WaitForDuration`(duration_sec), `WaitForGpsFix`(timeout_sec, min_fix_type), `SaveObstacles`, `ResetEmergency` |
 | Navigation — `navigation_nodes.{hpp,cpp}` | `StopMoving`(duration_sec), `ClearCostmap`, `SetNav2Lifecycle`(command PAUSE/RESUME), `NavigateToPose`†(goal "x;y;yaw"), `BackUp`(backup_dist, backup_speed), `SetNavMode`(mode precise/degraded), `NavigateInsideBoundary` |
 | Escape — `escape_nodes.{hpp,cpp}` | `EscapeStartBlocked` |
-| Status — `status_nodes.{hpp,cpp}` | `PublishHighLevelStatus`(state, state_name), `WasRainingAtStart`, `ClearCommand`, `EndSession`, `IncrementSkippedSwaths`† |
+| Status — `status_nodes.{hpp,cpp}` | `PublishHighLevelStatus`(state, state_name), `WasRainingAtStart`, `ClearCommand`, `MarkGuardHalt`(reason), `EndSession`, `IncrementSkippedSwaths`† |
 | Calibration — `calibration_nodes.{hpp,cpp}` | `RecordUndockStart`, `CalibrateHeadingFromUndock`(min_displacement_m), `SeedYawFromMotion`(distance_m, speed_ms, timeout_sec, min_displacement_m) |
 | Docking — `docking_nodes.{hpp,cpp}` | `DockRobot`(dock_id, dock_type), `UndockRobot`†(dock_type), `RecordResumeUndockFailure` |
 | Coverage — `coverage_nodes.{hpp,cpp}` | `GetNextUnmowedArea`(max_areas → out `area_index`), `FollowStrip`(max_detours_per_segment, detour_footprint_radius_m), `TransitToStrip`, `DetourAroundObstacle`†(forward_m, lateral_m), `PlanCoverageArea`(area_index) |
@@ -208,7 +208,7 @@ Publishes none. `ctx->tf_buffer` (`behavior_tree_node.cpp` :82) is used to look 
 
 ## Change coupling — "if you change X, also update Y"
 - New/renamed BT node → `src/register_nodes.cpp` AND `trees/main_tree.xml`; add a gtest target in `CMakeLists.txt` (link only the `.cpp` files the test needs — see existing targets).
-- New blocking guard in `main_tree.xml` → must end with `<AlwaysFailure/>`; `test/test_guard_fallthrough.cpp` structurally asserts this. Touching `StartPoseBlockedRetry` → `test/test_start_occupied_retry.cpp`.
+- New blocking guard in `main_tree.xml` → must end with `<AlwaysFailure/>`; `test/test_guard_fallthrough.cpp` structurally asserts this. A guard whose halt PAUSES a mow (rather than ending the session) must also tick `<MarkGuardHalt reason="…"/>` as the FIRST child of its handler (the `ReactiveFallback` halts the handler the moment the fault clears, so a marker behind `StopMoving`/`WaitForDuration` misses short pauses), or its pauses exhaust the five `GetNextUnmowedArea` dispatch attempts and the mow "completes" at 0 swaths (`SensorSafetyGuard` / `LocalizationGuard` do; `test_guard_fallthrough` pins both, position included). Touching `StartPoseBlockedRetry` → `test/test_start_occupied_retry.cpp`.
 - New `state_name` in `main_tree.xml` → GUI maps `gui/web/src/components/dashboard/constants.ts` (`MOWER_STATES`), `gui/web/src/components/utils.tsx`, `gui/web/src/components/BTStateGraph.tsx` (+ `BTStateGraph.test.tsx`), and `wiki/Behavior-Trees.md`.
 - New `HighLevelControl` command → `ros2/src/mowgli_interfaces/srv/HighLevelControl.srv`, the handler in `behavior_tree_node.cpp` :547, an `IsCommand` branch in `main_tree.xml`, the guard whitelists (`SensorSafetyGuard` :86-89, `BoundaryGuard` :155-182, `LocalizationGuard` :262-270), GUI bindings (see `docs/claude/commands.md` codegen), and `docs/claude/high-level-api.md`.
 - New `HighLevelStatus` field → `status_snapshot.cpp` (`withLiveStatusFields`) or it will be frozen by the 1 Hz republish; `test/test_high_level_status_snapshot.cpp`; firmware `HL_MODE_*` mirror if `state` values change (see `docs/claude/high-level-api.md`).
@@ -235,7 +235,7 @@ Publishes none. `ctx->tf_buffer` (`behavior_tree_node.cpp` :82) is used to look 
 - `SaveObstacles` targets `/obstacle_tracker/save_obstacles`, which nothing in the repo serves — it always logs "service unavailable, skipping" and returns SUCCESS (`utility_nodes.cpp` :219-224).
 - Undock is `BackUp` via `/backup`, not `UndockRobot` (Invariant 10); `undock_distance` must exceed `CalibrateHeadingFromUndock` `min_displacement_m` (`main_tree.xml` :534 passes 0.5; the C++ port default is 0.20) or the yaw refinement is skipped — and if the charger is STILL on at that point the node returns FAILURE and the whole undock sequence retries (`calibration_nodes.cpp` :124-152).
 - `PreFlightCheck` requires only `min_gps_fix_type=2` on the dock; RTK-Fixed is enforced after undock by `WaitForGpsFix(min_fix_type=4)` (`main_tree.xml` :489-528). Do not raise the dock gate (chicken-and-egg under the canopy).
-- `GetNextUnmowedArea` skips `is_navigation_area` areas (`coverage_nodes.cpp` :1693-1698) and retires an area after `kMaxAreaAttempts=5` no-progress dispatches (+`kMaxStartBlockedAttempts=3` exempted START_OCCUPIED passes) — `bt_context.hpp` :141-202.
+- `GetNextUnmowedArea` skips `is_navigation_area` areas (`coverage_nodes.cpp` :1693-1698) and retires an area after `kMaxAreaAttempts=5` no-progress dispatches (+`kMaxStartBlockedAttempts=3` exempted START_OCCUPIED passes, +`kMaxGuardHaltedPasses=200` exempted guard-interrupted passes flagged by `MarkGuardHalt`) — `bt_context.hpp` :141-235. A guard that halts the Root mid-pass WITHOUT `MarkGuardHalt` charges every pause to that budget: field 2026-09-07/08, a flaky LiDAR link tripped `IsScanStale` 3× in 25 s and the area retired with 0 swaths.
 - `BoundaryGuard`/`LocalizationGuard` whitelist commands 7/3/5/6/2 and the blade-off dock transit (`IsCommand 1` + `IsDocking`); dropping 5/6 from the whitelist silently loses every finished recording (`main_tree.xml` :146-154).
 - `GUI` state maps: `WAITING_FOR_RTK` is emitted but present in none of `constants.ts` / `utils.tsx` / `BTStateGraph.tsx`; `SKIP_STRIP` is listed there but never emitted.
 

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/bt_context.hpp
@@ -202,6 +202,38 @@ struct BTContext
   static constexpr uint32_t kMaxStartBlockedAttempts = 3;
 
   // -----------------------------------------------------------------------
+  // Guard-halted passes (field 2026-09-07 / 2026-09-08)
+  // -----------------------------------------------------------------------
+  /// Set by MarkGuardHalt from a Root guard handler (SensorFaultHandler,
+  /// LocalizationDegradedHandler) while that guard is halting the tree.
+  /// Halting the Root interrupts FollowStrip ("area N interrupted at pose K —
+  /// resume cursor saved"), and the next GetNextUnmowedArea dispatch of that
+  /// area used to charge the re-dispatch to the no-progress budget exactly as
+  /// if the pass had aborted at an obstacle. With an intermittent LiDAR serial
+  /// link IsScanStale halted the Root every few seconds: three scan-stale
+  /// halts in 25 s burnt the five kMaxAreaAttempts, the mow "completed" with
+  /// ZERO swaths and the robot sat on the lawn. LocalizationGuard pauses did
+  /// the same. A transient sensor / localization fault must PAUSE a mow,
+  /// never fail it — the pass never had a chance to make progress.
+  ///
+  /// Carries the guard's reason string ("scan_stale", "localization_degraded")
+  /// for the log line. Consumed (reset) by the next GetNextUnmowedArea
+  /// dispatch: it describes ONE finished pass. Cleared by EndSession.
+  std::optional<std::string> guard_halted_reason;
+  /// Per-area count of dispatches that were EXEMPTED from the no-progress
+  /// retirement counter because the previous pass was interrupted by a guard.
+  /// Cleared by EndSession.
+  std::map<uint32_t, uint32_t> area_guard_halt_count;
+  /// Maximum guard-halted dispatches exempted from area_attempt_count per
+  /// area. Deliberately GENEROUS: a permanently dead sensor is not this cap's
+  /// problem — the guard itself holds the whole tree (blade off, stopped) for
+  /// as long as the fault lasts, so nothing dispatches at all. The cap only
+  /// bounds the FLAPPING case (a fault that clears and re-trips every few
+  /// seconds) so a pathological flap cannot re-dispatch the same area forever;
+  /// past it the normal no-progress budget takes over and the area retires.
+  static constexpr uint32_t kMaxGuardHaltedPasses = 200;
+
+  // -----------------------------------------------------------------------
   // Start-pose escape motion (issue #487, follow-up to the above)
   // -----------------------------------------------------------------------
   //

--- a/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
+++ b/ros2/src/mowgli_behavior/include/mowgli_behavior/status_nodes.hpp
@@ -116,6 +116,40 @@ public:
 };
 
 // ---------------------------------------------------------------------------
+// MarkGuardHalt
+// ---------------------------------------------------------------------------
+
+/// Records in BTContext that a Root guard is halting the tree (sets
+/// ctx->guard_halted_reason), so the next GetNextUnmowedArea dispatch of the
+/// interrupted area is NOT charged to the no-progress retirement budget. Place
+/// it as the FIRST child of the handler Sequence of every guard whose pause
+/// interrupts a mowing pass (SensorFaultHandler, LocalizationDegradedHandler):
+/// the enclosing ReactiveFallback halts the handler the moment the fault
+/// clears, so a marker behind StopMoving / WaitForDuration misses every short
+/// pause. A guard that halts the Root without it lets a flapping sensor exhaust
+/// the five dispatch attempts and fail the mow at 0 swaths (field 2026-09-07 /
+/// 2026-09-08). Idempotent: the handler re-runs every tick while the fault
+/// holds. Always returns SUCCESS.
+///
+/// Input ports:
+///   reason (string) – short tag naming the guard, for the dispatch log line.
+class MarkGuardHalt : public BT::SyncActionNode
+{
+public:
+  MarkGuardHalt(const std::string& name, const BT::NodeConfig& config)
+      : BT::SyncActionNode(name, config)
+  {
+  }
+
+  static BT::PortsList providedPorts()
+  {
+    return {BT::InputPort<std::string>("reason", "Guard tag, e.g. scan_stale")};
+  }
+
+  BT::NodeStatus tick() override;
+};
+
+// ---------------------------------------------------------------------------
 // EndSession
 // ---------------------------------------------------------------------------
 

--- a/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
+++ b/ros2/src/mowgli_behavior/src/behavior_tree_node.cpp
@@ -1084,6 +1084,8 @@ private:
       context_->coverage_start_blocked = false;
       context_->start_blocked_area.reset();
       context_->area_start_blocked_count.clear();
+      context_->guard_halted_reason.reset();
+      context_->area_guard_halt_count.clear();
       // Disarm the #487 escape motion too — see EndSession for why.
       context_->start_blocked_escape_armed = false;
       clearCoverageResumeState(*context_);

--- a/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/coverage_nodes.cpp
@@ -1776,6 +1776,44 @@ BT::NodeStatus GetNextUnmowedArea::processResponse()
                 blocked_n);
   }
 
+  // Field 2026-09-07/08: the PREVIOUS pass was not aborted by the field but
+  // INTERRUPTED by a Root guard (IsScanStale on a flaky LiDAR serial link,
+  // LocalizationGuard on a σ spike) halting the tree — FollowStrip saved its
+  // resume cursor and the guard released. That pass never had a chance to make
+  // progress either, and charging it retired a mowable field after three
+  // scan-stale halts in 25 s ("completed" with 0 swaths). A transient sensor
+  // fault must PAUSE a mow, never fail it. Exempt it — bounded only by the
+  // generous kMaxGuardHaltedPasses (a dead sensor is held by the guard itself;
+  // this cap merely stops a pathological flap from re-dispatching forever).
+  const std::optional<std::string> guard_reason = ctx->guard_halted_reason;
+  ctx->guard_halted_reason.reset();  // consume: it describes ONE finished pass
+  if (guard_reason.has_value())
+  {
+    auto& halted_n = ctx->area_guard_halt_count[current_area_idx_];
+    if (halted_n < BTContext::kMaxGuardHaltedPasses)
+    {
+      halted_n++;
+      setOutput("area_index", current_area_idx_);
+      ctx->current_area = static_cast<int>(current_area_idx_);
+      RCLCPP_INFO(ctx->node->get_logger(),
+                  "GetNextUnmowedArea: area %u re-dispatched after a pass interrupted by guard "
+                  "'%s' (%u/%u) — no-progress budget NOT charged (still %u/%u)",
+                  current_area_idx_,
+                  guard_reason->c_str(),
+                  halted_n,
+                  BTContext::kMaxGuardHaltedPasses,
+                  ctx->area_attempt_count[current_area_idx_],
+                  BTContext::kMaxAreaAttempts);
+      return BT::NodeStatus::SUCCESS;
+    }
+    RCLCPP_WARN(ctx->node->get_logger(),
+                "GetNextUnmowedArea: area %u interrupted by guard '%s' again after %u exempted "
+                "passes — charging it to the no-progress budget from now on",
+                current_area_idx_,
+                guard_reason->c_str(),
+                halted_n);
+  }
+
   auto& n = ctx->area_attempt_count[current_area_idx_];
   auto last_it = ctx->area_last_coverage.find(current_area_idx_);
   const bool made_progress = (last_it == ctx->area_last_coverage.end()) ||

--- a/ros2/src/mowgli_behavior/src/register_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/register_nodes.cpp
@@ -73,6 +73,10 @@ void registerAllNodes(BT::BehaviorTreeFactory& factory)
   factory.registerNodeType<NavigateInsideBoundary>("NavigateInsideBoundary");
   factory.registerNodeType<BackUp>("BackUp");
   factory.registerNodeType<ClearCommand>("ClearCommand");
+  // Guard-halt marker: a guard handler that halts the Root mid-mow must tick
+  // this, or its pauses are charged to GetNextUnmowedArea's no-progress budget
+  // and a flapping sensor fails the mow at 0 swaths (field 2026-09-07/08).
+  factory.registerNodeType<MarkGuardHalt>("MarkGuardHalt");
   factory.registerNodeType<EndSession>("EndSession");
   factory.registerNodeType<IncrementSkippedSwaths>("IncrementSkippedSwaths");
   factory.registerNodeType<SaveObstacles>("SaveObstacles");

--- a/ros2/src/mowgli_behavior/src/status_nodes.cpp
+++ b/ros2/src/mowgli_behavior/src/status_nodes.cpp
@@ -153,6 +153,34 @@ BT::NodeStatus ClearCommand::tick()
 }
 
 // ---------------------------------------------------------------------------
+// MarkGuardHalt
+// ---------------------------------------------------------------------------
+
+BT::NodeStatus MarkGuardHalt::tick()
+{
+  auto ctx = config().blackboard->get<std::shared_ptr<BTContext>>("context");
+  auto reason = getInput<std::string>("reason");
+  if (!reason)
+  {
+    RCLCPP_ERROR(ctx->node->get_logger(),
+                 "MarkGuardHalt: missing required port 'reason': %s",
+                 reason.error().c_str());
+    return BT::NodeStatus::FAILURE;
+  }
+  // Log only on the first tick of a halt — the handler re-runs every tick
+  // while the fault holds, and the guard already logs its own condition.
+  if (!ctx->guard_halted_reason.has_value())
+  {
+    RCLCPP_INFO(ctx->node->get_logger(),
+                "MarkGuardHalt: guard '%s' is halting the tree — the interrupted pass will "
+                "not be charged to the area's no-progress budget",
+                reason.value().c_str());
+  }
+  ctx->guard_halted_reason = reason.value();
+  return BT::NodeStatus::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
 // EndSession
 // ---------------------------------------------------------------------------
 
@@ -190,6 +218,11 @@ BT::NodeStatus EndSession::tick()
   ctx->coverage_start_blocked = false;
   ctx->start_blocked_area.reset();
   ctx->area_start_blocked_count.clear();
+  // Guard-halted bookkeeping is per-session for the same reason: a stale
+  // guard_halted_reason would exempt the new session's first dispatch for a
+  // pause that happened last session.
+  ctx->guard_halted_reason.reset();
+  ctx->area_guard_halt_count.clear();
   // SAFETY (issue #487 escape motion): disarm the escape and forget the
   // last-motion direction at the session boundary. A token or a direction that
   // survived into the next session would describe a pose the robot may no

--- a/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
+++ b/ros2/src/mowgli_behavior/test/test_get_next_unmowed_area.cpp
@@ -51,6 +51,7 @@ using mowgli_behavior::BTContext;
 using mowgli_behavior::clearSingleAreaMode;
 using mowgli_behavior::EndSession;
 using mowgli_behavior::GetNextUnmowedArea;
+using mowgli_behavior::MarkGuardHalt;
 using GetMowingArea = mowgli_interfaces::srv::GetMowingArea;
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,7 @@ protected:
 
     factory.registerNodeType<GetNextUnmowedArea>("GetNextUnmowedArea");
     factory.registerNodeType<EndSession>("EndSession");
+    factory.registerNodeType<MarkGuardHalt>("MarkGuardHalt");
 
     server_node = rclcpp::Node::make_shared("fake_map_server");
     service = server_node->create_service<GetMowingArea>(
@@ -188,6 +190,27 @@ protected:
         "<EndSession/>"
         "</BehaviorTree></root>";
     return factory.createTreeFromText(xml, blackboard);
+  }
+
+  /// A bare <MarkGuardHalt reason="..."/> tree — the real guard-handler node,
+  /// so the guard-halted exemption is driven the way main_tree.xml drives it.
+  BT::Tree makeMarkGuardHaltTree(const std::string& reason)
+  {
+    const std::string xml =
+        "<root BTCPP_format=\"4\"><BehaviorTree ID=\"MainTree\">"
+        "<MarkGuardHalt reason=\"" +
+        reason +
+        "\"/>"
+        "</BehaviorTree></root>";
+    return factory.createTreeFromText(xml, blackboard);
+  }
+
+  /// Simulate "a guard halted the tree mid-pass": tick the real MarkGuardHalt
+  /// node the way SensorFaultHandler / LocalizationDegradedHandler do.
+  void guardHaltsTree(const std::string& reason = "scan_stale")
+  {
+    auto halt_tree = makeMarkGuardHaltTree(reason);
+    ASSERT_EQ(halt_tree.tickOnce(), BT::NodeStatus::SUCCESS);
   }
 };
 
@@ -310,6 +333,184 @@ TEST_F(GetNextUnmowedAreaTest, StartBlockedFlagIsConsumedByOneDispatch)
   EXPECT_EQ(ctx->area_start_blocked_count[0u], 1u);
   EXPECT_EQ(ctx->area_attempt_count[0u], 0u)
       << "the exempted dispatch must not have advanced the no-progress counter";
+}
+
+// ---------------------------------------------------------------------------
+// Field 2026-09-07/08 — a pass INTERRUPTED by a Root guard must not retire
+// the area.
+//
+// With an intermittent LiDAR serial link IsScanStale (SensorSafetyGuard)
+// halted the Root every few seconds. Each halt interrupts FollowStrip ("area 0
+// interrupted at pose N — resume cursor saved") and the next dispatch charged
+// the re-dispatch to the no-progress budget: three scan-stale halts in 25 s
+// exhausted kMaxAreaAttempts, the mow "completed" with 0 swaths and the robot
+// sat on the lawn. LocalizationGuard pauses did the same. The guard handlers
+// now tick MarkGuardHalt, which GetNextUnmowedArea consumes as "this pass was
+// a pause, not a failure".
+// ---------------------------------------------------------------------------
+
+// MarkGuardHalt records its reason in the context and always succeeds; it is
+// idempotent across the handler's per-tick re-runs.
+TEST_F(GetNextUnmowedAreaTest, MarkGuardHaltRecordsTheReason)
+{
+  ASSERT_FALSE(ctx->guard_halted_reason.has_value());
+
+  guardHaltsTree("scan_stale");
+  ASSERT_TRUE(ctx->guard_halted_reason.has_value());
+  EXPECT_EQ(*ctx->guard_halted_reason, "scan_stale");
+
+  // The handler re-ticks every cycle while the fault holds — same result.
+  guardHaltsTree("scan_stale");
+  ASSERT_TRUE(ctx->guard_halted_reason.has_value());
+  EXPECT_EQ(*ctx->guard_halted_reason, "scan_stale");
+
+  // A different guard overwrites the tag (the last halt describes the pass).
+  guardHaltsTree("localization_degraded");
+  ASSERT_TRUE(ctx->guard_halted_reason.has_value());
+  EXPECT_EQ(*ctx->guard_halted_reason, "localization_degraded");
+}
+
+// (a) A single guard-halted pass is not charged and re-selects the same area.
+TEST_F(GetNextUnmowedAreaTest, GuardHaltedPassIsNotChargedAndReselectsTheArea)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  // First dispatch of the session — the normal charging path (attempt 1/5).
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+    ASSERT_EQ(ctx->current_area, 0);
+    ASSERT_EQ(ctx->area_attempt_count[0u], 1u);
+  }
+
+  // IsScanStale halts the Root mid-pass; FollowStrip saves its cursor.
+  guardHaltsTree("scan_stale");
+
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  uint32_t selected = 99;
+  ASSERT_TRUE(blackboard->get("area_index", selected));
+  EXPECT_EQ(selected, 0u) << "the interrupted area must be re-dispatched";
+  EXPECT_EQ(ctx->current_area, 0);
+  EXPECT_EQ(ctx->area_attempt_count[0u], 1u)
+      << "a guard-interrupted pass must NOT advance the no-progress counter";
+  EXPECT_EQ(ctx->area_guard_halt_count[0u], 1u);
+}
+
+// (b) The field incident: FIVE consecutive guard-halted passes (one more than
+// the three that killed the 2026-09-07 mow) still do not retire the area.
+TEST_F(GetNextUnmowedAreaTest, RepeatedGuardHaltsDoNotBurnTheNoProgressBudget)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  for (uint32_t halt = 0; halt < BTContext::kMaxAreaAttempts; ++halt)
+  {
+    guardHaltsTree(halt % 2 == 0 ? "scan_stale" : "localization_degraded");
+    auto tree = makeTree(/*max_areas=*/5);
+    EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS)
+        << "dispatch after guard halt " << halt << " must still select the area";
+    EXPECT_EQ(ctx->current_area, 0) << "halt " << halt;
+  }
+  EXPECT_EQ(ctx->attempted_areas.count(0u), 0u)
+      << "a run of guard pauses must not retire a mowable area";
+  EXPECT_LT(ctx->area_attempt_count[0u], BTContext::kMaxAreaAttempts);
+  EXPECT_EQ(ctx->area_attempt_count[0u], 0u)
+      << "none of the guard-interrupted passes may be charged";
+  EXPECT_EQ(ctx->area_guard_halt_count[0u], BTContext::kMaxAreaAttempts);
+}
+
+// (c) The flag describes ONE finished pass: it is consumed by the dispatch
+// that reads it, and the following (uninterrupted) no-progress pass IS
+// charged as before.
+TEST_F(GetNextUnmowedAreaTest, GuardHaltFlagIsConsumedSoTheNextPlainPassIsCharged)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  guardHaltsTree("scan_stale");
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  }
+  EXPECT_FALSE(ctx->guard_halted_reason.has_value()) << "must be consumed by the dispatch";
+  EXPECT_EQ(ctx->area_attempt_count[0u], 0u);
+
+  // The pass that follows ends without a guard halt and without progress.
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  }
+  EXPECT_EQ(ctx->area_attempt_count[0u], 1u)
+      << "an ordinary no-progress pass must still be charged (first dispatch counts 1)";
+
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  }
+  EXPECT_EQ(ctx->area_attempt_count[0u], 2u)
+      << "the exemption must not linger past the one dispatch that consumed it";
+}
+
+// (d) ...and the exemption is BOUNDED by kMaxGuardHaltedPasses: past it the
+// normal charging path takes over so a pathological flap cannot loop forever.
+// (A permanently dead sensor never reaches this — the guard holds the tree.)
+TEST_F(GetNextUnmowedAreaTest, GuardHaltExemptionStopsAtTheCap)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  for (uint32_t halt = 0; halt < BTContext::kMaxGuardHaltedPasses; ++halt)
+  {
+    guardHaltsTree("scan_stale");
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS) << "exempted halt " << halt;
+  }
+  ASSERT_EQ(ctx->area_guard_halt_count[0u], BTContext::kMaxGuardHaltedPasses);
+  ASSERT_EQ(ctx->area_attempt_count[0u], 0u);
+
+  // Cap reached: guard-halted passes now fall through to the charging path.
+  const uint32_t kMaxDispatches = BTContext::kMaxAreaAttempts + 2;
+  bool retired = false;
+  for (uint32_t attempt = 0; attempt < kMaxDispatches && !retired; ++attempt)
+  {
+    guardHaltsTree("scan_stale");
+    auto tree = makeTree(/*max_areas=*/5);
+    tickToCompletion(tree);
+    EXPECT_FALSE(ctx->guard_halted_reason.has_value())
+        << "the flag must be consumed on the charging path too (attempt " << attempt << ")";
+    retired = ctx->attempted_areas.count(0u) > 0;
+  }
+  EXPECT_TRUE(retired) << "past kMaxGuardHaltedPasses the no-progress budget must apply again";
+  EXPECT_EQ(ctx->area_guard_halt_count[0u], BTContext::kMaxGuardHaltedPasses)
+      << "the exemption counter must not grow past the cap";
+}
+
+// EndSession is the session boundary: a guard halt that ended one session
+// must not exempt the next session's first dispatch.
+TEST_F(GetNextUnmowedAreaTest, EndSessionClearsGuardHaltBookkeeping)
+{
+  areas[0] = {"lawn", /*is_navigation_area=*/false};
+  waitForService();
+
+  guardHaltsTree("localization_degraded");
+  {
+    auto tree = makeTree(/*max_areas=*/5);
+    ASSERT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  }
+  ASSERT_EQ(ctx->area_guard_halt_count[0u], 1u);
+  guardHaltsTree("localization_degraded");  // halted again on the way to the dock
+
+  auto end_tree = makeEndSessionTree();
+  ASSERT_EQ(end_tree.tickOnce(), BT::NodeStatus::SUCCESS);
+  EXPECT_FALSE(ctx->guard_halted_reason.has_value());
+  EXPECT_TRUE(ctx->area_guard_halt_count.empty());
+
+  // Next session: the first dispatch is charged normally (1/5).
+  auto tree = makeTree(/*max_areas=*/5);
+  EXPECT_EQ(tickToCompletion(tree), BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(ctx->area_attempt_count[0u], 1u);
 }
 
 // ---------------------------------------------------------------------------

--- a/ros2/src/mowgli_behavior/test/test_guard_fallthrough.cpp
+++ b/ros2/src/mowgli_behavior/test/test_guard_fallthrough.cpp
@@ -57,6 +57,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <rclcpp/rclcpp.hpp>
@@ -323,6 +324,47 @@ TEST(GuardFallthroughTest, AllBlockingGuardsTerminateWithFailure)
            "handler can return SUCCESS lets the Root ReactiveSequence advance "
            "into MainLogic for one tick per cycle, restarting MowingSequence "
            "from PREFLIGHT_CHECK/UNDOCKING (issues #459, #445).";
+  }
+}
+
+// The guards whose halt interrupts a mowing PASS (as opposed to ending the
+// session — emergency, boundary, rain, battery, dig obstruction) must tick
+// <MarkGuardHalt/> as the FIRST child of their handler Sequence, or every
+// pause is charged to GetNextUnmowedArea's per-area no-progress budget and a
+// flapping sensor fails the mow at 0 swaths (field 2026-09-07 / 2026-09-08:
+// three IsScanStale halts in 25 s exhausted the five attempts). First, not
+// merely before <AlwaysFailure/>: the ReactiveFallback halts the handler the
+// moment the fault clears, so a marker behind StopMoving + WaitForDuration
+// would miss every pause shorter than their combined duration.
+TEST(GuardFallthroughTest, PausingGuardsMarkTheHaltFirst)
+{
+  const std::string xml = ReadMainTree();
+  ASSERT_FALSE(xml.empty());
+
+  for (const auto& [guard, reason] : std::vector<std::pair<std::string, std::string>>{
+           {"SensorSafetyGuard", "scan_stale"}, {"LocalizationGuard", "localization_degraded"}})
+  {
+    const std::string block = ExtractGuardBlock(xml, guard);
+    ASSERT_FALSE(block.empty()) << "Guard not found in main_tree.xml: " << guard;
+    const std::size_t mark = block.find("<MarkGuardHalt reason=\"" + reason + "\"/>");
+    ASSERT_NE(mark, std::string::npos)
+        << guard << " does not tick <MarkGuardHalt reason=\"" << reason
+        << "\"/> — its pauses would be charged to the no-progress budget and retire the area.";
+    // Nothing that can return RUNNING or FAILURE may precede the marker: the
+    // handler's other children (SetMowerEnabled, StopMoving, WaitForDuration,
+    // PublishHighLevelStatus) must all come after it.
+    const std::size_t handler = block.find("Handler\">");
+    ASSERT_NE(handler, std::string::npos) << guard << ": no *Handler Sequence found";
+    ASSERT_LT(handler, mark) << guard << ": <MarkGuardHalt/> is outside the handler Sequence";
+    const std::string between = block.substr(handler, mark - handler);
+    for (const std::string preceding :
+         {"<SetMowerEnabled", "<StopMoving", "<WaitForDuration", "<PublishHighLevelStatus"})
+    {
+      EXPECT_EQ(between.find(preceding), std::string::npos)
+          << guard << ": " << preceding << " runs before <MarkGuardHalt/> — a fault that clears "
+          << "while it is RUNNING (or a service call that FAILS) skips the marker and the "
+          << "interrupted pass is charged after all.";
+    }
   }
 }
 

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -79,6 +79,13 @@
            the operator is the safety in manual modes. Firmware remains the
            sole hard e-stop authority (invariant 9); this guard is the
            software-side blade-off that was missing.
+           The halt is a PAUSE, not a failure: MarkGuardHalt flags the
+           interrupted pass so GetNextUnmowedArea does not charge the
+           re-dispatch to the per-area no-progress budget. Field 2026-09-07/08:
+           a flaky LiDAR serial link tripped IsScanStale every few seconds and
+           three halts in 25 s exhausted the five attempts — the mow
+           "completed" with 0 swaths. A permanently dead scanner is still held
+           here, blade off, for as long as the fault lasts.
            ================================================================ -->
       <ReactiveFallback name="SensorSafetyGuard">
         <IsCharging/>
@@ -98,6 +105,13 @@
           </Fallback>
         </Inverter>
         <Sequence name="SensorFaultHandler">
+          <!-- FIRST child on purpose: the Root is already halted the tick
+               this handler starts, but the ReactiveFallback halts this
+               Sequence the moment the fault clears — a sub-1.5 s blip would
+               never get past StopMoving (0.5 s) + WaitForDuration (1 s) to a
+               marker placed at the end, and the pass would be charged after
+               all. Pure context write, no motion; idempotent across re-ticks. -->
+          <MarkGuardHalt reason="scan_stale"/>
           <SetMowerEnabled enabled="false"/>
           <StopMoving/>
           <WaitForDuration duration_sec="1.0"/>
@@ -256,6 +270,11 @@
            operator-supervised; HOME + the blade-off dock transit must not
            be stranded mid-return by a GPS outage (docking itself is
            charger-detection based).
+           Like SensorSafetyGuard, this pause must never FAIL the mow:
+           MarkGuardHalt flags the interrupted pass so GetNextUnmowedArea
+           re-dispatches the area without charging its no-progress budget
+           (field 2026-09-07/08 — repeated "Localization degraded … pausing"
+           halts retired the area at 0 swaths).
            ================================================================ -->
       <ReactiveFallback name="LocalizationGuard">
         <IsCharging/>
@@ -275,6 +294,11 @@
              tick, so the guard releases within one tick of the hysteresis
              clearing and the resume-cursor machinery continues the strip. -->
         <Sequence name="LocalizationDegradedHandler">
+          <!-- FIRST child, same reasoning as SensorFaultHandler: the
+               ReactiveFallback halts this Sequence as soon as σ recovers, so
+               a marker after the 2 s WaitForDuration would miss every short
+               pause. Pure context write, no motion; idempotent. -->
+          <MarkGuardHalt reason="localization_degraded"/>
           <SetMowerEnabled enabled="false"/>
           <StopMoving/>
           <PublishHighLevelStatus state="2" state_name="WAITING_FOR_RTK"/>


### PR DESCRIPTION
## What
A pass interrupted by a **pausing guard** (SensorSafetyGuard's `IsScanStale`, LocalizationGuard) no longer counts against the per-area no-progress budget (`kMaxAreaAttempts` = 5). The handlers tick a new `MarkGuardHalt` node (first child, so even a sub-second blip is marked before the ReactiveFallback halts the handler); `GetNextUnmowedArea` consumes the flag and re-dispatches the same area at the saved cursor without charging it — the same shape as the START_OCCUPIED exemption (#487). Cap `kMaxGuardHaltedPasses` = 200 bounds a pathological flap; a dead sensor is still held by the guard itself.

## Why
Field 2026-09-07/08 with an intermittent LiDAR cable: three `IsScanStale` halts in 25 s burned the five attempts, the mow "completed" with 0 swaths and the robot stayed on the lawn. Same with `LocalizationGuard` pauses. The operator's rule: a connection problem pauses the mow, it must not fail it.

## Test plan
- [x] `test_get_next_unmowed_area` 17/17 (6 new), `test_guard_fallthrough` 8/8 (1 new structural), package gtests 231 cases green in the image
- [ ] CI ROS2 build & test (cpplint on dev is already red on untouched lines)
- [ ] Field: mow with a flaky LiDAR link keeps resuming instead of completing at 0 %

https://claude.ai/code/session_01D46c8dsyRG7k8Q7Djs1NjZ
