### PR TITLE
fix(gui): show saved dock position on dashboard map

### DIFF
--- a/gui/pkg/msgs/mowgli/types.go
+++ b/gui/pkg/msgs/mowgli/types.go
@@ -12,9 +12,10 @@ type Map struct {
 	MapCenterY      float64   `json:"map_center_y"`
 	NavigationAreas []MapArea `json:"navigation_areas"`
 	WorkingArea     []MapArea `json:"working_area"`
-	DockX           float64   `json:"dock_x"`
-	DockY           float64   `json:"dock_y"`
-	DockHeading     float64   `json:"dock_heading"`
+	// Nil means no pose received; an explicitly received zero is a valid dock.
+	DockX       *float64 `json:"dock_x,omitempty"`
+	DockY       *float64 `json:"dock_y,omitempty"`
+	DockHeading *float64 `json:"dock_heading,omitempty"`
 }
 
 // DockingSensor - placeholder, may not exist in ROS2 mowgli

--- a/gui/pkg/providers/map_dock.go
+++ b/gui/pkg/providers/map_dock.go
@@ -1,0 +1,15 @@
+package providers
+
+import "github.com/mowglinext/mowglinext/pkg/msgs/mowgli"
+
+// addDockPose preserves absence until the map server supplies a pose. Copy the
+// values under the cache lock; pointers must not alias the live mutable cache.
+func (r *RosProvider) addDockPose(data *mowgli.Map) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if !r.dockPoseSet {
+		return
+	}
+	x, y, heading := r.dockX, r.dockY, r.dockHeading
+	data.DockX, data.DockY, data.DockHeading = &x, &y, &heading
+}

--- a/gui/pkg/providers/map_dock_test.go
+++ b/gui/pkg/providers/map_dock_test.go
@@ -1,0 +1,52 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mowglinext/mowglinext/pkg/msgs/mowgli"
+)
+
+func TestMapDockPresenceAndSnapshot(t *testing.T) {
+	r := &RosProvider{}
+	var unknown mowgli.Map
+	r.addDockPose(&unknown)
+	encoded, err := json.Marshal(unknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"dock_x", "dock_y", "dock_heading"} {
+		if _, exists := fields[key]; exists {
+			t.Fatalf("unknown dock emitted %s", key)
+		}
+	}
+	// Origin is valid once supplied by the map server, including zero heading.
+	r.dockPoseSet = true
+	var origin mowgli.Map
+	r.addDockPose(&origin)
+	encoded, err = json.Marshal(origin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"dock_x", "dock_y", "dock_heading"} {
+		if string(fields[key]) != "0" {
+			t.Fatalf("origin %s = %s", key, fields[key])
+		}
+	}
+	r.dockX, r.dockY, r.dockHeading = -12.5, 8, 1.5
+	var moved mowgli.Map
+	r.addDockPose(&moved)
+	if *origin.DockX != 0 || *origin.DockY != 0 || *origin.DockHeading != 0 {
+		t.Fatal("previous map aliases mutable dock cache")
+	}
+	if *moved.DockX != -12.5 || *moved.DockY != 8 || *moved.DockHeading != 1.5 {
+		t.Fatalf("updated dock not included: %+v", moved)
+	}
+}

--- a/gui/pkg/providers/ros.go
+++ b/gui/pkg/providers/ros.go
@@ -31,8 +31,8 @@ var topicMap = map[string]topicDef{
 	// One-click dock calibration live status (the GUI's foxglove-friendly
 	// window into the CalibrateDock action — foxglove_bridge has no action op).
 	"dockCalibrationStatus": {"/calibrate_imu_yaw_node/dock_calibration/status", "mowgli_interfaces/msg/DockCalibrationStatus"},
-	"gps":             {"/gps/fix", "sensor_msgs/msg/NavSatFix"},
-	"gnssStatus":      {"/gps/status", "mowgli_interfaces/msg/GnssStatus"},
+	"gps":                   {"/gps/fix", "sensor_msgs/msg/NavSatFix"},
+	"gnssStatus":            {"/gps/status", "mowgli_interfaces/msg/GnssStatus"},
 	// The robot's global pose comes from fusion_graph_node, the sole
 	// map-frame localizer. "pose" and "fusionRaw" both point at
 	// /odometry/filtered_map; the duplicate key is kept for backwards
@@ -440,13 +440,6 @@ func (r *RosProvider) pollMap() {
 		navAreas = []mowgli.MapArea{}
 	}
 
-	// Read cached docking pose (written by initDockPoseSubscription)
-	r.mtx.Lock()
-	dockX := r.dockX
-	dockY := r.dockY
-	dockHeading := r.dockHeading
-	r.mtx.Unlock()
-
 	mapData := mowgli.Map{
 		MapWidth:        20.0,
 		MapHeight:       20.0,
@@ -454,10 +447,8 @@ func (r *RosProvider) pollMap() {
 		MapCenterY:      0.0,
 		NavigationAreas: navAreas,
 		WorkingArea:     workingAreas,
-		DockX:           dockX,
-		DockY:           dockY,
-		DockHeading:     dockHeading,
 	}
+	r.addDockPose(&mapData)
 
 	data, err := json.Marshal(mapData)
 	if err != nil {

--- a/gui/web/src/concept/components/LiveMapMini.tsx
+++ b/gui/web/src/concept/components/LiveMapMini.tsx
@@ -36,6 +36,8 @@ interface LiveMapMiniProps {
   progress?: MiniProgress | null;
   /** Robot position 0..1. */
   robot?:   {x: number; y: number; heading: number};
+  /** Saved dock in the same normalised space. Omitted until known. */
+  dock?: {x: number; y: number};
   /** Coverage fraction 0..1 -- synthetic band drawn only when no `progress`. */
   coverage?: number;
   height?: number;
@@ -62,6 +64,7 @@ export function LiveMapMini({
   polygons,
   progress = null,
   robot   = {x: 0.62, y: 0.46, heading: 30},
+  dock,
   coverage = 0.42,
   height = 200,
 }: LiveMapMiniProps) {
@@ -88,10 +91,11 @@ export function LiveMapMini({
   return (
     <div style={{position: "relative", width: "100%", height, overflow: "hidden"}}>
       <svg
+        data-testid="live-map-mini"
         viewBox={`0 0 ${w} ${h}`}
         width="100%"
         height={height}
-        preserveAspectRatio="xMidYMid slice"
+        preserveAspectRatio="xMidYMid meet"
         style={{display: "block"}}
       >
         <defs>
@@ -190,13 +194,13 @@ export function LiveMapMini({
           )}
         </g>
 
-        {/* dock marker */}
-        <g transform={`translate(${toX(0.16)} ${toY(0.22)})`}>
+        {/* Only draw a dock supplied by the map; no decorative fallback. */}
+        {dock && <g data-testid="mini-map-dock" transform={`translate(${toX(dock.x)} ${toY(dock.y)})`}>
           <rect x={-6} y={-3} width={12} height={6} rx={2}
                 fill="rgba(243, 168, 92, 0.14)"
                 stroke="var(--amber)" strokeWidth={1}/>
           <circle cx={0} cy={0} r={1.2} fill="var(--amber)"/>
-        </g>
+        </g>}
       </svg>
     </div>
   );

--- a/gui/web/src/pages/MowgliNextPage.tsx
+++ b/gui/web/src/pages/MowgliNextPage.tsx
@@ -132,6 +132,9 @@ export const MowgliNextPage = () => {
   // multi-area field render just the first zone on the dashboard.
   const workingAreas = map.working_area ?? [];
   const validAreas = workingAreas.filter(a => (a.area?.points?.length ?? 0) >= 3);
+  const dock = typeof map.dock_x === "number" && Number.isFinite(map.dock_x)
+    && typeof map.dock_y === "number" && Number.isFinite(map.dock_y)
+    ? {x: map.dock_x, y: map.dock_y} : undefined;
   const bbox = (() => {
     let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
     validAreas.forEach(a => (a.area?.points ?? []).forEach(p => {
@@ -142,6 +145,12 @@ export const MowgliNextPage = () => {
       if (y > y1) y1 = y;
     }));
     if (!isFinite(x0)) return null;
+    // Docks can sit outside the mowing polygons. Expand the shared bounds
+    // instead of clipping the marker or clamping it to a false position.
+    if (dock) {
+      x0 = Math.min(x0, dock.x); x1 = Math.max(x1, dock.x);
+      y0 = Math.min(y0, dock.y); y1 = Math.max(y1, dock.y);
+    }
     return {x0, y0, dx: (x1 - x0) || 1, dy: (y1 - y0) || 1};
   })();
   // Map frame -> unit square with a 10 % inset (matches the old look). Non-
@@ -167,6 +176,7 @@ export const MowgliNextPage = () => {
   const robotNormalised = (pose && bbox)
     ? {...norm(pose.x ?? 0, pose.y ?? 0), heading: robotYawDeg}
     : undefined;
+  const dockNormalised = dock && bbox ? norm(dock.x, dock.y) : undefined;
 
   // Real mowed-cell overlay: same OccupancyGrid MapPage renders, rasterised
   // once per grid message (throttled to ~1 Hz) and placed in the same unit
@@ -335,7 +345,7 @@ export const MowgliNextPage = () => {
                 todayMowedM2={todayMowedM2} totalArea={totalArea}
               />
             </motion.div>
-            <motion.div variants={riseFade}><LiveMapCard polygons={polygons} progress={progress} robot={robotNormalised} coverage={coveragePct} onViewMap={() => navigate("/map")}/></motion.div>
+            <motion.div variants={riseFade}><LiveMapCard polygons={polygons} progress={progress} robot={robotNormalised} dock={dockNormalised} coverage={coveragePct} onViewMap={() => navigate("/map")}/></motion.div>
             <motion.div variants={riseFade}><TilesRow data={data}/></motion.div>
             <motion.div variants={riseFade}><HealthCard data={data}/></motion.div>
           </div>
@@ -354,7 +364,7 @@ export const MowgliNextPage = () => {
               <motion.div variants={riseFade}><HealthCard data={data}/></motion.div>
             </div>
             <div style={{display: 'flex', flexDirection: 'column', gap: 18}}>
-              <motion.div variants={riseFade}><LiveMapCard polygons={polygons} progress={progress} robot={robotNormalised} coverage={coveragePct} height={300} onViewMap={() => navigate("/map")}/></motion.div>
+              <motion.div variants={riseFade}><LiveMapCard polygons={polygons} progress={progress} robot={robotNormalised} dock={dockNormalised} coverage={coveragePct} height={300} onViewMap={() => navigate("/map")}/></motion.div>
               <motion.div variants={riseFade}><TilesRow data={data}/></motion.div>
             </div>
           </div>
@@ -480,12 +490,13 @@ interface LiveMapCardProps {
   polygons: MiniArea[];
   progress: MiniProgress | null;
   robot?: {x: number; y: number; heading: number};
+  dock?: {x: number; y: number};
   coverage: number;
   height?: number;
   onViewMap?: () => void;
 }
 
-function LiveMapCard({polygons, progress, robot, coverage, height = 220, onViewMap}: LiveMapCardProps) {
+function LiveMapCard({polygons, progress, robot, dock, coverage, height = 220, onViewMap}: LiveMapCardProps) {
   const {t} = useTranslation();
   const hasArea = polygons.length > 0;
   return (
@@ -522,6 +533,7 @@ function LiveMapCard({polygons, progress, robot, coverage, height = 220, onViewM
           polygons={polygons}
           progress={progress}
           robot={robot}
+          dock={dock}
           coverage={coverage}
           height={height}
         />

--- a/gui/web/tests/e2e/dashboard-dock.spec.ts
+++ b/gui/web/tests/e2e/dashboard-dock.spec.ts
@@ -1,0 +1,56 @@
+import {expect, test} from "@playwright/test";
+import {installMockBackend} from "./mock/mockBackend.ts";
+
+const area = {area: {points: [
+  {x: 10, y: 10}, {x: 20, y: 10}, {x: 20, y: 20}, {x: 10, y: 20},
+]}};
+
+for (const width of [375, 1440]) {
+  for (const sample of [
+    {name: "saved", coords: {dock_x: 15, dock_y: 15}, unit: [0.5, 0.5]},
+    {name: "outside", coords: {dock_x: 30, dock_y: 15}, unit: [0.9, 0.5]},
+    {name: "origin", coords: {dock_x: 0, dock_y: 0}, unit: [0.1, 0.9]},
+    {name: "missing", coords: {}, unit: null},
+    {name: "partial", coords: {dock_x: 15}, unit: null},
+    {name: "non-finite", coords: {dock_x: Infinity, dock_y: 15}, unit: null},
+  ]) {
+    test(`dashboard dock ${sample.name} at ${width}px`, async ({page}) => {
+      await page.setViewportSize({width, height: 900});
+      await installMockBackend(page, {
+        name: "dashboard-dock",
+        topics: {
+          map: {working_area: [area], ...sample.coords},
+          fusionRaw: {pose: {pose: {position: {x: 15, y: 15, z: 0}}}},
+        },
+      });
+      await page.goto("/#/mowglinext");
+      const map = page.getByTestId("live-map-mini");
+      // This SVG is only mounted after the page has received recorded areas.
+      await expect(map).toBeVisible();
+      const marker = page.getByTestId("mini-map-dock");
+      if (!sample.unit) {
+        await expect(marker).toHaveCount(0);
+        return;
+      }
+      const height = width < 768 ? 220 : 300;
+      const transform = await marker.getAttribute("transform");
+      const coords = transform!.match(/[-\d.]+/g)!.map(Number);
+      expect(coords[0]).toBeCloseTo(sample.unit[0] * 600);
+      expect(coords[1]).toBeCloseTo(sample.unit[1] * height);
+      // A dock outside the lawn must remain inside the visible SVG on narrow
+      // screens too (slice used to crop the ends of the normalised view).
+      await marker.scrollIntoViewIfNeeded();
+      const bounds = await map.boundingBox();
+      const dot = await marker.boundingBox();
+      expect(dot!.x).toBeGreaterThanOrEqual(bounds!.x);
+      expect(dot!.x + dot!.width).toBeLessThanOrEqual(bounds!.x + bounds!.width);
+      expect(dot!.y).toBeGreaterThanOrEqual(bounds!.y);
+      expect(dot!.y + dot!.height).toBeLessThanOrEqual(bounds!.y + bounds!.height);
+      if (sample.name === "saved") {
+        const robot = map.locator('circle[filter="url(#robotGlow)"]').locator("..");
+        await expect(robot).toHaveAttribute("transform", transform!);
+      }
+      await page.screenshot({path: `tests/e2e/.artifacts/dashboard-dock-${sample.name}-${width}.png`});
+    });
+  }
+}


### PR DESCRIPTION
The dashboard's orange dock marker was drawn at the fixed demo position `(0.16, 0.22)`, regardless of the saved dock. Use the dock coordinates from the existing map feed and the same transform as the areas, mower and coverage overlay. Include the dock in the preview bounds and fit the SVG on narrow screens so a dock outside the lawn remains visible.

The GUI backend now omits dock fields until it has received a dock pose, rather than sending an invented `(0, 0)`. An explicitly received origin remains valid. The dashboard hides missing, partial or non-finite coordinates. This only changes the GUI's map view; it does not alter the saved dock or robot navigation.

Validation:

- 12 mocked Playwright checks at 375px and 1440px: saved location, outside-lawn location, valid origin, absent/partial/non-finite pose, alignment with the mower and visible bounds. Screenshots visually reviewed.
- `go test ./...` passed, including dock presence, origin serialization and immutable snapshot regression coverage.
- TypeScript and production frontend build passed.
- Frontend lint: 0 errors (821 existing warnings).
- Full frontend unit suite: 52 files / 389 tests passed.

Based on upstream `dev` at `e252b3d4`, in an isolated bugfix worktree. No mower deployment performed.
