### PR TITLE
fix: recover ground filter from stable IMU offset

### DIFF
--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -184,6 +184,8 @@ add_executable(costmap_scan_filter_node
   src/costmap_scan_filter_node.cpp
 )
 
+target_include_directories(costmap_scan_filter_node PUBLIC ${INCLUDE_DIR})
+
 ament_target_dependencies(costmap_scan_filter_node
   rclcpp
   sensor_msgs

--- a/ros2/src/mowgli_localization/CMakeLists.txt
+++ b/ros2/src/mowgli_localization/CMakeLists.txt
@@ -380,6 +380,15 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
 
+  # ---- test_gravity_estimator ----
+  # Pure C++ regression test for the costmap IMU gravity gate.
+  ament_add_gtest(test_gravity_estimator
+    test/test_gravity_estimator.cpp
+  )
+  target_include_directories(test_gravity_estimator PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+
   # ---- test_robot_yaml_scalar ----
   # Guards the ONE canonical dock_pose persist path (Invariant 6): the
   # motion-derived (yaw_source=MOTION) write must splice only the dock_pose_*

--- a/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
@@ -18,11 +18,13 @@
 
 #include <cmath>
 #include <cstddef>
+#include <limits>
 
 namespace mowgli_localization
 {
 
 constexpr double kStandardGravityMs2 = 9.80665;
+constexpr double kDefaultMaxReseedTiltRad = 0.52359877559829887308;
 
 struct GravityVector
 {
@@ -44,6 +46,8 @@ struct GravityEstimatorConfig
   double candidate_max_gap_s{0.5};
   /// Stable candidate duration needed to replace a stale baseline.
   double reseed_after_s{5.0};
+  /// Largest tilt allowed when adopting a replacement gravity direction.
+  double max_reseed_tilt_rad{kDefaultMaxReseedTiltRad};
   /// Direction low-pass weight for ordinary accepted samples.
   double direction_alpha{0.2};
 };
@@ -101,8 +105,15 @@ public:
       candidate_mean_ = add(candidate_mean_,
                             scale(subtract(acceleration, candidate_mean_),
                                   1.0 / static_cast<double>(candidate_count_)));
-      if (t_s >= candidate_start_s_ && t_s - candidate_start_s_ >= cfg_.reseed_after_s)
+      if (candidate_window_complete(t_s))
       {
+        if (!candidate_tilt_is_safe())
+        {
+          // An off-axis frozen bus must not turn recovery into obstacle removal.
+          // Require a new, full candidate window before trying again.
+          clear_candidate();
+          return GravityEstimatorAction::REJECTED;
+        }
         direction_ = normalized(candidate_mean_);
         previous_baseline_magnitude_ms2_ = baseline_magnitude_ms2_;
         baseline_magnitude_ms2_ = magnitude(candidate_mean_);
@@ -176,6 +187,48 @@ private:
   {
     return magnitude(subtract(a, b));
   }
+  bool reseed_config_is_valid() const
+  {
+    // A valid window must need more than one bounded interval. This prevents a
+    // permissive direct-use configuration from treating two isolated samples
+    // several seconds apart as a continuous five-second observation.
+    return std::isfinite(cfg_.candidate_max_gap_s) && cfg_.candidate_max_gap_s > 0.0 &&
+           std::isfinite(cfg_.reseed_after_s) && cfg_.reseed_after_s > 0.0 &&
+           cfg_.candidate_max_gap_s < cfg_.reseed_after_s &&
+           std::isfinite(cfg_.max_reseed_tilt_rad) && cfg_.max_reseed_tilt_rad >= 0.0 &&
+           cfg_.max_reseed_tilt_rad <= kHalfPi;
+  }
+  std::size_t minimum_reseed_sample_count() const
+  {
+    if (!reseed_config_is_valid())
+    {
+      return std::numeric_limits<std::size_t>::max();
+    }
+    const double intervals = std::ceil(cfg_.reseed_after_s / cfg_.candidate_max_gap_s);
+    if (!std::isfinite(intervals) ||
+        intervals >= static_cast<double>(std::numeric_limits<std::size_t>::max() - 1U))
+    {
+      return std::numeric_limits<std::size_t>::max();
+    }
+    return static_cast<std::size_t>(intervals) + 1U;
+  }
+  bool candidate_window_complete(double t_s) const
+  {
+    return reseed_config_is_valid() && t_s >= candidate_start_s_ &&
+           t_s - candidate_start_s_ >= cfg_.reseed_after_s &&
+           candidate_count_ >= minimum_reseed_sample_count();
+  }
+  bool candidate_tilt_is_safe() const
+  {
+    const double candidate_magnitude = magnitude(candidate_mean_);
+    if (!std::isfinite(candidate_magnitude) || candidate_magnitude < 1e-3)
+    {
+      return false;
+    }
+    const double horizontal_magnitude = std::hypot(candidate_mean_.x, candidate_mean_.y);
+    const double sin_tilt = horizontal_magnitude / candidate_magnitude;
+    return std::isfinite(sin_tilt) && sin_tilt <= std::sin(cfg_.max_reseed_tilt_rad);
+  }
   void clear_candidate()
   {
     have_candidate_ = false;
@@ -187,6 +240,7 @@ private:
   }
 
   GravityEstimatorConfig cfg_{};
+  static constexpr double kHalfPi = 1.57079632679489661923;
   bool have_direction_{false};
   GravityVector direction_{0.0, 0.0, 1.0};
   double baseline_magnitude_ms2_{kStandardGravityMs2};

--- a/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
@@ -1,0 +1,189 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+/// @file gravity_estimator.hpp
+/// @brief Conservative gravity-direction gate with stale-latch recovery.
+//
+// The scan ground filter needs a trustworthy gravity direction, but must not
+// mistake a bump or body acceleration for gravity. Samples near the active
+// gravity-magnitude baseline are accepted immediately. A plausible, but
+// out-of-band, acceleration vector is held as a candidate; only five seconds
+// of mutually-consistent full vectors
+// can replace a stale baseline. This avoids a permanent rejected-sample latch
+// while preserving pass-through behaviour until the new baseline is proven.
+
+#ifndef MOWGLI_LOCALIZATION__GRAVITY_ESTIMATOR_HPP_
+#define MOWGLI_LOCALIZATION__GRAVITY_ESTIMATOR_HPP_
+
+#include <cmath>
+#include <cstddef>
+
+namespace mowgli_localization
+{
+
+constexpr double kStandardGravityMs2 = 9.80665;
+
+struct GravityVector
+{
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+};
+
+struct GravityEstimatorConfig
+{
+  /// Allowed deviation from the active gravity baseline for ordinary samples.
+  double accel_g_tolerance_ms2{3.0};
+  /// Plausibility envelope applies even before the first accepted sample.
+  double min_plausible_magnitude_ms2{0.5 * kStandardGravityMs2};
+  double max_plausible_magnitude_ms2{1.5 * kStandardGravityMs2};
+  /// Maximum full-vector distance within a stable rejected candidate run.
+  double candidate_consistency_ms2{0.5};
+  /// Stable candidate duration needed to replace a stale baseline.
+  double reseed_after_s{5.0};
+  /// Direction low-pass weight for ordinary accepted samples.
+  double direction_alpha{0.2};
+};
+
+enum class GravityEstimatorAction
+{
+  SEEDED,
+  ACCEPTED,
+  REJECTED,
+  RESEEDED,
+  INVALID,
+};
+
+class GravityEstimator
+{
+public:
+  GravityEstimator() = default;
+  explicit GravityEstimator(const GravityEstimatorConfig& cfg) : cfg_(cfg)
+  {
+  }
+
+  GravityEstimatorAction update(const GravityVector& acceleration, double t_s)
+  {
+    const double mag = magnitude(acceleration);
+    if (!std::isfinite(t_s) || !finite(acceleration) || !std::isfinite(mag) || mag < 1e-3 ||
+        mag < cfg_.min_plausible_magnitude_ms2 || mag > cfg_.max_plausible_magnitude_ms2)
+    {
+      clear_candidate();
+      return GravityEstimatorAction::INVALID;
+    }
+
+    const GravityVector direction = normalized(acceleration, mag);
+    if (std::abs(mag - baseline_magnitude_ms2_) <= cfg_.accel_g_tolerance_ms2)
+    {
+      clear_candidate();
+      if (!have_direction_)
+      {
+        direction_ = direction;
+        have_direction_ = true;
+        return GravityEstimatorAction::SEEDED;
+      }
+      direction_ = normalized(add(scale(direction, cfg_.direction_alpha),
+                                  scale(direction_, 1.0 - cfg_.direction_alpha)));
+      return GravityEstimatorAction::ACCEPTED;
+    }
+
+    // Out of the normal band but physically plausible. It cannot refresh
+    // freshness until a consistent, stationary-looking run proves a new bias.
+    if (have_candidate_ &&
+        distance(acceleration, candidate_anchor_) <= cfg_.candidate_consistency_ms2)
+    {
+      ++candidate_count_;
+      candidate_mean_ = add(candidate_mean_,
+                            scale(subtract(acceleration, candidate_mean_),
+                                  1.0 / static_cast<double>(candidate_count_)));
+      if (t_s >= candidate_start_s_ && t_s - candidate_start_s_ >= cfg_.reseed_after_s)
+      {
+        direction_ = normalized(candidate_mean_);
+        baseline_magnitude_ms2_ = magnitude(candidate_mean_);
+        have_direction_ = true;
+        clear_candidate();
+        return GravityEstimatorAction::RESEEDED;
+      }
+      return GravityEstimatorAction::REJECTED;
+    }
+
+    candidate_anchor_ = acceleration;
+    candidate_mean_ = acceleration;
+    candidate_count_ = 1;
+    candidate_start_s_ = t_s;
+    have_candidate_ = true;
+    return GravityEstimatorAction::REJECTED;
+  }
+
+  bool has_direction() const
+  {
+    return have_direction_;
+  }
+  GravityVector direction() const
+  {
+    return direction_;
+  }
+  bool has_candidate() const
+  {
+    return have_candidate_;
+  }
+  double baseline_magnitude_ms2() const
+  {
+    return baseline_magnitude_ms2_;
+  }
+
+private:
+  static bool finite(const GravityVector& v)
+  {
+    return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+  }
+  static double magnitude(const GravityVector& v)
+  {
+    return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  }
+  static GravityVector normalized(const GravityVector& v, double mag)
+  {
+    return GravityVector{v.x / mag, v.y / mag, v.z / mag};
+  }
+  static GravityVector normalized(const GravityVector& v)
+  {
+    return normalized(v, magnitude(v));
+  }
+  static GravityVector add(const GravityVector& a, const GravityVector& b)
+  {
+    return GravityVector{a.x + b.x, a.y + b.y, a.z + b.z};
+  }
+  static GravityVector subtract(const GravityVector& a, const GravityVector& b)
+  {
+    return GravityVector{a.x - b.x, a.y - b.y, a.z - b.z};
+  }
+  static GravityVector scale(const GravityVector& v, double factor)
+  {
+    return GravityVector{factor * v.x, factor * v.y, factor * v.z};
+  }
+  static double distance(const GravityVector& a, const GravityVector& b)
+  {
+    return magnitude(subtract(a, b));
+  }
+  void clear_candidate()
+  {
+    have_candidate_ = false;
+    candidate_count_ = 0;
+  }
+
+  GravityEstimatorConfig cfg_{};
+  bool have_direction_{false};
+  GravityVector direction_{0.0, 0.0, 1.0};
+  double baseline_magnitude_ms2_{kStandardGravityMs2};
+
+  bool have_candidate_{false};
+  GravityVector candidate_anchor_{};
+  GravityVector candidate_mean_{};
+  std::size_t candidate_count_{0};
+  double candidate_start_s_{0.0};
+};
+
+}  // namespace mowgli_localization
+
+#endif  // MOWGLI_LOCALIZATION__GRAVITY_ESTIMATOR_HPP_

--- a/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
+++ b/ros2/src/mowgli_localization/include/mowgli_localization/gravity_estimator.hpp
@@ -9,9 +9,9 @@
 // mistake a bump or body acceleration for gravity. Samples near the active
 // gravity-magnitude baseline are accepted immediately. A plausible, but
 // out-of-band, acceleration vector is held as a candidate; only five seconds
-// of mutually-consistent full vectors
-// can replace a stale baseline. This avoids a permanent rejected-sample latch
-// while preserving pass-through behaviour until the new baseline is proven.
+// of continuous, mutually-consistent full vectors can replace a stale baseline.
+// This avoids a permanent rejected-sample latch while preserving pass-through
+// behaviour until the new baseline is proven.
 
 #ifndef MOWGLI_LOCALIZATION__GRAVITY_ESTIMATOR_HPP_
 #define MOWGLI_LOCALIZATION__GRAVITY_ESTIMATOR_HPP_
@@ -40,6 +40,8 @@ struct GravityEstimatorConfig
   double max_plausible_magnitude_ms2{1.5 * kStandardGravityMs2};
   /// Maximum full-vector distance within a stable rejected candidate run.
   double candidate_consistency_ms2{0.5};
+  /// Maximum time between samples in a continuous candidate run.
+  double candidate_max_gap_s{0.5};
   /// Stable candidate duration needed to replace a stale baseline.
   double reseed_after_s{5.0};
   /// Direction low-pass weight for ordinary accepted samples.
@@ -90,9 +92,11 @@ public:
 
     // Out of the normal band but physically plausible. It cannot refresh
     // freshness until a consistent, stationary-looking run proves a new bias.
-    if (have_candidate_ &&
+    const double candidate_gap_s = t_s - candidate_last_s_;
+    if (have_candidate_ && candidate_gap_s >= 0.0 && candidate_gap_s <= cfg_.candidate_max_gap_s &&
         distance(acceleration, candidate_anchor_) <= cfg_.candidate_consistency_ms2)
     {
+      candidate_last_s_ = t_s;
       ++candidate_count_;
       candidate_mean_ = add(candidate_mean_,
                             scale(subtract(acceleration, candidate_mean_),
@@ -100,6 +104,7 @@ public:
       if (t_s >= candidate_start_s_ && t_s - candidate_start_s_ >= cfg_.reseed_after_s)
       {
         direction_ = normalized(candidate_mean_);
+        previous_baseline_magnitude_ms2_ = baseline_magnitude_ms2_;
         baseline_magnitude_ms2_ = magnitude(candidate_mean_);
         have_direction_ = true;
         clear_candidate();
@@ -112,6 +117,7 @@ public:
     candidate_mean_ = acceleration;
     candidate_count_ = 1;
     candidate_start_s_ = t_s;
+    candidate_last_s_ = t_s;
     have_candidate_ = true;
     return GravityEstimatorAction::REJECTED;
   }
@@ -131,6 +137,10 @@ public:
   double baseline_magnitude_ms2() const
   {
     return baseline_magnitude_ms2_;
+  }
+  double previous_baseline_magnitude_ms2() const
+  {
+    return previous_baseline_magnitude_ms2_;
   }
 
 private:
@@ -169,19 +179,25 @@ private:
   void clear_candidate()
   {
     have_candidate_ = false;
+    candidate_anchor_ = GravityVector{};
+    candidate_mean_ = GravityVector{};
     candidate_count_ = 0;
+    candidate_start_s_ = 0.0;
+    candidate_last_s_ = 0.0;
   }
 
   GravityEstimatorConfig cfg_{};
   bool have_direction_{false};
   GravityVector direction_{0.0, 0.0, 1.0};
   double baseline_magnitude_ms2_{kStandardGravityMs2};
+  double previous_baseline_magnitude_ms2_{kStandardGravityMs2};
 
   bool have_candidate_{false};
   GravityVector candidate_anchor_{};
   GravityVector candidate_mean_{};
   std::size_t candidate_count_{0};
   double candidate_start_s_{0.0};
+  double candidate_last_s_{0.0};
 };
 
 }  // namespace mowgli_localization

--- a/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
+++ b/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
@@ -110,7 +110,10 @@ public:
     min_ground_run_ = declare_parameter<int>("min_ground_run", 8);
     imu_max_age_s_ = declare_parameter<double>("imu_max_age_s", 0.5);
     accel_g_tolerance_ms2_ = declare_parameter<double>("accel_g_tolerance_ms2", 3.0);
-    gravity_estimator_ = GravityEstimator(GravityEstimatorConfig{accel_g_tolerance_ms2_});
+    GravityEstimatorConfig gravity_estimator_config;
+    gravity_estimator_config.accel_g_tolerance_ms2 = accel_g_tolerance_ms2_;
+    gravity_estimator_config.candidate_max_gap_s = imu_max_age_s_;
+    gravity_estimator_ = GravityEstimator(gravity_estimator_config);
     const std::string input_topic = declare_parameter<std::string>("input_topic", "/scan");
     const std::string output_topic =
         declare_parameter<std::string>("output_topic", "/scan_costmap");
@@ -352,13 +355,17 @@ private:
     last_imu_stamp_ = sample_time;
     if (action == GravityEstimatorAction::RESEEDED)
     {
-      RCLCPP_INFO_THROTTLE(
-          get_logger(),
-          *get_clock(),
-          5000,
-          "ground filter IMU baseline re-seeded at %.3f m/s² after stable out-of-band "
-          "acceleration",
-          gravity_estimator_.baseline_magnitude_ms2());
+      const double old_baseline = gravity_estimator_.previous_baseline_magnitude_ms2();
+      const double new_baseline = gravity_estimator_.baseline_magnitude_ms2();
+      const double absolute_change = std::abs(new_baseline - old_baseline);
+      const double percentage_change = 100.0 * absolute_change / old_baseline;
+      RCLCPP_WARN(get_logger(),
+                  "ground filter IMU baseline re-seeded %.3f -> %.3f m/s² "
+                  "(absolute change %.3f m/s², %.1f%%); IMU scale or calibration may be incorrect",
+                  old_baseline,
+                  new_baseline,
+                  absolute_change,
+                  percentage_change);
     }
   }
 

--- a/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
+++ b/ros2/src/mowgli_localization/src/costmap_scan_filter_node.cpp
@@ -49,11 +49,13 @@
 //      0.08 m floor → filtered. Real obstacles whose top sits above the
 //      0.08 m floor keep returns in-band.
 //
-//      Outlier guard: if |accel| differs from g by more than
-//      accel_g_tolerance_ms2 (default 3.0 m/s²), the sample is treated
-//      as motion-dominated and the previous low-pass-filtered estimate
-//      is used. The robot mows at ~0.2 m/s with low body acceleration,
-//      so this is rarely needed but protects against bumps.
+//      Outlier guard: if |accel| differs from the active gravity baseline
+//      by more than accel_g_tolerance_ms2 (default 3.0 m/s²), the sample
+//      is treated as motion-dominated and the previous low-pass-filtered
+//      estimate is used. A plausible out-of-band vector can replace a stale
+//      baseline only after remaining mutually consistent for five seconds;
+//      this recovers from a stable sensor offset without blessing a transient.
+//      Samples outside 0.5g..1.5g never qualify for recovery.
 //
 //      Falls back to pass-through if no IMU sample within `imu_max_age_s`
 //      so we never silently strip obstacles when localization is sick.
@@ -73,6 +75,7 @@
 #include <vector>
 
 #include "mowgli_interfaces/msg/status.hpp"
+#include "mowgli_localization/gravity_estimator.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/imu.hpp"
@@ -107,6 +110,7 @@ public:
     min_ground_run_ = declare_parameter<int>("min_ground_run", 8);
     imu_max_age_s_ = declare_parameter<double>("imu_max_age_s", 0.5);
     accel_g_tolerance_ms2_ = declare_parameter<double>("accel_g_tolerance_ms2", 3.0);
+    gravity_estimator_ = GravityEstimator(GravityEstimatorConfig{accel_g_tolerance_ms2_});
     const std::string input_topic = declare_parameter<std::string>("input_topic", "/scan");
     const std::string output_topic =
         declare_parameter<std::string>("output_topic", "/scan_costmap");
@@ -174,8 +178,6 @@ public:
                 accel_g_tolerance_ms2_,
                 imu_topic.c_str());
   }
-
-  static constexpr double kGravityMs2 = 9.80665;
 
   // --- Pure logic exposed for unit tests ---------------------------------
 
@@ -332,52 +334,32 @@ private:
     // attitude estimation), so accel is the only signal that knows the
     // robot's tilt. Treat as gravity reaction (points UP in IMU frame
     // when at rest).
-    const double ax = msg.linear_acceleration.x;
-    const double ay = msg.linear_acceleration.y;
-    const double az = msg.linear_acceleration.z;
-    const double mag = std::sqrt(ax * ax + ay * ay + az * az);
-    if (mag < 1e-3)
-      return;  // bogus sample, ignore
-
-    // Outlier guard: at mowing speeds (≤0.3 m/s) the body acceleration
-    // is small, so |accel| stays close to g. A bump or step on a curb
-    // can push it well above. Treat samples outside ±accel_g_tolerance
-    // as motion-dominated and keep the previous low-pass estimate so we
-    // don't briefly trust a tilted-by-impulse reading.
-    const double dev = std::fabs(mag - kGravityMs2);
-    if (last_up_in_imu_.has_value() && dev > accel_g_tolerance_ms2_)
+    const rclcpp::Time sample_time = now();
+    const GravityEstimatorAction action =
+        gravity_estimator_.update(GravityVector{msg.linear_acceleration.x,
+                                                msg.linear_acceleration.y,
+                                                msg.linear_acceleration.z},
+                                  sample_time.seconds());
+    if (action == GravityEstimatorAction::INVALID || action == GravityEstimatorAction::REJECTED)
     {
-      // Reject — keep the latched estimate alive (don't refresh stamp,
-      // so a sustained outlier window will eventually expire via
-      // imu_max_age_s_ and the filter will fall back to pass-through).
+      // Deliberately do not refresh last_imu_stamp_: the ground filter must
+      // become pass-through while a transient or a new baseline is unproven.
       return;
     }
 
-    Vec3 up{ax / mag, ay / mag, az / mag};
-    if (!last_up_in_imu_.has_value())
+    const GravityVector up = gravity_estimator_.direction();
+    last_up_in_imu_ = Vec3{up.x, up.y, up.z};
+    last_imu_stamp_ = sample_time;
+    if (action == GravityEstimatorAction::RESEEDED)
     {
-      last_up_in_imu_ = up;
+      RCLCPP_INFO_THROTTLE(
+          get_logger(),
+          *get_clock(),
+          5000,
+          "ground filter IMU baseline re-seeded at %.3f m/s² after stable out-of-band "
+          "acceleration",
+          gravity_estimator_.baseline_magnitude_ms2());
     }
-    else
-    {
-      // 1st-order low-pass (α = 0.2): smooths instantaneous accel jitter
-      // without lagging real tilt changes (mowing speed → tilt changes
-      // over many scan periods anyway).
-      const double a = 0.2;
-      Vec3 prev = *last_up_in_imu_;
-      Vec3 mixed{a * up.x + (1.0 - a) * prev.x,
-                 a * up.y + (1.0 - a) * prev.y,
-                 a * up.z + (1.0 - a) * prev.z};
-      const double mmag = std::sqrt(mixed.x * mixed.x + mixed.y * mixed.y + mixed.z * mixed.z);
-      if (mmag > 1e-6)
-      {
-        mixed.x /= mmag;
-        mixed.y /= mmag;
-        mixed.z /= mmag;
-        last_up_in_imu_ = mixed;
-      }
-    }
-    last_imu_stamp_ = now();
   }
 
   void on_scan(const sensor_msgs::msg::LaserScan& msg)
@@ -471,6 +453,7 @@ private:
   int min_ground_run_{8};
   double imu_max_age_s_{0.5};
   double accel_g_tolerance_ms2_{3.0};
+  GravityEstimator gravity_estimator_{};
 
   // --- Charging-state machine -------------------------------------------
 

--- a/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
+++ b/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
@@ -10,6 +10,7 @@
 
 using mowgli_localization::GravityEstimator;
 using mowgli_localization::GravityEstimatorAction;
+using mowgli_localization::GravityEstimatorConfig;
 using mowgli_localization::GravityVector;
 using mowgli_localization::kStandardGravityMs2;
 
@@ -75,6 +76,7 @@ TEST(GravityEstimator, StableOffsetReseedsAndContinuesAcceptingNewBaseline)
   }
   EXPECT_EQ(estimator.update(GravityVector{0.1, -0.1, 13.09}, 5.1),
             GravityEstimatorAction::RESEEDED);
+  EXPECT_NEAR(estimator.previous_baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
   // The first candidate is exactly vertical; re-seed uses the full candidate
   // average rather than the final sample's direction.
   const double mean_x = 50.0 * 0.1 / 51.0;
@@ -146,4 +148,116 @@ TEST(GravityEstimator, AcceptedSampleClearsRejectedRunAndRecoveryWorks)
   for (int i = 1; i <= 50; ++i)
     action = estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.3 + i * 0.1);
   EXPECT_EQ(action, GravityEstimatorAction::RESEEDED);
+}
+
+TEST(GravityEstimator, GapDoesNotCountTowardReseedDuration)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 6.1),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+}
+
+TEST(GravityEstimator, SamplesAtMaximumGapReseedAfterContinuousWindow)
+{
+  GravityEstimatorConfig config;
+  config.candidate_max_gap_s = 0.5;
+  GravityEstimator estimator(config);
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.0),
+            GravityEstimatorAction::RESEEDED);
+}
+
+TEST(GravityEstimator, EqualTimestampsDoNotAdvanceReseedDuration)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  for (int i = 0; i < 100; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 1.0),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+}
+
+TEST(GravityEstimator, ClockRollbackRestartsCandidateWindow)
+{
+  GravityEstimatorConfig config;
+  config.candidate_max_gap_s = 0.5;
+  GravityEstimator estimator(config);
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+
+  for (int i = 0; i <= 6; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 1.0),
+            GravityEstimatorAction::REJECTED);
+  for (int i = 3; i <= 10; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.5),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 6.0),
+            GravityEstimatorAction::RESEEDED);
+}
+
+TEST(GravityEstimator, GapPartwayThroughRequiresFreshFullWindow)
+{
+  GravityEstimatorConfig config;
+  config.candidate_max_gap_s = 0.5;
+  GravityEstimator estimator(config);
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+
+  for (int i = 0; i <= 6; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  for (int i = 8; i < 18; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 9.0),
+            GravityEstimatorAction::RESEEDED);
+}
+
+TEST(GravityEstimator, NonFiniteTimestampClearsCandidate)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1);
+  EXPECT_TRUE(estimator.has_candidate());
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09},
+                             std::numeric_limits<double>::infinity()),
+            GravityEstimatorAction::INVALID);
+  EXPECT_FALSE(estimator.has_candidate());
+}
+
+TEST(GravityEstimator, PlausibilityEnvelopeIncludesOnlyItsExactBoundaries)
+{
+  GravityEstimator lower_boundary;
+  EXPECT_EQ(lower_boundary.update(GravityVector{0.0, 0.0, 0.5 * kStandardGravityMs2}, 0.0),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_EQ(lower_boundary.update(GravityVector{0.0, 0.0, 0.5 * kStandardGravityMs2 - 1e-6}, 0.1),
+            GravityEstimatorAction::INVALID);
+
+  GravityEstimator upper_boundary;
+  EXPECT_EQ(upper_boundary.update(GravityVector{0.0, 0.0, 1.5 * kStandardGravityMs2}, 0.0),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_EQ(upper_boundary.update(GravityVector{0.0, 0.0, 1.5 * kStandardGravityMs2 + 1e-6}, 0.1),
+            GravityEstimatorAction::INVALID);
 }

--- a/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
+++ b/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
@@ -20,6 +20,11 @@ double magnitude(const GravityVector& v)
 {
   return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
 }
+
+GravityVector tilted_vector(double magnitude_ms2, double tilt_rad)
+{
+  return GravityVector{magnitude_ms2 * std::sin(tilt_rad), 0.0, magnitude_ms2 * std::cos(tilt_rad)};
+}
 }  // namespace
 
 TEST(GravityEstimator, NormalGravityAndSmallTiltAreAccepted)
@@ -260,4 +265,127 @@ TEST(GravityEstimator, PlausibilityEnvelopeIncludesOnlyItsExactBoundaries)
             GravityEstimatorAction::REJECTED);
   EXPECT_EQ(upper_boundary.update(GravityVector{0.0, 0.0, 1.5 * kStandardGravityMs2 + 1e-6}, 0.1),
             GravityEstimatorAction::INVALID);
+}
+
+TEST(GravityEstimator, SafeTiltedOffsetCanReseed)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  const GravityVector candidate = tilted_vector(13.09, 0.4);
+
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_EQ(estimator.update(candidate, 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(candidate, 5.0), GravityEstimatorAction::RESEEDED);
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), 13.09, 1e-12);
+  EXPECT_NEAR(estimator.direction().x, std::sin(0.4), 1e-12);
+  EXPECT_NEAR(estimator.direction().z, std::cos(0.4), 1e-12);
+}
+
+TEST(GravityEstimator, MaximumReseedTiltBoundaryIsAllowedButGreaterTiltIsRejected)
+{
+  GravityEstimator at_boundary;
+  at_boundary.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  const GravityVector boundary =
+      tilted_vector(13.09, mowgli_localization::kDefaultMaxReseedTiltRad);
+  for (int i = 0; i < 10; ++i)
+  {
+    EXPECT_EQ(at_boundary.update(boundary, 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(at_boundary.update(boundary, 5.0), GravityEstimatorAction::RESEEDED);
+
+  GravityEstimator above_boundary;
+  above_boundary.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  const GravityVector just_above =
+      tilted_vector(13.09, mowgli_localization::kDefaultMaxReseedTiltRad + 1e-3);
+  for (int i = 0; i <= 10; ++i)
+  {
+    EXPECT_EQ(above_boundary.update(just_above, 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_NEAR(above_boundary.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+  EXPECT_NEAR(above_boundary.direction().x, 0.0, 1e-12);
+  EXPECT_NEAR(above_boundary.direction().z, 1.0, 1e-12);
+  EXPECT_FALSE(above_boundary.has_candidate());
+}
+
+TEST(GravityEstimator, ExcessiveTiltNeverReseedsAndEachAttemptNeedsAFullWindow)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  const GravityVector unsafe = tilted_vector(13.09, 1.0);
+
+  for (int i = 0; i <= 10; ++i)
+  {
+    EXPECT_EQ(estimator.update(unsafe, 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_FALSE(estimator.has_candidate());
+
+  // The refused candidate was cleared: a new run has not inherited its time.
+  for (int i = 1; i <= 10; ++i)
+  {
+    EXPECT_EQ(estimator.update(unsafe, 5.0 + 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_TRUE(estimator.has_candidate());
+  EXPECT_EQ(estimator.update(unsafe, 10.5), GravityEstimatorAction::REJECTED);
+  EXPECT_FALSE(estimator.has_candidate());
+
+  // Continue well beyond five seconds: every completed unsafe attempt stays rejected.
+  for (int i = 1; i <= 20; ++i)
+  {
+    EXPECT_EQ(estimator.update(unsafe, 10.5 + 0.5 * i), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+  EXPECT_NEAR(estimator.direction().x, 0.0, 1e-12);
+  EXPECT_NEAR(estimator.direction().z, 1.0, 1e-12);
+}
+
+TEST(GravityEstimator, ElapsedTimeAloneCannotReseedWithPermissiveGapConfiguration)
+{
+  GravityEstimatorConfig config;
+  config.candidate_max_gap_s = 5.0;
+  config.reseed_after_s = 5.0;
+  GravityEstimator estimator(config);
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+
+  // Elapsed time and the configured gap alone would allow two isolated samples.
+  // Such a permissive configuration disables recovery instead.
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.0),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.0),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+}
+
+TEST(GravityEstimator, InvalidReseedTimingConfigurationCannotAdoptCandidate)
+{
+  const double invalid_values[] = {0.0,
+                                   -0.5,
+                                   std::numeric_limits<double>::infinity(),
+                                   std::numeric_limits<double>::quiet_NaN()};
+  for (const double invalid_gap : invalid_values)
+  {
+    GravityEstimatorConfig config;
+    config.candidate_max_gap_s = invalid_gap;
+    GravityEstimator estimator(config);
+    for (int i = 0; i <= 20; ++i)
+    {
+      EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+                GravityEstimatorAction::REJECTED);
+    }
+    EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+  }
+
+  for (const double invalid_duration : invalid_values)
+  {
+    GravityEstimatorConfig config;
+    config.reseed_after_s = invalid_duration;
+    GravityEstimator estimator(config);
+    for (int i = 0; i <= 20; ++i)
+    {
+      EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.5 * i),
+                GravityEstimatorAction::REJECTED);
+    }
+    EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+  }
 }

--- a/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
+++ b/ros2/src/mowgli_localization/test/test_gravity_estimator.cpp
@@ -1,0 +1,149 @@
+// Copyright 2026 Mowgli Project
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <cmath>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "mowgli_localization/gravity_estimator.hpp"
+
+using mowgli_localization::GravityEstimator;
+using mowgli_localization::GravityEstimatorAction;
+using mowgli_localization::GravityVector;
+using mowgli_localization::kStandardGravityMs2;
+
+namespace
+{
+double magnitude(const GravityVector& v)
+{
+  return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+}  // namespace
+
+TEST(GravityEstimator, NormalGravityAndSmallTiltAreAccepted)
+{
+  GravityEstimator estimator;
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0),
+            GravityEstimatorAction::SEEDED);
+  EXPECT_EQ(estimator.update(GravityVector{-1.7, 0.0, 9.66}, 0.1),
+            GravityEstimatorAction::ACCEPTED);
+  EXPECT_TRUE(estimator.has_direction());
+  EXPECT_NEAR(magnitude(estimator.direction()), 1.0, 1e-12);
+  EXPECT_LT(estimator.direction().x, 0.0);
+}
+
+TEST(GravityEstimator, SingleTransientDoesNotReplaceBaseline)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_TRUE(estimator.has_candidate());
+  EXPECT_NEAR(estimator.direction().z, 1.0, 1e-12);
+}
+
+TEST(GravityEstimator, StartupOffsetReseedsBeforeBecomingUsable)
+{
+  GravityEstimator estimator;
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1),
+            GravityEstimatorAction::REJECTED);
+  EXPECT_FALSE(estimator.has_direction());
+  for (int i = 1; i < 50; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1 + i * 0.1),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.1),
+            GravityEstimatorAction::RESEEDED);
+  EXPECT_TRUE(estimator.has_direction());
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), 13.09, 1e-12);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.2),
+            GravityEstimatorAction::ACCEPTED);
+}
+
+TEST(GravityEstimator, StableOffsetReseedsAndContinuesAcceptingNewBaseline)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1),
+            GravityEstimatorAction::REJECTED);
+  for (int i = 1; i < 50; ++i)
+  {
+    EXPECT_EQ(estimator.update(GravityVector{0.1, -0.1, 13.09}, 0.1 + i * 0.1),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_EQ(estimator.update(GravityVector{0.1, -0.1, 13.09}, 5.1),
+            GravityEstimatorAction::RESEEDED);
+  // The first candidate is exactly vertical; re-seed uses the full candidate
+  // average rather than the final sample's direction.
+  const double mean_x = 50.0 * 0.1 / 51.0;
+  const double mean_y = -mean_x;
+  EXPECT_NEAR(estimator.direction().x,
+              mean_x / std::sqrt(mean_x * mean_x + mean_y * mean_y + 13.09 * 13.09),
+              1e-12);
+  EXPECT_NEAR(magnitude(estimator.direction()), 1.0, 1e-12);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.2),
+            GravityEstimatorAction::ACCEPTED);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 5.3),
+            GravityEstimatorAction::ACCEPTED);
+  EXPECT_TRUE(estimator.has_direction());
+  EXPECT_NEAR(magnitude(estimator.direction()), 1.0, 1e-12);
+}
+
+TEST(GravityEstimator, CandidateInconsistencyPreventsReseed)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  for (int i = 1; i <= 70; ++i)
+  {
+    const GravityVector sample =
+        (i % 2 == 0) ? GravityVector{0.0, 0.0, 13.09} : GravityVector{1.0, 0.0, 13.09};
+    EXPECT_EQ(estimator.update(sample, i * 0.1), GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_NEAR(estimator.direction().z, 1.0, 1e-12);
+}
+
+TEST(GravityEstimator, SlowlyDriftingCandidateCannotFollowItsOwnMean)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  for (int i = 0; i <= 60; ++i)
+  {
+    const double x = 0.02 * i;
+    EXPECT_EQ(estimator.update(GravityVector{x, 0.0, 13.09}, 0.1 * i),
+              GravityEstimatorAction::REJECTED);
+  }
+  EXPECT_NEAR(estimator.baseline_magnitude_ms2(), kStandardGravityMs2, 1e-12);
+}
+
+TEST(GravityEstimator, ObviousMotionAndInvalidSamplesAreRejectedAndResetCandidate)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1);
+  EXPECT_TRUE(estimator.has_candidate());
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 20.0}, 0.2), GravityEstimatorAction::INVALID);
+  EXPECT_FALSE(estimator.has_candidate());
+  EXPECT_EQ(estimator.update(GravityVector{std::numeric_limits<double>::quiet_NaN(), 0.0, 9.8},
+                             0.3),
+            GravityEstimatorAction::INVALID);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 0.0}, 0.4), GravityEstimatorAction::INVALID);
+}
+
+TEST(GravityEstimator, AcceptedSampleClearsRejectedRunAndRecoveryWorks)
+{
+  GravityEstimator estimator;
+  estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.0);
+  estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.1);
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, kStandardGravityMs2}, 0.2),
+            GravityEstimatorAction::ACCEPTED);
+  EXPECT_FALSE(estimator.has_candidate());
+
+  EXPECT_EQ(estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.3),
+            GravityEstimatorAction::REJECTED);
+  GravityEstimatorAction action = GravityEstimatorAction::REJECTED;
+  for (int i = 1; i <= 50; ++i)
+    action = estimator.update(GravityVector{0.0, 0.0, 13.09}, 0.3 + i * 0.1);
+  EXPECT_EQ(action, GravityEstimatorAction::RESEEDED);
+}


### PR DESCRIPTION
## Summary

- extract the costmap ground filter's acceleration gate into a directly tested pure helper
- preserve the standard-gravity fast path and stale/pass-through safety behavior
- allow a plausible out-of-band baseline to re-seed only after five seconds of continuous, full-vector consistency
- restart the recovery window after stale sample gaps, clock rollback, invalid input, candidate inconsistency, or a normal accepted sample
- require enough observations for the configured window and reject unsafe timing configurations
- limit replacement gravity directions to 30° tilt so a frozen off-axis bus remains fail-safe
- warn on an actual re-seed with the old/new baseline and absolute/percentage change
- permanently reject non-finite values and magnitudes outside 0.5g..1.5g

Addresses the ground-filter stale-latch portion of #583. It does not close the underlying WT901 scale/range investigation.

## What the investigation found

Before this PR, the node accepted its first nonzero acceleration sample even when its magnitude was outside the configured gravity tolerance. Once it had an estimate, later out-of-band samples were rejected without refreshing the freshness timestamp. That correctly made the ground filter fall back to conservative pass-through after `imu_max_age_s`, but a stable 13.09 m/s² stream could never make the ground filter usable again.

The persisted hardware-bridge calibration does not currently contain `mean_az` or a gravity-magnitude baseline. Its Z mean is only a local value used to report implied mounting tilt, so this change does not reinterpret that file or couple the costmap node to it.

The WT901 driver still assumes an accelerometer range without configuring or reading it back. The observed approximately 1.335x ratio is not an obvious standard full-scale mismatch, and there is not enough repository or hardware evidence to change that conversion in this PR.

Recommended follow-up scope is WT901 configured-range verification, scale-factor investigation, and device-to-device comparison. No follow-up issue is created by this PR.

## Safety behavior

Rejected and invalid samples do not refresh IMU freshness. Until a new baseline proves stable, `/scan_costmap` falls back to pass-through. `/scan_collision` remains outside the gravity filter and is unchanged.

A recovery candidate must remain within 0.5 m/s² of its initial full acceleration vector for five continuous seconds. The maximum gap between candidate samples is the existing `imu_max_age_s` value (default 0.5 s). Larger gaps and backwards time restart the full window. Re-seed requires both the full elapsed duration and at least `ceil(reseed_after_s / candidate_max_gap_s) + 1` consistent observations. Non-finite/non-positive timing and a maximum gap large enough to permit a two-sample window disable recovery.

Before replacing the trusted direction, the estimator also requires the candidate mean to be within `max_reseed_tilt_rad` (default 30°) of vertical. An off-axis candidate above that bound is cleared and remains `REJECTED`; it cannot change the direction/baseline or refresh IMU freshness. `/scan_costmap` therefore continues toward stale-data pass-through rather than removing obstacles from an untrusted gravity estimate.

Using a fixed anchor prevents a slowly drifting sequence from following its own moving mean. Values outside 0.5g..1.5g never seed or re-seed the filter.

Strong blade vibration may delay recovery until the vector settles; this is intentionally conservative and this PR does not attempt a general vibration-filter redesign.

## Tests

Focused pure-state regression coverage includes:

- standard gravity, immediate normal seeding, and low-pass tilt acceptance
- startup and recovery on a continuously stable 13.09 m/s² offset
- stale gaps not counting toward the five-second window
- a partway gap requiring a fresh full window
- clock rollback restarting the candidate
- exact maximum-gap and equal-timestamp behavior
- elapsed time alone and permissive/invalid timing configurations cannot re-seed
- safe approximately 23° tilted recovery and the exact 30° boundary
- just-over-limit and approximately 57° frozen off-axis candidates remain rejected across repeated windows
- fixed-anchor inconsistent and slowly drifting candidates
- invalid/non-finite input and accepted samples clearing candidates
- exact 0.5g and 1.5g plausibility boundaries

Local checks:

- Xcode clang-format dry run: pass
- standalone C++17 compile/runtime continuity scenarios: pass
- `git diff --check`: pass

The macOS host has no local ROS Kilted installation, and Docker Desktop is not running, so the ROS package build and ament/gtest suite are validated by GitHub CI.

Fresh GitHub CI at final rebased head `6d4d5d4e`:

- ROS Kilted full workspace build: pass
- `mowgli_localization`: 14/14 tests passed, including `test_gravity_estimator`
- full ROS test summary: 1810 tests, 0 errors, 0 failures
- clang-format, cppcheck, config drift, and external GNSS launch contract: pass

## Validation boundary

No mower or WT901 hardware was available. This PR fixes the demonstrated costmap ground-filter stale-latch/recovery behavior only. It does not establish why the WT901 reports approximately 13.09 m/s² instead of approximately 9.81 m/s², change the firmware conversion, or claim hardware validation.
