### PR TITLE
fix(behavior): keep HL state AUTONOMOUS while docking after a completed mow

### DIFF
--- a/gui/pkg/providers/scheduler.go
+++ b/gui/pkg/providers/scheduler.go
@@ -39,9 +39,10 @@ type SchedulerProvider struct {
 	dbProvider   types.IDBProvider
 	soilProvider types.ISoilProvider
 
-	mu                 sync.RWMutex
-	lastHighLevelState uint8
-	lastEmergency      bool
+	mu                     sync.RWMutex
+	lastHighLevelState     uint8
+	lastHighLevelStateName string
+	lastEmergency          bool
 }
 
 // NewSchedulerProvider creates and starts the scheduler background goroutine.
@@ -76,9 +77,17 @@ func (s *SchedulerProvider) subscribeToStatus() {
 					break
 				}
 			}
+			// Accept "state_name" or "StateName"
+			for _, k := range []string{"state_name", "StateName"} {
+				if v, ok := raw[k]; ok {
+					_ = json.Unmarshal(v, &hls.StateName)
+					break
+				}
+			}
 		}
 		s.mu.Lock()
 		s.lastHighLevelState = hls.State
+		s.lastHighLevelStateName = hls.StateName
 		s.mu.Unlock()
 	}); err != nil {
 		logrus.Warnf("Scheduler: failed to subscribe to highLevelStatus: %v", err)
@@ -215,7 +224,9 @@ func (s *SchedulerProvider) persistSkip(sched schedule, reason string, now time.
 // safeToStart returns true when it is safe to send COMMAND_START.
 // It blocks mowing when:
 //   - an emergency is active (latched or active), or
-//   - the robot is already in autonomous (2) or recording (3) state.
+//   - the robot is already in autonomous (2) or recording (3) state,
+//     EXCEPT the post-mow dock transit (state 2, state_name MOWING_COMPLETE),
+//     which reports autonomous only to keep the firmware wheel gate open.
 //
 // HIGH_LEVEL_STATE constants:
 //
@@ -227,11 +238,26 @@ func (s *SchedulerProvider) persistSkip(sched schedule, reason string, now time.
 func (s *SchedulerProvider) safeToStart() bool {
 	s.mu.RLock()
 	state := s.lastHighLevelState
+	stateName := s.lastHighLevelStateName
 	emergency := s.lastEmergency
 	s.mu.RUnlock()
 
 	if emergency {
 		return false
+	}
+	// The blade-off dock transit that follows a FINISHED mow stays startable:
+	// the run is over, the robot is only trundling home, and a schedule due in
+	// that window should not be silently skipped. It reports AUTONOMOUS purely
+	// so the firmware will move the wheels (HL_MODE_IDLE is a wheel hard stop),
+	// not because a session is still running.
+	//
+	// Deliberately MOWING_COMPLETE only. The other transits that report
+	// AUTONOMOUS must stay blocked: RETURNING_HOME is an explicit operator
+	// "go home", and LOW_BATTERY_DOCKING / CRITICAL_BATTERY_DOCKING /
+	// RAIN_DETECTED_DOCKING are the robot protecting itself — starting a mow
+	// on a flat battery or in the rain is exactly what they exist to prevent.
+	if state == 2 && stateName == "MOWING_COMPLETE" {
+		return true
 	}
 	// Do not interrupt an already-running autonomous session or an ongoing
 	// area recording. State 0 (NULL/emergency) is also blocked.

--- a/gui/pkg/providers/scheduler_test.go
+++ b/gui/pkg/providers/scheduler_test.go
@@ -158,6 +158,49 @@ func TestSafeToStart_ManualMowing(t *testing.T) {
 	assert.True(t, s.safeToStart())
 }
 
+// The blade-off dock transit after a FINISHED mow reports AUTONOMOUS only so
+// the firmware will drive the wheels (HL_MODE_IDLE is a wheel hard stop). The
+// run itself is over, so a schedule due in that window must still fire — this
+// pins the behaviour that existed before the state was raised from IDLE to
+// AUTONOMOUS, so the motion fix does not silently start skipping schedules.
+func TestSafeToStart_PostMowDockTransitStaysStartable(t *testing.T) {
+	s := buildScheduler(types.NewMockRosProvider(), types.NewMockDBProvider())
+	s.lastHighLevelState = 2 // AUTONOMOUS (wheel gate held open)
+	s.lastHighLevelStateName = "MOWING_COMPLETE"
+	s.lastEmergency = false
+	assert.True(t, s.safeToStart())
+}
+
+// An emergency still wins over the post-mow exemption.
+func TestSafeToStart_PostMowDockTransitBlockedByEmergency(t *testing.T) {
+	s := buildScheduler(types.NewMockRosProvider(), types.NewMockDBProvider())
+	s.lastHighLevelState = 2
+	s.lastHighLevelStateName = "MOWING_COMPLETE"
+	s.lastEmergency = true
+	assert.False(t, s.safeToStart())
+}
+
+// The exemption is MOWING_COMPLETE only. Every other AUTONOMOUS transit stays
+// blocked: RETURNING_HOME is an explicit operator "go home", and the battery /
+// rain docks are the robot protecting itself — starting a mow on a flat battery
+// or in the rain is precisely what those states exist to prevent.
+func TestSafeToStart_OtherDockTransitsStayBlocked(t *testing.T) {
+	for _, name := range []string{
+		"RETURNING_HOME",
+		"LOW_BATTERY_DOCKING",
+		"CRITICAL_BATTERY_DOCKING",
+		"RAIN_DETECTED_DOCKING",
+		"COVERAGE_FAILED_DOCKING",
+		"MOWING",
+	} {
+		s := buildScheduler(types.NewMockRosProvider(), types.NewMockDBProvider())
+		s.lastHighLevelState = 2
+		s.lastHighLevelStateName = name
+		s.lastEmergency = false
+		assert.False(t, s.safeToStart(), "state_name %s must not be startable", name)
+	}
+}
+
 // --------------------------------------------------------------------------
 // checkSchedules — integration-style tests using mocks
 // --------------------------------------------------------------------------

--- a/gui/pkg/providers/session_tracker.go
+++ b/gui/pkg/providers/session_tracker.go
@@ -192,7 +192,12 @@ func (s *SessionTracker) OnHighLevelStatus(msg []byte) {
 	prevState := s.currentState
 	s.currentState = status.StateName
 
-	isMowing := status.State == 2 // HIGH_LEVEL_STATE_AUTONOMOUS
+	// HIGH_LEVEL_STATE_AUTONOMOUS. MOWING_COMPLETE is excluded on purpose: since the
+	// dock-motion gate fix the tree keeps publishing state=2 while it drives back to
+	// the dock after a finished mow (the firmware hard-stops the wheels on IDLE), but
+	// that return trip is not part of the mowing session — counting it would inflate
+	// the session distance/duration and turn a failed docking into an "error" session.
+	isMowing := status.State == 2 && status.StateName != "MOWING_COMPLETE"
 	wasMowing := prevState == "MOWING" || prevState == "TRANSIT" || prevState == "RECOVERING" || prevState == "RESUMING_AFTER_RAIN" || prevState == "RESUMING_UNDOCKING"
 
 	// Start session

--- a/gui/pkg/providers/session_tracker_test.go
+++ b/gui/pkg/providers/session_tracker_test.go
@@ -68,6 +68,38 @@ func TestSessionTracker_RecordsRealSession(t *testing.T) {
 	}
 }
 
+// Regression for the dock-motion gate (#584): after a finished mow the tree now
+// publishes state=2 (AUTONOMOUS) together with MOWING_COMPLETE while it drives
+// back to the dock. That return trip must close the session as "completed"
+// exactly as before, not keep it open (inflating distance/duration) nor turn a
+// failed docking into an "error" session.
+func TestSessionTracker_MowingCompleteWithAutonomousStateEndsTheSession(t *testing.T) {
+	db := types.NewMockDBProvider()
+	s := newTrackerNoGoroutine(db)
+	s.OnHighLevelStatus(status(2, "MOWING", false))
+	s.sessionStart = time.Now().UTC().Add(-60 * time.Second)
+	// Completed mow, robot still AUTONOMOUS (state=2) while returning to the dock.
+	s.OnHighLevelStatus(status(2, "MOWING_COMPLETE", false))
+	s.OnHighLevelStatus(status(2, "MOWING_COMPLETE", false))
+	got := loadStoredSessions(t, db)
+	if len(got) != 1 {
+		t.Fatalf("expected the session to be finalized at MOWING_COMPLETE, got %d stored sessions", len(got))
+	}
+	if got[0].Status != "completed" {
+		t.Fatalf("expected completed, got %q", got[0].Status)
+	}
+	if s.inSession {
+		t.Fatalf("session must not stay open during the return-to-dock trip")
+	}
+	// A docking failure after the finished mow must not rewrite the finished session.
+	s.OnHighLevelStatus(status(0, "NAV_TO_DOCK_FAILED", false))
+	s.OnHighLevelStatus(status(0, "NAV_TO_DOCK_FAILED", false))
+	got = loadStoredSessions(t, db)
+	if len(got) != 1 || got[0].Status != "completed" {
+		t.Fatalf("docking failure after a finished mow must leave the session completed, got %+v", got)
+	}
+}
+
 // progressStatus builds a mowing status carrying live coverage/swath telemetry.
 func progressStatus(coverage float32, completed, skipped int) []byte {
 	b, _ := json.Marshal(map[string]any{
@@ -124,11 +156,11 @@ func TestSessionTracker_AccumulatesDistance(t *testing.T) {
 
 	s.OnHighLevelStatus(status(2, "MOWING", false)) // start; resets odometer
 	s.sessionStart = time.Now().UTC().Add(-60 * time.Second)
-	s.OnOdometry(odomAt(0, 0))   // baseline
-	s.OnOdometry(odomAt(0.3, 0)) // +0.3
-	s.OnOdometry(odomAt(0.6, 0)) // +0.3
-	s.OnOdometry(odomAt(0.9, 0)) // +0.3 => 0.9
-	s.OnOdometry(odomAt(50, 50)) // jump > maxOdomStepM: discarded, re-baseline
+	s.OnOdometry(odomAt(0, 0))     // baseline
+	s.OnOdometry(odomAt(0.3, 0))   // +0.3
+	s.OnOdometry(odomAt(0.6, 0))   // +0.3
+	s.OnOdometry(odomAt(0.9, 0))   // +0.3 => 0.9
+	s.OnOdometry(odomAt(50, 50))   // jump > maxOdomStepM: discarded, re-baseline
 	s.OnOdometry(odomAt(50.3, 50)) // +0.3 => 1.2
 
 	s.OnHighLevelStatus(status(1, "IDLE_DOCKED", false))

--- a/ros2/src/mowgli_behavior/CMakeLists.txt
+++ b/ros2/src/mowgli_behavior/CMakeLists.txt
@@ -685,6 +685,20 @@ if(BUILD_TESTING)
     $<INSTALL_INTERFACE:include>
   )
 
+  # ---- test_dock_motion_gate ----
+  # Structural guard over the real main_tree.xml: a DockRobot must never be
+  # entered while the last published high-level state is IDLE. The firmware
+  # turns HL_MODE_IDLE into a per-cycle wheel hard stop (cpp_main.cpp
+  # motors_handler), so a dock transit started in IDLE can never move and
+  # DockRobot never returns. Needs no ROS deps - it only reads the tree.
+  ament_add_gtest(test_dock_motion_gate
+    test/test_dock_motion_gate.cpp
+  )
+
+  target_compile_definitions(test_dock_motion_gate PRIVATE
+    MOWGLI_MAIN_TREE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/trees/main_tree.xml"
+  )
+
 endif()
 
 ament_package()

--- a/ros2/src/mowgli_behavior/test/test_dock_motion_gate.cpp
+++ b/ros2/src/mowgli_behavior/test/test_dock_motion_gate.cpp
@@ -126,8 +126,8 @@ TEST(DockMotionGate, NoDockRobotIsEnteredWhilePublishingIdle)
       {
         violations.push_back(
             "DockRobot at line " + std::to_string(line_no) +
-            " is entered while publishing state=1 (IDLE) as '" + last.state_name +
-            "' at line " + std::to_string(last.line) +
+            " is entered while publishing state=1 (IDLE) as '" + last.state_name + "' at line " +
+            std::to_string(last.line) +
             "; the firmware hard-stops the wheels in IDLE so this dock can never drive");
       }
     }

--- a/ros2/src/mowgli_behavior/test/test_dock_motion_gate.cpp
+++ b/ros2/src/mowgli_behavior/test/test_dock_motion_gate.cpp
@@ -1,0 +1,148 @@
+// Copyright 2026 Mowgli Project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * @file test_dock_motion_gate.cpp
+ * @brief Structural regression test: no dock transit may be entered while the
+ *        published high-level state is IDLE.
+ *
+ * Field incident 2026-09-11. A completed mow published
+ * HighLevelStatus state=1 (HIGH_LEVEL_STATE_IDLE, state_name
+ * "MOWING_COMPLETE") and only then ran DockRobot. hardware_bridge forwards
+ * that state verbatim to the STM32 (current_mode_ = msg->state), where
+ * HL_MODE_IDLE becomes OPENMOWER_STATUS_IDLE and motors_handler() turns it
+ * into a per-cycle hard stop:
+ *
+ *     } else if (main_eOpenmowerStatus == OPENMOWER_STATUS_IDLE) {
+ *       hard_stop = true;
+ *
+ * So the tree declared the robot idle and then asked a hard-stopped robot to
+ * drive 6.4 m to the dock. Nav2 planned normally and twist_mux carried
+ * cmd_vel at 10 Hz, but every wheel setpoint was clamped to zero: the
+ * progress checker tripped, recovery ran spin then backup (both equally
+ * zeroed), and DockRobot never returned — so the tree accepted no further
+ * command either. Encoder totals sat frozen for 474 consecutive samples.
+ *
+ * The IDLE publish long predated the firmware gate and was latent until the
+ * wheel hard stop was added for blade safety, which is why it surfaced as a
+ * sudden "stuck after mowing complete" with no tree change to blame.
+ *
+ * The contract: the LAST state published before a DockRobot must not be
+ * IDLE, because the firmware refuses to move the wheels in that mode. Every
+ * other dock path in the tree already honours it — CRITICAL_BATTERY_DOCKING,
+ * RAIN_DETECTED_DOCKING, LOW_BATTERY_DOCKING, COVERAGE_FAILED_DOCKING and
+ * RETURNING_HOME all publish state=2 (AUTONOMOUS) before docking. Only the
+ * two MOWING_COMPLETE sites did not.
+ *
+ * This is deliberately a STRUCTURAL test against the real main_tree.xml
+ * rather than a behavioural one: the failure is a mismatch between a literal
+ * in the tree and a gate in firmware, so it cannot be caught by ticking
+ * mocked nodes. It fails on the pre-fix tree and passes on the fixed one.
+ */
+
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/// HIGH_LEVEL_STATE_IDLE — the value the firmware maps to a wheel hard stop.
+constexpr const char* kStateIdle = "1";
+
+std::string readMainTree()
+{
+  std::ifstream file(MOWGLI_MAIN_TREE_PATH);
+  EXPECT_TRUE(file.is_open()) << "cannot open " << MOWGLI_MAIN_TREE_PATH;
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+struct Publish
+{
+  std::string state;
+  std::string state_name;
+  std::size_t line;
+};
+
+}  // namespace
+
+// Walk the tree in document order. Track the most recent
+// PublishHighLevelStatus; every time a DockRobot is reached, that publish is
+// the state the firmware will be sitting in when the dock drive starts.
+TEST(DockMotionGate, NoDockRobotIsEnteredWhilePublishingIdle)
+{
+  const std::string tree = readMainTree();
+  const std::regex publish_re(
+      R"RE(<PublishHighLevelStatus\s+state="(\d+)"\s+state_name="([^"]+)")RE");
+  const std::regex dock_re(R"RE(<DockRobot\b)RE");
+
+  std::istringstream stream(tree);
+  std::string line;
+  std::size_t line_no = 0;
+  std::size_t dock_sites = 0;
+  bool have_publish = false;
+  Publish last{};
+  std::vector<std::string> violations;
+
+  while (std::getline(stream, line))
+  {
+    ++line_no;
+
+    std::smatch match;
+    if (std::regex_search(line, match, publish_re))
+    {
+      last = Publish{match[1].str(), match[2].str(), line_no};
+      have_publish = true;
+    }
+
+    if (std::regex_search(line, dock_re))
+    {
+      ++dock_sites;
+      if (!have_publish)
+      {
+        violations.push_back("DockRobot at line " + std::to_string(line_no) +
+                             " is not preceded by any PublishHighLevelStatus");
+      }
+      else if (last.state == kStateIdle)
+      {
+        violations.push_back(
+            "DockRobot at line " + std::to_string(line_no) +
+            " is entered while publishing state=1 (IDLE) as '" + last.state_name +
+            "' at line " + std::to_string(last.line) +
+            "; the firmware hard-stops the wheels in IDLE so this dock can never drive");
+      }
+    }
+  }
+
+  // Guard the guard: if the tree is refactored so DockRobot disappears or the
+  // publish attribute order changes, this test must fail loudly rather than
+  // silently passing over nothing.
+  EXPECT_GT(dock_sites, 0u) << "found no <DockRobot> sites — scan is not matching the tree";
+  EXPECT_TRUE(have_publish) << "found no <PublishHighLevelStatus> — scan is not matching the tree";
+
+  std::string report;
+  for (const auto& v : violations)
+  {
+    report += "\n  " + v;
+  }
+  EXPECT_TRUE(violations.empty()) << "dock transit(s) entered in IDLE:" << report;
+}

--- a/ros2/src/mowgli_behavior/trees/main_tree.xml
+++ b/ros2/src/mowgli_behavior/trees/main_tree.xml
@@ -1061,7 +1061,18 @@
               <Sequence name="CoverageCompleteDock">
                 <IsCoverageComplete/>
                 <SetMowerEnabled enabled="false"/>
-                <PublishHighLevelStatus state="1" state_name="MOWING_COMPLETE"/>
+                <!-- state=2 (AUTONOMOUS), NOT 1 (IDLE). The firmware hard-stops the
+                     wheels whenever the forwarded high-level mode is IDLE
+                     (cpp_main.cpp motors_handler: "else if
+                     main_eOpenmowerStatus == OPENMOWER_STATUS_IDLE ->
+                     hard_stop"). Publishing IDLE here froze the wheels for
+                     the DockRobot drive that follows, so a completed run
+                     could never reach the dock and DockRobot never returned.
+                     state_name still reads MOWING_COMPLETE for the GUI, and
+                     IDLE_DOCKED below remains the real idle transition. This
+                     matches FailedCoverageDock, which already publishes
+                     state=2 before its own dock. -->
+                <PublishHighLevelStatus state="2" state_name="MOWING_COMPLETE"/>
                 <SaveObstacles/>
                 <ClearCostmap/>
                 <Fallback name="CompleteNavOrStop">
@@ -1120,7 +1131,10 @@
             <IsCommand command="1"/>
             <Sequence name="MowingCompleteAction">
               <SetMowerEnabled enabled="false"/>
-              <PublishHighLevelStatus state="1" state_name="MOWING_COMPLETE"/>
+              <!-- state=2 (AUTONOMOUS), NOT 1 (IDLE) - the firmware hard-stops
+                   the wheels while the forwarded HL mode is IDLE, which would
+                   freeze the DockRobot drive below. See CoverageCompleteDock. -->
+              <PublishHighLevelStatus state="2" state_name="MOWING_COMPLETE"/>
               <SaveObstacles/>
               <ClearCostmap/>
               <ReactiveFallback name="MowingCompleteOrDocked">


### PR DESCRIPTION
## Summary

A completed mow leaves the robot frozen where it stands: it reports `MOWING_COMPLETE`, never drives to the dock, and accepts no further command until the stack is restarted (which does not help) or the operator drives it in manual mode.

The tree publishes `HighLevelStatus state=1` (`HIGH_LEVEL_STATE_IDLE`) and *then* runs `DockRobot`. `hardware_bridge` forwards that state verbatim to the STM32 (`current_mode_ = msg->state`), where `HL_MODE_IDLE` becomes `OPENMOWER_STATUS_IDLE` and `motors_handler()` re-asserts it as a per-cycle hard stop:

```c
} else if (main_eOpenmowerStatus == OPENMOWER_STATUS_IDLE) {
  hard_stop = true;
```

So the tree declares the robot idle and then asks a hard-stopped robot to drive to the dock.

## Evidence from the robot

Captured live, robot 6.4 m from the dock:

- `/cmd_vel_nav` publishing at 10 Hz, `/cmd_vel` (post-mux) carrying the command
- encoder totals frozen at `L=26704 R=23167` for **474 consecutive samples**, not one tick
- no emergency, no dig latch, battery 27.0 V, firmware healthy and reporting
- Nav2 looping `follow_path` → `Failed to make progress` → `spin` → `backup`, all timing out
- driving `/cmd_vel_tuning` (priority 30, bypassing Nav2 entirely) at 0.15 m/s also produced **zero** motion, confirming the block is at the wire, not in planning

Manual mode recovered it, because `HL_MODE_MANUAL_MOWING` maps to `OPENMOWER_STATUS_MOWING`.

## Why now

The IDLE publish predates the gate and was latent and harmless. `a8fbe5fd` ("discontinuous coverage + per-swath MPPI, fusion/docking fixes") added two IDLE gates — one in `on_cmd_blade` for blade safety, and one in `motors_handler()` that also hard-stops the **wheels**. That turned a dormant inconsistency into a deadlock, with no tree change to blame.

## The fix

Publish `state=2` (AUTONOMOUS) with `state_name` unchanged at `MOWING_COMPLETE` until the robot is actually docked. The existing `IDLE_DOCKED` publish after `DockRobot` remains the real idle transition.

This is fixed in the tree rather than in firmware on purpose: firmware must stay free to refuse motion while it believes it is idle or docked.

**All 7 `DockRobot` sites were audited.** Five already publish `state=2` before docking — `CRITICAL_BATTERY_DOCKING`, `RAIN_DETECTED_DOCKING`, `LOW_BATTERY_DOCKING`, `COVERAGE_FAILED_DOCKING`, `RETURNING_HOME`. Only the two `MOWING_COMPLETE` sites were outliers, so this makes them consistent with five existing precedents rather than introducing a new convention.

## Regression test

`test_dock_motion_gate.cpp` walks the real `main_tree.xml` and asserts the last state published before any `DockRobot` is not IDLE. Structural rather than behavioural on purpose: the defect is a mismatch between a literal in the tree and a gate in firmware, so ticking mocked nodes cannot see it — the tree "succeeds" while the wheels never turn.

Verified to discriminate: fails on the pre-fix tree naming both offending sites, passes on the fixed tree.

## Consumer review

- `scheduler.go safeToStart()` — **behaviour preserved** (third commit). Raising the state to AUTONOMOUS would otherwise make the scheduler skip a mow falling due while the robot trundles home after a finished run, which used to fire. `state_name` is now tracked alongside the numeric state and `MOWING_COMPLETE` is exempted — and only that one. `RETURNING_HOME`, `LOW_BATTERY_DOCKING`, `CRITICAL_BATTERY_DOCKING` and `RAIN_DETECTED_DOCKING` stay blocked, as they were before this series: a schedule must not interrupt the robot protecting itself. `safeToStart()` has a single caller and gates only *scheduled* starts — the GUI Start button is unaffected either way
- `session_tracker.go` — unaffected, keys on `state_name`
- idle debounce in `status_nodes.hpp` — unaffected; debounce state is per-node-instance, so `IDLE_DOCKED` keeps its own history and still publishes immediately
- `led_ring_node.cpp` — cosmetic only: shows autonomous during the dock transit, exactly as `RETURNING_HOME` already does
- blade safety — `SetMowerEnabled(false)` runs *before* the publish in both sequences, so lifting the IDLE blade gate cannot arm blades

## Test status

**Confirmed end to end on the robot.** Full multi-area run to completion, on the patched tree:

```
mode=2 (AUTONOMOUS), state_name='MOWING_COMPLETE'   <- was mode=1 (IDLE)
docking_server: Attempting to dock robot at home_dock.
docking_server: Successful navigation to staging pose      (+56 s of driving)
docking_server: Successful initial dock detection
docking_server: Made contact with dock
docking_server: Robot is charging!
mode=1 (IDLE), state_name='IDLE_DOCKED'
EndSession: clearing per-session flags
```

79 s from mow complete to charging, against an indefinite deadlock before.
Encoders ran continuously through the transit (`cum L=342057 -> 342338` in
3 s) where they had previously sat frozen at `L=26704 R=23167` for 474
consecutive samples.

Note the last two lines: `IDLE_DOCKED` correctly drops back to `mode=1`
once the robot is actually docked, so the firmware idle gate is restored
exactly where it belongs — the change moves that transition, it does not
remove it.
